### PR TITLE
Fix examples/rust_gpu debug build not working on Windows

### DIFF
--- a/examples/rust_gpu/src/lib.rs
+++ b/examples/rust_gpu/src/lib.rs
@@ -6,8 +6,6 @@ use after_effects as ae;
 //
 // This example is *not* gpu zero-copy (yet)
 // To build the SPIR-V module from Rust code, cd to `spirv_builder` and run `cargo run --release`
-//
-// For some reason, this example doesn't work in Debug build, but it works if you run `just release`
 
 mod wgpu_proc;
 use wgpu_proc::*;


### PR DESCRIPTION
Creating a `wgpu::Instance` with the DX12 backend and validation turned on was removing AE's internal D3D12 device:
> To enable the debug layers using this API, it must be called before the D3D12 device is created. Calling this API after creating the D3D12 device will cause the D3D12 runtime to remove the device.

https://learn.microsoft.com/en-us/windows/win32/api/d3d12sdklayers/nf-d3d12sdklayers-id3d12debug-enabledebuglayer

I fixed it by disabling `Backends::DX12` if `InstanceFlags::VALIDATION` is turned on.

Fixes #61