### PR TITLE
Expose GuidInMixPtr function in public module & Added Cargo.lock in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ target/
 sdk/
 .vscode
 .DS_Store
+
+# Cargo.lock should be ignored for libraries
+Cargo.lock

--- a/after-effects/src/pf/render.rs
+++ b/after-effects/src/pf/render.rs
@@ -252,13 +252,22 @@ impl PreRenderCallbacks {
         self.rc_ptr
     }
 
-    pub fn guid_mix_in_ptr(
+    pub fn guid_mix_in_ptr<T>(
         &self,
-        buf_size: ae_sys::A_u_long,
-        buf: *const std::ffi::c_void,
+        buf: &T,
     ) -> Result<(), Error> {
+        let buf_ptr: *const std::ffi::c_void = buf as *const _ as *const std::ffi::c_void;
+        if buf_ptr.is_null() {
+            return Err(Error::InvalidCallback);
+        }
+
+        let buf_size = std::mem::size_of_val(buf);
+        if buf_size == 0 {
+            return Err(Error::InvalidCallback);
+        }
+
         if let Some(guid_mix_in_ptr) = unsafe { *self.rc_ptr }.GuidMixInPtr {
-            match unsafe { guid_mix_in_ptr((*self.in_data_ptr).effect_ref, buf_size, buf) } {
+            match unsafe { guid_mix_in_ptr((*self.in_data_ptr).effect_ref, buf_size as u32, buf_ptr) } {
                 0 => Ok(()),
                 e => Err(Error::from(e)),
             }


### PR DESCRIPTION
I wrote a rust safe implementation of GuidInMixPtr under PreRenderCallbacks.

This function is useful to force rerender of a layer without bit toggling the ForceRerender flag which under some mystics conditions will not work.

My implementation can be improved by checking that `PF_OutFlag2_I_MIX_GUID_DEPENDENCIES` is set. But I don't know if this library want this kind of error checking or let after effects/premiere handle it.