### PR TITLE
Wrap PrSDKWindowSuite

### DIFF
--- a/premiere/src/lib.rs
+++ b/premiere/src/lib.rs
@@ -28,6 +28,7 @@ pub mod suites {
     pub(crate) mod sequence_info;            pub use sequence_info       ::SequenceInfoSuite       as SequenceInfo;
     pub(crate) mod video_segment;            pub use video_segment       ::VideoSegmentSuite       as VideoSegment;
     pub(crate) mod string;                   pub use string              ::PrStringSuite           as PrString;
+    pub(crate) mod window;                   pub use window              ::WindowSuite             as Window;
     pub(crate) mod video_segment_properties;
     #[cfg(has_ae_sdk)] mod opaque_effect_data;
     #[cfg(has_ae_sdk)] pub use opaque_effect_data::OpaqueEffectDataSuite as OpaqueEffectData;

--- a/premiere/src/suites/window.rs
+++ b/premiere/src/suites/window.rs
@@ -1,0 +1,28 @@
+use crate::*;
+use pr_sys::*;
+
+define_suite!(
+    WindowSuite,
+    PrSDKWindowSuite,
+    kPrSDKWindowSuite,
+    kPrSDKWindowSuiteVersion
+);
+
+impl WindowSuite {
+    /// Acquire this suite from the host. Returns error if the suite is not available.
+    /// Suite is released on drop.
+    pub fn new() -> Result<Self, Error> {
+        crate::Suite::new()
+    }
+
+    /// Returns a handle to the main application window-- a `HWND` on Windows and a `*mut NSView` on macOS.
+    /// These correspond to the `Win32WindowHandle` and `AppKitWindowHandle` types in the `raw-window-handle` crate.
+    pub fn get_main_window(&self) -> prWnd {
+        call_suite_fn_no_err!(self, GetMainWindow, )
+    }
+
+    /// Updates all windows. Windows only, doesn’t work on Mac OS.
+    pub fn update_all_windows(&self) {
+        call_suite_fn_no_err!(self, UpdateAllWindows, )
+    }
+}


### PR DESCRIPTION
This is useful for getting raw window handles, necessary for allowing effects to properly open dialogs. If you try to open a dialog without setting the parent window handle, at least on Windows, bad things can happen (see https://github.com/mobile-bungalow/tweak_shader_ae_plugin/issues/10).

Not sure if it's preferable to return the `prWnd` type, or depend on `raw-window-handle` and return its `RawWindowHandle` wrapper type.