### PR TITLE
Warn during PiPL build about setting OutFlags2::SupportsThreadedRendering without OutFlags2::SupportsGetFlattenedSequenceData

### DIFF
--- a/pipl/src/lib.rs
+++ b/pipl/src/lib.rs
@@ -1597,6 +1597,10 @@ pub fn plugin_build(properties: Vec<Property>) {
                 }
                 if x.contains(OutFlags2::SupportsThreadedRendering) {
                     println!("cargo:rustc-cfg=threaded_rendering");
+
+                    if !x.contains(OutFlags2::SupportsGetFlattenedSequenceData) {
+                        println!("cargo:warning=Setting the SupportsThreadedRendering flag without the SupportsGetFlattenedSequenceData flag can cause plugins to fail to load in some older versions of After Effects.");
+                    }
                 }
                 println!("cargo:rustc-env=PIPL_OUTFLAGS2={}", x.bits());
             }


### PR DESCRIPTION
The `OutFlags2::SupportsThreadedRendering` documentation states (emphasis mine):

> **If the effect sets PF_OutFlag_SEQUENCE_DATA_NEEDS_FLATTENING** indicating the sequence data needs flattening then it must also set PF_OutFlag2_SUPPORTS_GET_FLATTENED_SEQUENCE_DATA.

However, it seems that in AE 2020, setting `OutFlags2::SupportsThreadedRendering` *unconditionally* requires you to set `OutFlags2::SupportsGetFlattenedSequenceData`. Otherwise the plugin will fail to load with an "internal verification failure"; see https://github.com/valadaptive/ntsc-rs/issues/214.

This seems to be specific to AE 2020. In AE 2019 and older, `OutFlags2::SupportsThreadedRendering` is reserved and does nothing. In newer versions of AE (I've tested 2023 and 2024), no error is displayed. A clue for this might be that the error message calls the flag `PF_OutFlag2_THREADSAFE_INSTANCES` and not `PF_OutFlag2_SUPPORTS_THREADED_RENDERING`, and that the [SDK docs for multi-frame rendering](https://ae-plugins.docsforadobe.dev/effect-details/multi-frame-rendering-in-ae.html) say that it only works in AE 2022 and up. This may indicate that they were still developing the feature in 2020, and simply forgot to disable the (faulty) flag-checking code.