### PR TITLE
Make layer checkout functions return Option<Layer>

### DIFF
--- a/examples/color_grid/src/lib.rs
+++ b/examples/color_grid/src/lib.rs
@@ -197,7 +197,9 @@ impl AdobePluginGlobal for Plugin {
                 let mut current_color = 0;
 
                 let cb = extra.callbacks();
-                let input_world = cb.checkout_layer_pixels(0)?;
+                let Some(input_world) = cb.checkout_layer_pixels(0)? else {
+                    return Ok(());
+                };
 
                 let param = params.get(Params::GridUI)?;
                 let colors = param.as_arbitrary()?.value::<ArbData>()?;
@@ -225,7 +227,7 @@ impl AdobePluginGlobal for Plugin {
                     let color16_g = (color32.green * ae::MAX_CHANNEL16 as f32) as u32;
                     let color16_b = (color32.blue  * ae::MAX_CHANNEL16 as f32) as u32;
 
-                    if let Ok(mut output_world) = cb.checkout_output() {
+                    if let Ok(Some(mut output_world)) = cb.checkout_output() {
                         let progress_final = output_world.height() as _;
 
                         origin = in_data.output_origin();

--- a/examples/histo_grid/src/lib.rs
+++ b/examples/histo_grid/src/lib.rs
@@ -266,7 +266,9 @@ impl AdobePluginInstance for Instance {
                 let mut current_color = 0;
 
                 let cb = extra.callbacks();
-                let input_world = cb.checkout_layer_pixels(0)?;
+                let Some(input_world) = cb.checkout_layer_pixels(0)? else {
+                    return Ok(());
+                };
 
                 let mut color_cache = ColorCache::new();
                 color_cache.compute_color_grid_from_frame(&input_world)?;
@@ -294,7 +296,7 @@ impl AdobePluginInstance for Instance {
                     let color16_g = (color32.green * ae::MAX_CHANNEL16 as f32) as u32;
                     let color16_b = (color32.blue  * ae::MAX_CHANNEL16 as f32) as u32;
 
-                    if let Ok(mut output_world) = cb.checkout_output() {
+                    if let Ok(Some(mut output_world)) = cb.checkout_output() {
                         let progress_final = output_world.height() as _;
 
                         origin = in_data.output_origin();

--- a/examples/resizer/src/lib.rs
+++ b/examples/resizer/src/lib.rs
@@ -249,9 +249,11 @@ impl AdobePluginGlobal for Plugin {
             }
             ae::Command::SmartRender { extra } => {
                 let cb = extra.callbacks();
-                let in_layer = cb.checkout_layer_pixels(0)?;
+                let Some(in_layer) = cb.checkout_layer_pixels(0)? else {
+                    return Ok(());
+                };
 
-                if let Ok(mut out_layer) = cb.checkout_output() {
+                if let Ok(Some(mut out_layer)) = cb.checkout_output() {
                     let border = params.get(Params::Amount)?.as_slider()?.value() as f32;
 
                     let color = params.get(Params::Color)?.as_color()?.value();

--- a/examples/rust_gpu/src/lib.rs
+++ b/examples/rust_gpu/src/lib.rs
@@ -111,9 +111,11 @@ impl AdobePluginGlobal for Plugin {
             }
             ae::Command::SmartRender { extra } => {
                 let cb = extra.callbacks();
-                let in_layer = cb.checkout_layer_pixels(0)?;
+                let Some(in_layer) = cb.checkout_layer_pixels(0)? else {
+                    return Ok(());
+                };
 
-                if let Ok(mut out_layer) = cb.checkout_output() {
+                if let Ok(Some(mut out_layer)) = cb.checkout_output() {
                     let in_size  = (in_layer.width()  as usize, in_layer.height()  as usize, in_layer.buffer_stride());
                     let out_size = (out_layer.width() as usize, out_layer.height() as usize, out_layer.buffer_stride());
 

--- a/examples/sdk_noise/src/lib.rs
+++ b/examples/sdk_noise/src/lib.rs
@@ -156,9 +156,11 @@ impl AdobePluginGlobal for Plugin {
             }
             ae::Command::SmartRender { extra } => {
                 let cb = extra.callbacks();
-                let input_world = cb.checkout_layer_pixels(0)?;
+                let Some(input_world) = cb.checkout_layer_pixels(0)? else {
+                    return Ok(());
+                };
 
-                if let Ok(mut output_world) = cb.checkout_output() {
+                if let Ok(Some(mut output_world)) = cb.checkout_output() {
                     let progress_final = output_world.height() as _;
 
                     let value = params.get(Params::Noise)?.as_float_slider()?.value() as f32 / 100.0;

--- a/examples/supervisor/src/lib.rs
+++ b/examples/supervisor/src/lib.rs
@@ -226,7 +226,9 @@ impl AdobePluginInstance for Instance {
             }
             ae::Command::SmartRender { mut extra } => {
                 let cb = extra.callbacks();
-                let input_world = cb.checkout_layer_pixels(0)?;
+                let Some(input_world) = cb.checkout_layer_pixels(0)? else {
+                    return Ok(());
+                };
 
                 let pre_render_data = extra.pre_render_data_mut::<PreRenderData>().unwrap();
                 if self.advanced_mode {
@@ -246,7 +248,7 @@ impl AdobePluginInstance for Instance {
 
                 let pixel_float = pre_render_data.color;
 
-                if let Ok(mut output_world) = cb.checkout_output() {
+                if let Ok(Some(mut output_world)) = cb.checkout_output() {
                     let out_extent_hint = output_world.extent_hint();
                     let progress_final = output_world.height() as _;
                     // iterate over image data.


### PR DESCRIPTION
Even if the functions succeed, the returned layer pointer is sometimes null. For example, if the effect is applied to an adjustment layer with nothing beneath it (https://github.com/valadaptive/ntsc-rs/issues/220).

Somehow this isn't a problem for [tweak_shader_ae_plugin](https://github.com/mobile-bungalow/tweak_shader_ae_plugin) (I tested it), but it *is* reproducible using any of the Rust demo effects that use the SmartFX API. Just apply the effect to an adjustment layer, then move it to the bottom of the layer stack or delete all the layers below it.

I'm also not sure how this isn't a problem for the original C++ versions of the examples--they use the AE pixel iteration suites which may handle null layer pointers, but they also call `PF_GetPixelFormat`, which [I know causes an "internal verification error" message if you pass *it* a null layer pointer](https://github.com/valadaptive/ntsc-rs/commit/0996d15b961a7a92001587164856062e9abab9cd).