### PR TITLE
Fix working directory issues in AdobePlugin.just on Windows

### DIFF
--- a/AdobePlugin.just
+++ b/AdobePlugin.just
@@ -8,7 +8,7 @@ export PRSDK_ROOT := if env("PRSDK_ROOT", "") == "" { justfile_directory() / "..
 build:
     cargo build
     if (-not $env:NO_INSTALL) { \
-        Start-Process PowerShell -Verb runAs -ArgumentList "-command Copy-Item -Force '{{TargetDir}}\debug\{{BinaryName}}.dll' 'C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\{{PluginName}}.aex'" \
+        Start-Process PowerShell -Verb runAs -ArgumentList "-command Set-Location '{{source_directory()}}'; Copy-Item -Force '{{TargetDir}}\debug\{{BinaryName}}.dll' 'C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\{{PluginName}}.aex'" \
     }
 
 [windows]
@@ -16,7 +16,7 @@ release:
     cargo build --release
     Copy-Item -Force '{{TargetDir}}\release\{{BinaryName}}.dll' '{{TargetDir}}\release\{{PluginName}}.aex'
     if (-not $env:NO_INSTALL) { \
-        Start-Process PowerShell -Verb runAs -ArgumentList "-command Copy-Item -Force '{{TargetDir}}\release\{{BinaryName}}.dll' 'C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\{{PluginName}}.aex'" \
+        Start-Process PowerShell -Verb runAs -ArgumentList "-command Set-Location '{{source_directory()}}'; Copy-Item -Force '{{TargetDir}}\release\{{BinaryName}}.dll' 'C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\{{PluginName}}.aex'" \
     }
 
 [macos]


### PR DESCRIPTION
## Problem
When using `Start-Process` with the `runAs` parameter, the current working directory is reset to system directories like `C:\Windows\System32`. This behavior causes `Copy-Item` to not work properly when the `target` directory is referenced by a relative path.

Additionally, the `-WorkingDirectory` parameter does not function properly in this context, causing file operations to fail or target incorrect locations.

ref: https://stackoverflow.com/questions/43494863/start-process-workingdirectory-as-administrator-does-not-set-location/55236108

## Solution
This PR addresses the issue by:

1. Explicitly setting the working directory using `Set-Location` before performing file operations
2. Using `source_directory()` to correctly reference the directory where AdobePlugin.just is located

This change is needed because the all examples in the repository reference the `AdobePlugin.just` file, and they need to correctly resolve the repository root location regardless of where the command is invoked from.