### PR TITLE
#73: Work In Progess AEGP support

### DIFF
--- a/AdobePlugin.just
+++ b/AdobePlugin.just
@@ -61,7 +61,8 @@ create_bundle profile TargetDir:
 
     DEV_CERT=$(security find-identity -v -p codesigning | grep -m 1 "Apple Development" | awk -F ' ' '{print $2}')
 
-    # Perform signing
+    # Perform signing - as of AE and PR 25.2 all macos plugins require a signature or else
+    # they will fail to load with error code "2685337601" - see your "Plugin Loading.log" for details
     if [ -n "$DEV_CERT" ]; then
        codesign --options runtime --timestamp -strict --sign "$DEV_CERT" {{TargetDir}}/{{profile}}/{{PluginName}}.plugin
     else

--- a/AdobePlugin.just
+++ b/AdobePlugin.just
@@ -59,9 +59,14 @@ create_bundle profile TargetDir:
         cp {{TargetDir}}/{{profile}}/lib{{BinaryName}}.dylib {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/MacOS/{{PluginName}}
     fi
 
-    # codesign with the first development cert we can find using its hash
-    if [ -z "$NO_SIGN" ]; then
-        codesign --options runtime --timestamp -strict  --sign $( security find-identity -v -p codesigning | grep -m 1 "Apple Development" | awk -F ' ' '{print $2}' ) {{TargetDir}}/{{profile}}/{{PluginName}}.plugin
+    DEV_CERT=$(security find-identity -v -p codesigning | grep -m 1 "Apple Development" | awk -F ' ' '{print $2}')
+
+    # Perform signing
+    if [ -n "$DEV_CERT" ]; then
+       codesign --options runtime --timestamp -strict --sign "$DEV_CERT" {{TargetDir}}/{{profile}}/{{PluginName}}.plugin
+    else
+       codesign --options runtime --timestamp -strict --sign - {{TargetDir}}/{{profile}}/{{PluginName}}.plugin
+       echo "Note: Using ad-hoc signature. For distribution, a valid Apple Developer certificate is recommended."
     fi
 
     # Install

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ AfterEffectsSDK
 | ✅ Camera               | ✅ AE Adv Item                    | ✅ Image    | ✅ AE Plugin Helper 2 |
 | ✅ Canvas               | 🔳 AE Adv Time                    | ✅ Path     |                       |
 | 🔳 Collection           | ✅ AE App                         | ✅ Pen      |                       |
-| 🔳 Command              | ✅ AngleParam                     | ✅ Supplier |                       |
+| ✅ Command              | ✅ AngleParam                     | ✅ Supplier |                       |
 | ✅ Comp                 | 🔳 ANSI                           | ✅ Surface  |                       |
 | ✅ Composite            | ✅ Background Frame               |             |                       |
 | 🔳 Compute              | 🔳 Batch Sampling                 |             |                       |
@@ -169,7 +169,7 @@ AfterEffectsSDK
 | ✅ PF Interface         | ✅ PointParam                     |             |                       |
 | ✅ Proj                 | 🔳 Sampling8                      |             |                       |
 | 🔳 QueryXform           | 🔳 Sampling16                     |             |                       |
-| 🔳 Register             | 🔳 SamplingFloat                  |             |                       |
+| ✅  Register             | 🔳 SamplingFloat                  |             |                       |
 | ✅ Render Asyc Manager  | ✅ Source Settings                |             |                       |
 | ✅ Render Options       | ✅ Transition                     |             |                       |
 | 🔳 Render Queue Item    | ✅ Utility                        |             |                       |
@@ -185,6 +185,8 @@ AfterEffectsSDK
 | ✅ Utility              |                                   |             |                       |
 | 🔳 Workspace Panel      |                                   |             |                       |
 | ✅ World                |                                   |             |                       |
+
+*The register suite currently excludes the artisan and AEIO registration API
 
 ### Premiere
 

--- a/after-effects-sys/build.rs
+++ b/after-effects-sys/build.rs
@@ -81,6 +81,7 @@ fn main() {
 
     if cfg!(target_os = "macos") {
         ae_bindings = ae_bindings
+            .clang_arg("-Wno-elaborated-enum-base")
             //.clang_arg("-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreFoundation.framework/Versions/A/Headers/")
             //.clang_arg("-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Versions/A/Headers/")
             //.clang_arg("-I/Library/Developer/CommandLineTools/usr/include/c++/v1/")

--- a/after-effects/Cargo.toml
+++ b/after-effects/Cargo.toml
@@ -19,7 +19,7 @@ catch-panics = []
 default = []
 
 [dependencies]
-after-effects-sys = "0.2"                                              #{path = "../after-effects-sys"}
+after-effects-sys = { path = "../after-effects-sys" }
 bincode = "1.3"
 bitflags = "2.6"
 cstr-literal = "0.1"

--- a/after-effects/src/aegp/mod.rs
+++ b/after-effects/src/aegp/mod.rs
@@ -43,6 +43,8 @@ pub type PluginId = ae_sys::AEGP_PluginID;
 pub type ItemId = i32;
 pub type LayerId = u32;
 
+pub use suites::command::{MenuId, MenuOrder};
+pub use suites::register::{HookPriority, CommandHookStatus};
 pub use suites::project::{
     ProjectHandle,
     ProjectBitDepth,

--- a/after-effects/src/aegp/mod.rs
+++ b/after-effects/src/aegp/mod.rs
@@ -12,6 +12,7 @@ pub mod suites {
     pub(crate) mod camera;               pub use camera              ::CameraSuite             as Camera;
     pub(crate) mod canvas;               pub use canvas              ::CanvasSuite             as Canvas;
     pub(crate) mod color_settings;       pub use color_settings      ::ColorSettingsSuite      as ColorSettings;
+    pub(crate) mod command;              pub use command             ::CommandSuite            as Command;
     pub(crate) mod comp;                 pub use comp                ::CompSuite               as Comp;
     pub(crate) mod composite;            pub use composite           ::CompositeSuite          as Composite;
     pub(crate) mod effect;               pub use effect              ::EffectSuite             as Effect;
@@ -27,6 +28,7 @@ pub mod suites {
     pub(crate) mod memory;               pub use memory              ::MemorySuite             as Memory;
     pub(crate) mod pf_interface;         pub use pf_interface        ::PFInterfaceSuite        as PFInterface;
     pub(crate) mod project;              pub use project             ::ProjectSuite            as Project;
+    pub(crate) mod register;             pub use register            ::RegisterSuite           as Register;
     pub(crate) mod render_async_manager; pub use render_async_manager::RenderAsyncManagerSuite as RenderAsyncManager;
     pub(crate) mod render_options;       pub use render_options      ::RenderOptionsSuite      as RenderOptions;
     pub(crate) mod render;               pub use render              ::RenderSuite             as Render;

--- a/after-effects/src/aegp/mod.rs
+++ b/after-effects/src/aegp/mod.rs
@@ -28,7 +28,8 @@ pub mod suites {
     pub(crate) mod memory;               pub use memory              ::MemorySuite             as Memory;
     pub(crate) mod pf_interface;         pub use pf_interface        ::PFInterfaceSuite        as PFInterface;
     pub(crate) mod project;              pub use project             ::ProjectSuite            as Project;
-    pub(crate) mod register;             pub use register            ::RegisterSuite           as Register;
+    pub(crate) mod register;             pub use register            ::{ RegisterSuite         as Register,
+                                                                         RegisterNonAegpSuite  as RegisterNonAegp };
     pub(crate) mod render_async_manager; pub use render_async_manager::RenderAsyncManagerSuite as RenderAsyncManager;
     pub(crate) mod render_options;       pub use render_options      ::RenderOptionsSuite      as RenderOptions;
     pub(crate) mod render;               pub use render              ::RenderSuite             as Render;

--- a/after-effects/src/aegp/suites/command.rs
+++ b/after-effects/src/aegp/suites/command.rs
@@ -34,6 +34,25 @@ define_enum! {
     }
 }
 
+#[repr(i32)]
+pub enum MenuOrder {
+    Sorted = -2,
+    Top    = -1,
+    Bottom = 0,
+    Other(i32),
+}
+
+impl Into<i32> for MenuOrder {
+    fn into(self) -> i32 {
+        match self {
+            MenuOrder::Sorted => -2,
+            MenuOrder::Top => -1,
+            MenuOrder::Bottom => 0,
+            MenuOrder::Other(val) => val,
+        }
+    }
+}
+
 impl CommandSuite {
     pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
@@ -56,13 +75,13 @@ impl CommandSuite {
         )
     }
 
-    /// Inserts a command into a menu
+    /// Inserts a command into a menu, after_item indicates ordering corresponding to the
     pub fn insert_command(
         &self,
         command_name: &str,
         command_id: AEGP_Command,
         menu_id: MenuId,
-        after_item: i32,
+        after_item: MenuOrder,
     ) -> Result<(), Error> {
         let command_name = CString::new(command_name).map_err(|_| Error::InvalidParms)?;
 
@@ -72,7 +91,7 @@ impl CommandSuite {
             command_id,
             command_name.as_ptr(),
             menu_id.into(),
-            after_item,
+            after_item.into(),
         )
     }
 

--- a/after-effects/src/aegp/suites/command.rs
+++ b/after-effects/src/aegp/suites/command.rs
@@ -1,0 +1,109 @@
+use std::ffi::CString;
+
+use after_effects_sys::AEGP_Command;
+
+use crate::*;
+
+define_suite!(
+    CommandSuite,
+    AEGP_CommandSuite1,
+    kAEGPCommandSuite,
+    kAEGPCommandSuiteVersion1
+);
+
+define_enum! {
+    ae_sys::AEGP_MenuID,
+    MenuId {
+        None = ae_sys::AEGP_Menu_NONE,
+        Apple = ae_sys::AEGP_Menu_APPLE,
+        File = ae_sys::AEGP_Menu_FILE,
+        Edit = ae_sys::AEGP_Menu_EDIT,
+        Composition = ae_sys::AEGP_Menu_COMPOSITION,
+        Layer = ae_sys::AEGP_Menu_LAYER,
+        Effect = ae_sys::AEGP_Menu_EFFECT,
+        Window = ae_sys::AEGP_Menu_WINDOW,
+        Floaters = ae_sys::AEGP_Menu_FLOATERS,
+        KfAssist = ae_sys::AEGP_Menu_KF_ASSIST,
+        Import = ae_sys::AEGP_Menu_IMPORT,
+        SaveFrameAs = ae_sys::AEGP_Menu_SAVE_FRAME_AS,
+        Prefs = ae_sys::AEGP_Menu_PREFS,
+        Export = ae_sys::AEGP_Menu_EXPORT,
+        Animation = ae_sys::AEGP_Menu_ANIMATION,
+        Purge = ae_sys::AEGP_Menu_PURGE,
+        New = ae_sys::AEGP_Menu_NEW,
+    }
+}
+
+impl CommandSuite {
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
+    /// Obtain a unique command identifier. Use the Register Suite to register a handler for the command.
+    ///
+    /// Note: On occasion After Effects will send command 0 (zero), so don't use that as part of your command handling logic.
+    pub fn get_unique_command(&self) -> Result<AEGP_Command, Error> {
+        call_suite_fn_single!(self, AEGP_GetUniqueCommand -> ae_sys::AEGP_Command)
+    }
+
+    /// Set menu name of a command.
+    pub fn set_command_name(&self, command_name: &str, command: AEGP_Command) -> Result<(), Error> {
+        let command_name = CString::new(command_name).map_err(|_| Error::InvalidParms)?;
+
+        call_suite_fn!(
+            self,
+            AEGP_SetMenuCommandName,
+            command,
+            command_name.as_ptr()
+        )
+    }
+
+    /// Inserts a command into a menu
+    pub fn insert_command(
+        &self,
+        command_name: &str,
+        command_id: AEGP_Command,
+        menu_id: MenuId,
+        after_item: i32,
+    ) -> Result<(), Error> {
+        let command_name = CString::new(command_name).map_err(|_| Error::InvalidParms)?;
+
+        call_suite_fn!(
+            self,
+            AEGP_InsertMenuCommand,
+            command_id,
+            command_name.as_ptr(),
+            menu_id.into(),
+            after_item,
+        )
+    }
+
+    /// Removes a command from After Effects.
+    pub fn remove_command(&self, command_id: AEGP_Command) -> Result<(), Error> {
+        call_suite_fn!(self, AEGP_RemoveMenuCommand, command_id)
+    }
+
+    /// Enable a menu command.
+    pub fn enable_command(&self, command: AEGP_Command) -> Result<(), Error> {
+        call_suite_fn!(self, AEGP_EnableCommand, command)
+    }
+
+    /// Disable a menu command.
+    pub fn disable_command(&self, command: AEGP_Command) -> Result<(), Error> {
+        call_suite_fn!(self, AEGP_DisableCommand, command)
+    }
+
+    /// After Effects will draw a check mark next to the menu command.
+    pub fn check_mark_menu_command(&self, command: AEGP_Command, check: bool) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_CheckMarkMenuCommand,
+            command,
+            check as ae_sys::A_Boolean
+        )
+    }
+
+    /// Call the handler for a specified menu command. Every After Effects menu item has an associated command.
+    /// Note that we make no guarantees that command IDs will be consistent from version to version.
+    pub fn do_command(&self, command: AEGP_Command) -> Result<(), Error> {
+        call_suite_fn!(self, AEGP_DoCommand, command)
+    }
+}

--- a/after-effects/src/aegp/suites/register.rs
+++ b/after-effects/src/aegp/suites/register.rs
@@ -407,3 +407,314 @@ impl RegisterSuite {
         )
     }
 }
+
+pub type NonAegpUpdateMenuHook<R> = Box<dyn Fn(&mut R, WindowType) -> Result<(), Error>>;
+
+pub type NonAegpCommandHook<R> = Box<
+    dyn FnMut(&mut R, ae_sys::AEGP_Command, HookPriority, bool) -> Result<CommandHookStatus, Error>,
+>;
+
+pub type NonAegpDeathHook<R> = Box<dyn FnMut(&mut R) -> Result<(), Error>>;
+
+pub type NonAegpVersionHook<R> = Box<dyn FnMut(&mut R, &mut u32) -> Result<(), Error>>;
+
+pub type NonAegpAboutStringHook<R> = Box<dyn FnMut(&mut R, &mut [u8]) -> Result<(), Error>>;
+
+pub type NonAegpAboutHook<R> = Box<dyn FnMut(&mut R) -> Result<(), Error>>;
+
+pub type NonAegpIdleHook<R> = Box<dyn FnMut(&mut R, &mut i32) -> Result<(), Error>>;
+
+define_suite!(
+    RegisterNonAegpSuite,
+    AEGP_RegisterSuite5,
+    kAEGPRegisterSuite,
+    kAEGPRegisterSuiteVersion5
+);
+
+/// Note: functions in this suite assume the plugin_refcon is always null.
+/// This is appropriate for non-AEGP plugins.
+impl RegisterNonAegpSuite {
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
+    /// Register a hook (command handler) function with After Effects.
+    /// If you are replacing a function which After Effects also handles, `AEGP_HookPriority` determines whether your plug-in gets run first.
+    pub fn register_command_hook<RefCon>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        hook_priority: HookPriority,
+        command: ae_sys::AEGP_Command,
+        command_hook_func: NonAegpCommandHook<RefCon>,
+        command_refcon: RefCon,
+    ) -> Result<(), Error> {
+        unsafe extern "C" fn command_hook_wrapper<T>(
+            _: AEGP_GlobalRefcon,
+            refcon: AEGP_CommandRefcon,
+            command: ae_sys::AEGP_Command,
+            hook_priority: ae_sys::AEGP_HookPriority,
+            already_handled: ae_sys::A_Boolean,
+            handled_p: *mut ae_sys::A_Boolean,
+        ) -> ae_sys::A_Err {
+            let (cb, refcon) = &mut *(refcon as *mut (NonAegpCommandHook<T>, T));
+            let already_handled_bool = already_handled != 0;
+            let hook_priority_enum = match hook_priority {
+                ae_sys::AEGP_HP_BeforeAE => HookPriority::BeforeAE,
+                ae_sys::AEGP_HP_AfterAE => HookPriority::AfterAE,
+                _ => HookPriority::BeforeAE,
+            };
+
+            let res = cb(refcon, command, hook_priority_enum, already_handled_bool);
+
+            match res {
+                Ok(CommandHookStatus::Handled) => {
+                    *handled_p = 1;
+                    Error::None
+                }
+                Ok(CommandHookStatus::Unhandled) => {
+                    *handled_p = 0;
+                    Error::None
+                }
+                Err(e) => {
+                    *handled_p = 0;
+                    e
+                }
+            }
+            .into()
+        }
+
+        let refcon_cb_tuple = Box::new((command_hook_func, command_refcon));
+        call_suite_fn!(
+            self,
+            AEGP_RegisterCommandHook,
+            plugin_id,
+            hook_priority.into(),
+            command,
+            Some(command_hook_wrapper::<RefCon>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Register your menu update function (which determines whether or not items are active),
+    /// called every time any menu is to be drawn.
+    pub fn register_update_menu_hook<UpdateMenuRefCon>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        update_menu_hook_func: NonAegpUpdateMenuHook<UpdateMenuRefCon>,
+        update_menu_refcon: UpdateMenuRefCon,
+    ) -> Result<(), Error> {
+        unsafe extern "C" fn update_menu_hook_wrapper<T>(
+            _: AEGP_GlobalRefcon,
+            refcon: AEGP_UpdateMenuRefcon,
+            window_type: ae_sys::AEGP_WindowType,
+        ) -> sys::PF_Err {
+            let (callback, refcon) = &mut *(refcon as *mut (NonAegpUpdateMenuHook<T>, T));
+
+            match callback(refcon, window_type.into()) {
+                Ok(_) => Error::None,
+                Err(e) => e.into(),
+            }
+            .into()
+        }
+
+        let refcon_cb_tuple = Box::new((update_menu_hook_func, update_menu_refcon));
+
+        call_suite_fn!(
+            self,
+            AEGP_RegisterUpdateMenuHook,
+            plugin_id,
+            Some(update_menu_hook_wrapper::<UpdateMenuRefCon>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Register your termination function. Called when the application quits.
+    pub fn register_death_hook<DeathRefcon>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        death_hook_func: NonAegpDeathHook<DeathRefcon>,
+        death_refcon: DeathRefcon,
+    ) -> Result<(), Error> {
+        unsafe extern "C" fn death_hook_wrapper<T>(
+            _: AEGP_GlobalRefcon,
+            refcon: AEGP_DeathRefcon,
+        ) -> sys::PF_Err {
+            let (cb, refcon) = &mut *(refcon as *mut (NonAegpDeathHook<T>, T));
+            match cb(refcon) {
+                Ok(_) => Error::None,
+                Err(e) => e,
+            }
+            .into()
+        }
+
+        let refcon_cb_tuple = Box::new((death_hook_func, death_refcon));
+        call_suite_fn!(
+            self,
+            AEGP_RegisterDeathHook,
+            plugin_id,
+            Some(death_hook_wrapper::<DeathRefcon>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Currently not called.
+    pub fn register_version_hook<VersionRefCon>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        version_hook_func: NonAegpVersionHook<VersionRefCon>,
+        version_refcon: VersionRefCon,
+    ) -> Result<(), Error> {
+        unsafe extern "C" fn version_hook_wrapper<T>(
+            _: AEGP_GlobalRefcon,
+            refcon: AEGP_VersionRefcon,
+            pf_version_p: *mut ae_sys::A_u_long,
+        ) -> ae_sys::A_Err {
+            log::error!(
+                "The after effects documentation said version hook should never be called!"
+            );
+
+            let (cb, refcon) = &mut *(refcon as *mut (NonAegpVersionHook<T>, T));
+            let pf_version = &mut (*pf_version_p as u32);
+
+            match cb(refcon, pf_version) {
+                Ok(_) => Error::None,
+                Err(e) => e,
+            }
+            .into()
+        }
+
+        log::warn!("Called `register_version_hook`, this does nothing!");
+
+        let refcon_cb_tuple = Box::new((version_hook_func, version_refcon));
+        call_suite_fn!(
+            self,
+            AEGP_RegisterVersionHook,
+            plugin_id,
+            Some(version_hook_wrapper::<VersionRefCon>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Currently not called.
+    pub fn register_about_string_hook<AboutString>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        about_string_hook_func: NonAegpAboutStringHook<AboutString>,
+        about_string_refcon: AboutString,
+    ) -> Result<(), Error> {
+        unsafe extern "C" fn about_string_hook_wrapper<T>(
+            _: AEGP_GlobalRefcon,
+            refcon: AEGP_AboutStringRefcon,
+            // We have 0 documentation about this pointer
+            // besides that it is never constructed, so it's treated as null
+            _about_z: *mut ae_sys::A_char,
+        ) -> ae_sys::A_Err {
+            log::error!(
+                "The after effects documentation said about string hook should never be called!"
+            );
+
+            let (cb, refcon) = &mut *(refcon as *mut (NonAegpAboutStringHook<T>, T));
+
+            match cb(refcon, &mut []) {
+                Ok(_) => Error::None,
+                Err(e) => e,
+            }
+            .into()
+        }
+
+        log::warn!("Called `register_about_string_hook`, this does nothing!");
+
+        let refcon_cb_tuple = Box::new((about_string_hook_func, about_string_refcon));
+        call_suite_fn!(
+            self,
+            AEGP_RegisterAboutStringHook,
+            plugin_id,
+            Some(about_string_hook_wrapper::<AboutString>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Currently not called.
+    pub fn register_about_hook<About>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        about_hook_func: NonAegpAboutHook<About>,
+        about_refcon: About,
+    ) -> Result<(), Error> {
+        unsafe extern "C" fn about_hook_wrapper<T>(
+            _: AEGP_GlobalRefcon,
+            refcon: AEGP_AboutRefcon,
+        ) -> ae_sys::A_Err {
+            log::error!("The after effects documentation said about hook should never be called!");
+
+            let (cb, refcon) = &mut *(refcon as *mut (NonAegpAboutHook<T>, T));
+
+            match cb(refcon) {
+                Ok(_) => Error::None,
+                Err(e) => e,
+            }
+            .into()
+        }
+
+        log::warn!("Called `register_about_hook`, this does nothing!");
+
+        let refcon_cb_tuple = Box::new((about_hook_func, about_refcon));
+        call_suite_fn!(
+            self,
+            AEGP_RegisterAboutHook,
+            plugin_id,
+            Some(about_hook_wrapper::<About>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Register your IdleHook function. After Effects will call the function sporadically,
+    /// while the user makes difficult artistic decisions (or while they're getting more coffee).
+    pub fn register_idle_hook<IdleRefCon>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        idle_hook_func: NonAegpIdleHook<IdleRefCon>,
+        idle_refcon: IdleRefCon,
+    ) -> Result<(), Error> {
+        unsafe extern "C" fn idle_hook_wrapper<T>(
+            _: AEGP_GlobalRefcon,
+            refcon: ae_sys::AEGP_IdleRefcon,
+            max_sleep_p: *mut ae_sys::A_long,
+        ) -> ae_sys::A_Err {
+            let (cb, refcon) = &mut *(refcon as *mut (NonAegpIdleHook<T>, T));
+            let max_sleep = &mut (*max_sleep_p);
+
+            match cb(refcon, max_sleep) {
+                Ok(_) => Error::None,
+                Err(e) => e,
+            }
+            .into()
+        }
+
+        let refcon_cb_tuple = Box::new((idle_hook_func, idle_refcon));
+        call_suite_fn!(
+            self,
+            AEGP_RegisterIdleHook,
+            plugin_id,
+            Some(idle_hook_wrapper::<IdleRefCon>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Call this to register as many strings as you like for name-replacement when presets are loaded.
+    /// Any time a Property name is found, or referred to in an expression, and it starts with an ASCII tab character ('t'),
+    /// followed by one of the English names, it will be replaced with the localized name.
+    /// (In English the tab character will simply be removed).
+    pub fn register_preset_localization_string(
+        &self,
+        english_name: &str,
+        localized_name: &str,
+    ) -> Result<(), Error> {
+        let english_name_c = CString::new(english_name).map_err(|_| Error::InvalidParms)?;
+        let localized_name_c = CString::new(localized_name).map_err(|_| Error::InvalidParms)?;
+        call_suite_fn!(
+            self,
+            AEGP_RegisterPresetLocalizationString,
+            english_name_c.as_ptr(),
+            localized_name_c.as_ptr()
+        )
+    }
+}

--- a/after-effects/src/aegp/suites/register.rs
+++ b/after-effects/src/aegp/suites/register.rs
@@ -1,0 +1,434 @@
+use after_effects_sys::{
+    AEGP_AboutRefcon, AEGP_AboutStringRefcon, AEGP_CommandRefcon, AEGP_DeathRefcon,
+    AEGP_GlobalRefcon, AEGP_UpdateMenuRefcon, AEGP_VersionRefcon,
+};
+
+use crate::*;
+use std::ffi::CString;
+use std::os::raw::c_void;
+
+define_suite!(
+    RegisterSuite,
+    AEGP_RegisterSuite5,
+    kAEGPRegisterSuite,
+    kAEGPRegisterSuiteVersion5
+);
+
+define_enum! {
+    ae_sys::AEGP_HookPriority,
+    HookPriority {
+        BeforeAE = ae_sys::AEGP_HP_BeforeAE,
+        AfterAE = ae_sys::AEGP_HP_AfterAE,
+    }
+}
+
+define_enum! {
+    ae_sys::AEGP_WindowType,
+    WindowType {
+        None = ae_sys::AEGP_WindType_NONE,
+        Project = ae_sys::AEGP_WindType_PROJECT,
+        Comp = ae_sys::AEGP_WindType_COMP,
+        TimeLayout = ae_sys::AEGP_WindType_TIME_LAYOUT,
+        Layer = ae_sys::AEGP_WindType_LAYER,
+        Footage = ae_sys::AEGP_WindType_FOOTAGE,
+        RenderQueue = ae_sys::AEGP_WindType_RENDER_QUEUE,
+        QuickTime = ae_sys::AEGP_WindType_QT,
+        Dialog = ae_sys::AEGP_WindType_DIALOG,
+        Flowchart = ae_sys::AEGP_WindType_FLOWCHART,
+        Effect = ae_sys::AEGP_WindType_EFFECT,
+        Other = ae_sys::AEGP_WindType_OTHER,
+    }
+}
+
+/// Note: functions in this suite take a `Global` Paramater, for AEGPs this must be the same as your global `AegpPlugin` type, for all
+/// other plugins this should likely be `()` - as you will always receive a `None` Global argument in your callbacks.
+impl RegisterSuite {
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
+    /// Register a hook (command handler) function with After Effects.
+    /// If you are replacing a function which After Effects also handles, `AEGP_HookPriority` determines whether your plug-in gets run first.
+    pub fn register_command_hook<Global, Command, F>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        hook_priority: HookPriority,
+        command: ae_sys::AEGP_Command,
+        command_hook_func: F,
+        command_refcon: Command,
+    ) -> Result<(), Error>
+    where
+        F: FnMut(
+            Option<&mut Global>,
+            &mut Command,
+            ae_sys::AEGP_Command,
+            HookPriority,
+            bool,
+        ) -> (Error, bool),
+    {
+        unsafe extern "C" fn command_hook_wrapper<P, T, F>(
+            plugin_refcon: AEGP_GlobalRefcon,
+            refcon: AEGP_CommandRefcon,
+            command: ae_sys::AEGP_Command,
+            hook_priority: ae_sys::AEGP_HookPriority,
+            already_handled: ae_sys::A_Boolean,
+            handled_p: *mut ae_sys::A_Boolean,
+        ) -> ae_sys::A_Err
+        where
+            F: FnMut(
+                Option<&mut P>,
+                &mut T,
+                ae_sys::AEGP_Command,
+                HookPriority,
+                bool,
+            ) -> (Error, bool),
+        {
+            let global = if plugin_refcon.is_null() {
+                None
+            } else {
+                Some(&mut *(plugin_refcon as *mut P))
+            };
+
+            let (cb, refcon) = &mut *(refcon as *mut (F, T));
+            let already_handled_bool = already_handled != 0;
+
+            let hook_priority_enum = match hook_priority {
+                ae_sys::AEGP_HP_BeforeAE => HookPriority::BeforeAE,
+                ae_sys::AEGP_HP_AfterAE => HookPriority::AfterAE,
+                _ => HookPriority::BeforeAE, // Default case
+            };
+
+            let (error, was_handled) = cb(
+                global,
+                refcon,
+                command,
+                hook_priority_enum,
+                already_handled_bool,
+            );
+
+            if !handled_p.is_null() {
+                *handled_p = if was_handled { 1 } else { 0 };
+            }
+
+            error.into()
+        }
+
+        let refcon_cb_tuple = Box::new((command_hook_func, command_refcon));
+        call_suite_fn!(
+            self,
+            AEGP_RegisterCommandHook,
+            plugin_id,
+            hook_priority.into(),
+            command,
+            Some(command_hook_wrapper::<Global, Command, F>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Register your menu update function (which determines whether or not items are active),
+    /// called every time any menu is to be drawn.
+    pub fn register_update_menu_hook<Global, UpdateMenu, F>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        update_menu_hook_func: F,
+        update_menu_refcon: UpdateMenu,
+    ) -> Result<(), Error>
+    where
+        F: FnMut(Option<&mut Global>, &mut UpdateMenu, WindowType) -> Error,
+    {
+        unsafe extern "C" fn update_menu_hook_wrapper<P, T, F>(
+            plugin_refcon: AEGP_GlobalRefcon,
+            refcon: AEGP_UpdateMenuRefcon,
+            window_type: ae_sys::AEGP_WindowType,
+        ) -> sys::PF_Err
+        where
+            F: FnMut(Option<&mut P>, &mut T, WindowType) -> Error,
+        {
+            let global = if plugin_refcon.is_null() {
+                None
+            } else {
+                Some(&mut *(plugin_refcon as *mut P))
+            };
+
+            let (cb, refcon) = &mut *(refcon as *mut (F, T));
+            cb(global, refcon, window_type.into()).into()
+        }
+
+        let refcon_cb_tuple = Box::new((update_menu_hook_func, update_menu_refcon));
+        call_suite_fn!(
+            self,
+            AEGP_RegisterUpdateMenuHook,
+            plugin_id,
+            Some(update_menu_hook_wrapper::<Global, UpdateMenu, F>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Register your termination function. Called when the application quits.
+    pub fn register_death_hook<Global, Death, F>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        death_hook_func: F,
+        death_refcon: Death,
+    ) -> Result<(), Error>
+    where
+        F: FnMut(Option<&mut Global>, &mut Death) -> Error,
+    {
+        unsafe extern "C" fn death_hook_wrapper<P, T, F>(
+            plugin_refcon: AEGP_GlobalRefcon,
+            refcon: AEGP_DeathRefcon,
+        ) -> sys::PF_Err
+        where
+            F: FnMut(Option<&mut P>, &mut T) -> Error,
+        {
+            let global = if plugin_refcon.is_null() {
+                None
+            } else {
+                Some(&mut *(plugin_refcon as *mut P))
+            };
+
+            let (cb, refcon) = &mut *(refcon as *mut (F, T));
+            cb(global, refcon).into()
+        }
+
+        let refcon_cb_tuple = Box::new((death_hook_func, death_refcon));
+        call_suite_fn!(
+            self,
+            AEGP_RegisterDeathHook,
+            plugin_id,
+            Some(death_hook_wrapper::<Global, Death, F>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Currently not called.
+    pub fn register_version_hook<Global, Version, F>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        version_hook_func: F,
+        version_refcon: Version,
+    ) -> Result<(), Error>
+    where
+        F: FnMut(Option<&mut Global>, &mut Version, &mut u32) -> Error,
+    {
+        unsafe extern "C" fn version_hook_wrapper<P, T, F>(
+            plugin_refcon: AEGP_GlobalRefcon,
+            refcon: AEGP_VersionRefcon,
+            pf_version_p: *mut ae_sys::A_u_long,
+        ) -> ae_sys::A_Err
+        where
+            F: FnMut(Option<&mut P>, &mut T, &mut u32) -> Error,
+        {
+            log::error!(
+                "The after effects documentation said version hook should never be called!"
+            );
+            let global = if plugin_refcon.is_null() {
+                None
+            } else {
+                Some(&mut *(plugin_refcon as *mut P))
+            };
+
+            let (cb, refcon) = &mut *(refcon as *mut (F, T));
+            let pf_version = &mut (*pf_version_p as u32);
+
+            cb(global, refcon, pf_version).into()
+        }
+
+        log::warn!("Called `register_version_hook`, this does nothing!");
+
+        let refcon_cb_tuple = Box::new((version_hook_func, version_refcon));
+        call_suite_fn!(
+            self,
+            AEGP_RegisterVersionHook,
+            plugin_id,
+            Some(version_hook_wrapper::<Global, Version, F>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Currently not called.
+    pub fn register_about_string_hook<Global, AboutString, F>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        about_string_hook_func: F,
+        about_string_refcon: AboutString,
+    ) -> Result<(), Error>
+    where
+        F: FnMut(Option<&mut Global>, &mut AboutString, &mut [u8]) -> Error,
+    {
+        unsafe extern "C" fn about_string_hook_wrapper<P, T, F>(
+            plugin_refcon: AEGP_GlobalRefcon,
+            refcon: AEGP_AboutStringRefcon,
+            // We have 0 documentation about this pointer
+            // besides that it is never constructed, so i'm treating it as null
+            _about_z: *mut ae_sys::A_char,
+        ) -> ae_sys::A_Err
+        where
+            F: FnMut(Option<&mut P>, &mut T, &mut [u8]) -> Error,
+        {
+            log::error!(
+                "The after effects documentation said about string hook should never be called!"
+            );
+            let global = if plugin_refcon.is_null() {
+                None
+            } else {
+                Some(&mut *(plugin_refcon as *mut P))
+            };
+
+            let (cb, refcon) = &mut *(refcon as *mut (F, T));
+            cb(global, refcon, &mut []).into()
+        }
+
+        log::warn!("Called `register_about_string_hook`, this does nothing!");
+
+        let refcon_cb_tuple = Box::new((about_string_hook_func, about_string_refcon));
+        call_suite_fn!(
+            self,
+            AEGP_RegisterAboutStringHook,
+            plugin_id,
+            Some(about_string_hook_wrapper::<Global, AboutString, F>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Currently not called.
+    pub fn register_about_hook<Global, About, F>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        about_hook_func: F,
+        about_refcon: About,
+    ) -> Result<(), Error>
+    where
+        F: FnMut(Option<&mut Global>, &mut About) -> Error,
+    {
+        unsafe extern "C" fn about_hook_wrapper<P, T, F>(
+            plugin_refcon: AEGP_GlobalRefcon,
+            refcon: AEGP_AboutRefcon,
+        ) -> ae_sys::A_Err
+        where
+            F: FnMut(Option<&mut P>, &mut T) -> Error,
+        {
+            log::error!("The after effects documentation said about hook should never be called!");
+            let global = if plugin_refcon.is_null() {
+                None
+            } else {
+                Some(&mut *(plugin_refcon as *mut P))
+            };
+
+            let (cb, refcon) = &mut *(refcon as *mut (F, T));
+            cb(global, refcon).into()
+        }
+
+        log::warn!("Called `register_about_hook`, this does nothing!");
+
+        let refcon_cb_tuple = Box::new((about_hook_func, about_refcon));
+        call_suite_fn!(
+            self,
+            AEGP_RegisterAboutHook,
+            plugin_id,
+            Some(about_hook_wrapper::<Global, About, F>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Register your Artisan. See Artisans for more details.
+    pub fn register_artisan(
+        &self,
+        _api_version: ae_sys::A_Version,
+        _artisan_version: ae_sys::A_Version,
+        _plugin_id: i32,
+        _refcon: *mut c_void,
+        _match_name: &str,
+        _artisan_name: &str,
+        _entry_funcs: *mut ae_sys::PR_ArtisanEntryPoints,
+    ) -> Result<(), Error> {
+        todo!("Artisan plugins are not yet supported");
+    }
+
+    /// Register your AEIO plug-in. See AEIOs for more details.
+    pub fn register_io(
+        &self,
+        _plugin_id: ae_sys::AEGP_PluginID,
+        _refcon: ae_sys::AEGP_IORefcon,
+        _io_info: *const ae_sys::AEIO_ModuleInfo,
+        _aeio_fcn_block: *const ae_sys::AEIO_FunctionBlock4,
+    ) -> Result<(), Error> {
+        todo!("AEIO plugins are not yet supported");
+    }
+
+    /// Register your IdleHook function. After Effects will call the function sporadically,
+    /// while the user makes difficult artistic decisions (or while they're getting more coffee).
+    /// Register your IdleHook function. After Effects will call the function sporadically,
+    /// while the user makes difficult artistic decisions (or while they're getting more coffee).
+    pub fn register_idle_hook<Global, Idle, F>(
+        &self,
+        plugin_id: ae_sys::AEGP_PluginID,
+        idle_hook_func: F,
+        idle_refcon: Idle,
+    ) -> Result<(), Error>
+    where
+        F: FnMut(Option<&mut Global>, &mut Idle, &mut i32) -> Error,
+    {
+        unsafe extern "C" fn idle_hook_wrapper<P, T, F>(
+            plugin_refcon: AEGP_GlobalRefcon,
+            refcon: ae_sys::AEGP_IdleRefcon,
+            max_sleep_p: *mut ae_sys::A_long,
+        ) -> ae_sys::A_Err
+        where
+            F: FnMut(Option<&mut P>, &mut T, &mut i32) -> Error,
+        {
+            let global = if plugin_refcon.is_null() {
+                None
+            } else {
+                Some(&mut *(plugin_refcon as *mut P))
+            };
+
+            let (cb, refcon) = &mut *(refcon as *mut (F, T));
+            let max_sleep = &mut (*max_sleep_p);
+
+            cb(global, refcon, max_sleep).into()
+        }
+
+        let refcon_cb_tuple = Box::new((idle_hook_func, idle_refcon));
+        call_suite_fn!(
+            self,
+            AEGP_RegisterIdleHook,
+            plugin_id,
+            Some(idle_hook_wrapper::<Global, Idle, F>),
+            Box::into_raw(refcon_cb_tuple) as *mut _,
+        )
+    }
+
+    /// Registers your AEGP as an interactive artisan,
+    /// for use in previewing and rendering all layers in a given composition.
+    /// TODO: Artisan plugins are not yet supported
+    pub fn register_interactive_artisan(
+        &self,
+        _api_version: ae_sys::A_Version,
+        _artisan_version: ae_sys::A_Version,
+        _plugin_id: ae_sys::AEGP_PluginID,
+        _refcon: *mut c_void,
+        _match_name: &str,
+        _artisan_name: &str,
+        _entry_funcs: *mut ae_sys::PR_ArtisanEntryPoints,
+    ) -> Result<(), Error> {
+        todo!("Artisan plugins are not yet supported");
+    }
+
+    /// Call this to register as many strings as you like for name-replacement when presets are loaded.
+    /// Any time a Property name is found, or referred to in an expression, and it starts with an ASCII tab character ('t'),
+    /// followed by one of the English names, it will be replaced with the localized name.
+    /// (In English the tab character will simply be removed).
+    pub fn register_preset_localization_string(
+        &self,
+        english_name: &str,
+        localized_name: &str,
+    ) -> Result<(), Error> {
+        let english_name_c = CString::new(english_name).map_err(|_| Error::InvalidParms)?;
+        let localized_name_c = CString::new(localized_name).map_err(|_| Error::InvalidParms)?;
+        call_suite_fn!(
+            self,
+            AEGP_RegisterPresetLocalizationString,
+            english_name_c.as_ptr(),
+            localized_name_c.as_ptr()
+        )
+    }
+}

--- a/after-effects/src/lib.rs
+++ b/after-effects/src/lib.rs
@@ -19,7 +19,7 @@ mod macros;
 
 #[macro_use]
 mod plugin_base;
-pub use plugin_base::AegpPlugin;
+pub use plugin_base::{AegpPlugin, AegpSeal};
 
 #[macro_use]
 mod cross_thread_type;

--- a/after-effects/src/pf/handles.rs
+++ b/after-effects/src/pf/handles.rs
@@ -33,7 +33,9 @@ impl<'a, T> HandleLock<'a, T> {
 
 impl<'a, T> Drop for HandleLock<'a, T> {
     fn drop(&mut self) {
-        self.parent_handle.suite.unlock_handle(self.parent_handle.handle);
+        self.parent_handle
+            .suite
+            .unlock_handle(self.parent_handle.handle);
     }
 }
 
@@ -51,11 +53,7 @@ impl<T> BorrowedHandleLock<T> {
                 if ptr.is_null() {
                     return Err(Error::Generic);
                 }
-                Ok(BorrowedHandleLock {
-                    suite,
-                    handle,
-                    ptr
-                })
+                Ok(BorrowedHandleLock { suite, handle, ptr })
             }
             Err(_) => Err(Error::InvalidCallback),
         }
@@ -63,19 +61,14 @@ impl<T> BorrowedHandleLock<T> {
 }
 impl<T> std::ops::Deref for BorrowedHandleLock<T> {
     type Target = T;
-    fn deref(&self) -> &T {
-        unsafe { &*self.ptr }
-    }
+
+    fn deref(&self) -> &T { unsafe { &*self.ptr } }
 }
 impl<T> std::ops::DerefMut for BorrowedHandleLock<T> {
-    fn deref_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.ptr }
-    }
+    fn deref_mut(&mut self) -> &mut T { unsafe { &mut *self.ptr } }
 }
 impl<T> Drop for BorrowedHandleLock<T> {
-    fn drop(&mut self) {
-        self.suite.unlock_handle(self.handle);
-    }
+    fn drop(&mut self) { self.suite.unlock_handle(self.handle); }
 }
 
 impl<'a, T: 'a> Handle<'a, T> {
@@ -151,9 +144,7 @@ impl<'a, T: 'a> Handle<'a, T> {
         }
     }
 
-    pub fn size(&self) -> usize {
-        self.suite.handle_size(self.handle) as usize
-    }
+    pub fn size(&self) -> usize { self.suite.handle_size(self.handle) as usize }
 
     /*
     pub fn resize(&mut self, size: usize) -> Result<(), Error> {
@@ -163,14 +154,12 @@ impl<'a, T: 'a> Handle<'a, T> {
     pub fn from_raw(handle: ae_sys::PF_Handle, owned: bool) -> Result<Handle<'a, T>, Error> {
         assert!(!handle.is_null());
         match pf::suites::Handle::new() {
-            Ok(suite) => {
-                Ok(Handle {
-                    suite,
-                    handle,
-                    owned,
-                    _marker: PhantomData,
-                })
-            }
+            Ok(suite) => Ok(Handle {
+                suite,
+                handle,
+                owned,
+                _marker: PhantomData,
+            }),
             Err(_) => Err(Error::InvalidCallback),
         }
     }
@@ -193,9 +182,7 @@ impl<'a, T: 'a> Handle<'a, T> {
     }
 
     /// Returns the raw handle.
-    pub fn as_raw(&self) -> ae_sys::PF_Handle {
-        self.handle
-    }
+    pub fn as_raw(&self) -> ae_sys::PF_Handle { self.handle }
 }
 
 impl<'a, T: 'a> Drop for Handle<'a, T> {
@@ -217,7 +204,9 @@ pub struct FlatHandleLock<'a, 'b: 'a> {
 
 impl<'a, 'b> Drop for FlatHandleLock<'a, 'b> {
     fn drop(&mut self) {
-        self.parent_handle.suite.unlock_handle(self.parent_handle.handle);
+        self.parent_handle
+            .suite
+            .unlock_handle(self.parent_handle.handle);
     }
 }
 
@@ -235,7 +224,6 @@ pub struct FlatHandle<'a> {
 
 impl<'a> FlatHandle<'a> {
     pub fn new(slice: impl Into<Vec<u8>>) -> Result<FlatHandle<'a>, Error> {
-
         let suite = pf::suites::Handle::new()?;
         let vector = slice.into();
 
@@ -270,7 +258,7 @@ impl<'a> FlatHandle<'a> {
     }
 
     #[inline]
-    pub fn lock<'b: 'a>(&'b self) -> Result<FlatHandleLock, Error> {
+    pub fn lock<'b: 'a>(&'b self) -> Result<FlatHandleLock<'b, 'a>, Error> {
         let ptr = self.suite.lock_handle(self.handle) as *mut u8;
         if ptr.is_null() {
             Err(Error::InvalidIndex)
@@ -302,14 +290,10 @@ impl<'a> FlatHandle<'a> {
     }
 
     #[inline]
-    pub fn as_ptr(&self) -> *const u8 {
-        unsafe { *(self.handle as *const *const u8) }
-    }
+    pub fn as_ptr(&self) -> *const u8 { unsafe { *(self.handle as *const *const u8) } }
 
     #[inline]
-    pub fn as_ptr_mut(&self) -> *mut u8 {
-        unsafe { *(self.handle as *const *mut u8) }
-    }
+    pub fn as_ptr_mut(&self) -> *mut u8 { unsafe { *(self.handle as *const *mut u8) } }
 
     #[inline]
     pub fn to_vec(&self) -> Vec<u8> {
@@ -325,9 +309,7 @@ impl<'a> FlatHandle<'a> {
     }
 
     #[inline]
-    pub fn size(&self) -> usize {
-        self.suite.handle_size(self.handle) as usize
-    }
+    pub fn size(&self) -> usize { self.suite.handle_size(self.handle) as usize }
 
     #[inline]
     pub fn from_raw(handle: ae_sys::PF_Handle) -> Result<FlatHandle<'a>, Error> {
@@ -390,9 +372,7 @@ impl<'a> FlatHandle<'a> {
     }
 
     #[inline]
-    pub fn as_raw(&self) -> ae_sys::PF_Handle {
-        self.handle
-    }
+    pub fn as_raw(&self) -> ae_sys::PF_Handle { self.handle }
 }
 /*
 impl<'a> Clone for FlatHandle<'a> {

--- a/examples/aegp/Cargo.toml
+++ b/examples/aegp/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib"]
 
 [dependencies]
+log = "0.4"
 after-effects = { path = "../../after-effects" }
 
 [build-dependencies]

--- a/examples/aegp/Cargo.toml
+++ b/examples/aegp/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aegpdemo"
+version = "0.0.1"
+authors = ["Adrian <adrian.eddy@gmail.com>"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+after-effects = { path = "../../after-effects" }
+
+[build-dependencies]
+pipl = { path = "../../pipl" }

--- a/examples/aegp/Cargo.toml
+++ b/examples/aegp/Cargo.toml
@@ -11,6 +11,10 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4"
 after-effects = { path = "../../after-effects" }
+image = { version = "0.25.6", default-features = false, features = ["png"] }
+homedir = "0.2.1"
+raw-window-handle = "0.6.2"
+rfd = "0.15.3"
 
 [build-dependencies]
 pipl = { path = "../../pipl" }

--- a/examples/aegp/Justfile
+++ b/examples/aegp/Justfile
@@ -1,5 +1,81 @@
 PluginName       := "AegpDemo"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects.AegpDemo"
 BinaryName       := lowercase(PluginName)
 
-import '../../AdobePlugin.just'
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+
+TargetDir := env_var_or_default("CARGO_TARGET_DIR", "target")
+export AESDK_ROOT := if env("AESDK_ROOT", "") == "" { justfile_directory() / "../../../../sdk/AfterEffectsSDK" } else { env_var("AESDK_ROOT") }
+export PRSDK_ROOT := if env("PRSDK_ROOT", "") == "" { justfile_directory() / "../../../../sdk/Premiere Pro 22.0 C++ SDK" } else { env_var("PRSDK_ROOT") }
+
+[windows]
+build:
+    cargo build
+    if (-not $env:NO_INSTALL) { \
+        Start-Process PowerShell -Verb runAs -ArgumentList "-command Set-Location '{{source_directory()}}'; Copy-Item -Force '{{TargetDir}}\debug\{{BinaryName}}.dll' 'C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\{{PluginName}}.aex'" \
+    }
+
+[windows]
+release:
+    cargo build --release
+    Copy-Item -Force '{{TargetDir}}\release\{{BinaryName}}.dll' '{{TargetDir}}\release\{{PluginName}}.aex'
+    if (-not $env:NO_INSTALL) { \
+        Start-Process PowerShell -Verb runAs -ArgumentList "-command Set-Location '{{source_directory()}}'; Copy-Item -Force '{{TargetDir}}\release\{{BinaryName}}.dll' 'C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\{{PluginName}}.aex'" \
+    }
+
+[macos]
+build:
+    cargo build
+    just -f {{justfile()}} create_bundle debug {{TargetDir}}
+
+[macos]
+release:
+    cargo build --release
+    just -f {{justfile()}} create_bundle release {{TargetDir}}
+
+[macos]
+create_bundle profile TargetDir:
+    #!/bin/bash
+    set -e
+    echo "Creating plugin bundle"
+    rm -Rf {{TargetDir}}/{{profile}}/{{PluginName}}.plugin
+    mkdir -p {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/Resources
+    mkdir -p {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/MacOS
+
+    echo "AEgxFXTC" >> {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/PkgInfo
+    /usr/libexec/PlistBuddy -c 'add CFBundlePackageType string AEgx' {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/Info.plist
+    /usr/libexec/PlistBuddy -c 'add CFBundleSignature string FXTC' {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/Info.plist
+    /usr/libexec/PlistBuddy -c 'add CFBundleIdentifier string {{BundleIdentifier}}' {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/Info.plist
+    /usr/libexec/PlistBuddy -c 'add LSRequiresCarbon bool true' {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/Info.plist
+
+    if [ "{{profile}}" == "release" ]; then
+        # Build universal binary
+        rustup target add aarch64-apple-darwin
+        rustup target add x86_64-apple-darwin
+
+        cargo build --release --target x86_64-apple-darwin
+        cargo build --release --target aarch64-apple-darwin
+
+        cp {{TargetDir}}/x86_64-apple-darwin/release/{{BinaryName}}.rsrc {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/Resources/{{PluginName}}.rsrc
+        lipo {{TargetDir}}/{x86_64,aarch64}-apple-darwin/release/lib{{BinaryName}}.dylib -create -output {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/MacOS/{{PluginName}}.dylib
+        mv {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/MacOS/{{PluginName}}.dylib {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/MacOS/{{PluginName}}
+    else
+        cp {{TargetDir}}/{{profile}}/{{BinaryName}}.rsrc {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/Resources/{{PluginName}}.rsrc
+        cp {{TargetDir}}/{{profile}}/lib{{BinaryName}}.dylib {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/MacOS/{{PluginName}}
+    fi
+
+    DEV_CERT=$(security find-identity -v -p codesigning | grep -m 1 "Apple Development" | awk -F ' ' '{print $2}')
+
+    # Perform signing - as of AE and PR 25.2 all macos plugins require a signature or else
+    # they will fail to load with error code "2685337601" - see your "Plugin Loading.log" for details
+    if [ -n "$DEV_CERT" ]; then
+       codesign --options runtime --timestamp -strict --sign "$DEV_CERT" {{TargetDir}}/{{profile}}/{{PluginName}}.plugin
+    else
+       codesign --options runtime --timestamp -strict --sign - {{TargetDir}}/{{profile}}/{{PluginName}}.plugin
+       echo "Note: Using ad-hoc signature. For distribution, a valid Apple Developer certificate is recommended."
+    fi
+
+    # Install
+    if [ -z "$NO_INSTALL" ]; then
+        sudo cp -rf "{{TargetDir}}/{{profile}}/{{PluginName}}.plugin" "/Library/Application Support/Adobe/Common/Plug-ins/7.0/MediaCore/"
+    fi

--- a/examples/aegp/Justfile
+++ b/examples/aegp/Justfile
@@ -1,0 +1,5 @@
+PluginName       := "AegpDemo"
+BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BinaryName       := lowercase(PluginName)
+
+import '../../AdobePlugin.just'

--- a/examples/aegp/README.md
+++ b/examples/aegp/README.md
@@ -1,0 +1,3 @@
+## Description
+
+AEGP plugins add menu context items and can efficiently run in the background of a project on load. This particular example is a remake of the "Grabba" example, which adds a menu command to grab and export a frame.

--- a/examples/aegp/build.rs
+++ b/examples/aegp/build.rs
@@ -3,16 +3,9 @@ use pipl::*;
 #[rustfmt::skip]
 fn main() {
     pipl::plugin_build(vec![
-        Property::Kind(PIPLType::AEGeneral),
+        Property::Kind(PIPLType::AEGP),
         Property::Name("AegpDemo"),
         Property::Category("General Plugin"),
-        Property::Version {
-                    version: 1,
-                    subversion: 0,
-                    bugversion: 0,
-                    stage: Stage::Develop,
-                    build: 0,
-        },
         #[cfg(target_os = "windows")]
         #[cfg(target_arch = "x86_64")]
         Property::CodeWin64X86("EntryPointFunc"),

--- a/examples/aegp/build.rs
+++ b/examples/aegp/build.rs
@@ -1,0 +1,24 @@
+use pipl::*;
+
+#[rustfmt::skip]
+fn main() {
+    pipl::plugin_build(vec![
+        Property::Kind(PIPLType::AEGeneral),
+        Property::Name("AegpDemo"),
+        Property::Category("General Plugin"),
+        Property::Version {
+                    version: 1,
+                    subversion: 0,
+                    bugversion: 0,
+                    stage: Stage::Develop,
+                    build: 0,
+        },
+        #[cfg(target_os = "windows")]
+        #[cfg(target_arch = "x86_64")]
+        Property::CodeWin64X86("EntryPointFunc"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacIntel64("EntryPointFunc"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacARM64("EntryPointFunc"),
+    ])
+}

--- a/examples/aegp/src/img_proc.rs
+++ b/examples/aegp/src/img_proc.rs
@@ -1,0 +1,40 @@
+use after_effects::Error;
+use image::{ImageBuffer, Rgba};
+use log;
+
+pub fn save_frame_as_png(
+    data: &[u8],
+    width: u32,
+    height: u32,
+    stride: u32,
+    bit_depth: i32,
+    file_path: &std::path::Path,
+) -> Result<(), Error> {
+    if bit_depth != 8 {
+        log::error!(
+            "Unsupported bit depth: {}. Only 8-bit images are supported",
+            bit_depth
+        );
+        return Err(Error::Generic);
+    }
+
+    let mut img_buffer = ImageBuffer::<Rgba<u8>, Vec<u8>>::new(width, height);
+
+    for y in 0..height {
+        for x in 0..width {
+            let idx = (y * stride + x * 4) as usize;
+
+            let a = data[idx];
+            let r = data[idx + 1];
+            let g = data[idx + 2];
+            let b = data[idx + 3];
+
+            img_buffer.put_pixel(x, y, Rgba([r, g, b, a]));
+        }
+    }
+
+    img_buffer.save(file_path).map_err(|_| Error::Generic)?;
+    log::info!("Successfully saved frame to {:?}", file_path);
+
+    Ok(())
+}

--- a/examples/aegp/src/lib.rs
+++ b/examples/aegp/src/lib.rs
@@ -1,12 +1,15 @@
 use after_effects::{
     aegp::{
-        suites::{Command, Register, Utility},
-        CommandHookStatus, HookPriority, MenuOrder,
+        suites::{Command, Item, Register, Render, RenderOptions, Utility},
+        CommandHookStatus, HookPriority, ItemType, MenuOrder,
     },
     define_general_plugin,
-    sys::{AEGP_PluginID, SPBasicSuite},
-    AegpPlugin, Error, PicaBasicSuite,
+    sys::{AEGP_PluginID, PF_InData, SPBasicSuite},
+    AegpPlugin, Error, InData, Layer, PicaBasicSuite, Time,
 };
+
+mod img_proc;
+mod window_handle;
 
 define_general_plugin!(Grabber);
 
@@ -39,8 +42,76 @@ impl AegpPlugin for Grabber {
                 aegp_plugin_id,
                 HookPriority::BeforeAE,
                 grabba_cmd,
-                Box::new(|_, _, _, _, _| {
-                    // todo: print screen here
+                Box::new(move |_, _, _, _, _| {
+                    let item_suite = Item::new()?;
+                    let render_options_suite = RenderOptions::new()?;
+                    let render_suite = Render::new()?;
+
+                    if let Ok(Some(active_item)) = item_suite.active_item() {
+                        let render_options =
+                            render_options_suite.new_from_item(active_item, aegp_plugin_id)?;
+
+                        let time = Time { value: 0, scale: 1 };
+                        render_options_suite.set_time(&render_options, time)?;
+
+                        let world_type = render_options_suite.world_type(&render_options)?;
+                        log::debug!("World type: {:?}", world_type);
+
+                        if let Ok(receipt) = render_suite
+                            .render_and_checkout_frame(&render_options, Some(Box::new(|| false)))
+                        {
+                            if let Ok(frame) = render_suite.receipt_world(receipt) {
+                                let mut dialog = rfd::FileDialog::new();
+
+                                if cfg!(target_os = "windows") {
+                                    let parent =
+                                        window_handle::WindowAndDisplayHandle::try_get_main_handles().map_err(|e| Error::Generic)?;
+                                    dialog = dialog.set_parent(&parent);
+                                }
+
+                                let home_dir = match homedir::get_my_home() {
+                                    Ok(Some(home)) => home,
+                                    _ => "/".into(),
+                                };
+
+                                let Some(file_path) = dialog
+                                    .set_directory(home_dir)
+                                    .add_filter("PNG", &["png"])
+                                    .set_file_name("image.png")
+                                    .save_file()
+                                else {
+                                    log::warn!("Cancelled writing file!");
+                                    render_suite.checkin_frame(receipt)?;
+                                    return Ok(CommandHookStatus::Handled);
+                                };
+
+                                let dummy : PF_InData = unsafe { std::mem::zeroed() };
+                                let layer = Layer::from_aegp_world(&dummy as *const _, frame)?;
+                                let width = layer.width() as u32;
+                                let height = layer.height() as u32;
+                                let stride = layer.buffer_stride() as u32;
+                                let data = layer.buffer();
+                                let bit_depth = layer.bit_depth();
+
+                                log::info!("Frame dimensions: {}x{}, bit depth: {}", width, height, bit_depth);
+
+                                if let Err(e) = img_proc::save_frame_as_png(
+                                    data,
+                                    width,
+                                    height,
+                                    stride,
+                                    bit_depth.into(),
+                                    &file_path
+                                ) {
+                                    log::error!("Failed to save image: {:?}", e);
+                                }
+
+                            }
+
+                            render_suite.checkin_frame(receipt)?;
+                        }
+                    }
+
                     Ok(CommandHookStatus::Handled)
                 }),
                 (),
@@ -49,8 +120,21 @@ impl AegpPlugin for Grabber {
             register_suite.register_update_menu_hook::<Grabber, _>(
                 aegp_plugin_id,
                 Box::new(move |_, _, _| {
-                    let command_suite = Command::new().unwrap();
-                    command_suite.enable_command(grabba_cmd)?;
+                    let command_suite = Command::new()?;
+                    let item_suite = Item::new()?;
+
+                    if let Ok(Some(active_item)) = item_suite.active_item() {
+                        let item_type = item_suite.item_type(active_item)?;
+
+                        if item_type == ItemType::Comp || item_type == ItemType::Footage {
+                            command_suite.enable_command(grabba_cmd)?;
+                        } else {
+                            command_suite.disable_command(grabba_cmd)?;
+                        }
+                    } else {
+                        command_suite.disable_command(grabba_cmd)?;
+                    }
+
                     Ok(())
                 }),
                 (),

--- a/examples/aegp/src/lib.rs
+++ b/examples/aegp/src/lib.rs
@@ -1,6 +1,8 @@
 use after_effects::{
-    aegp::suites::Utility, define_general_plugin, sys::SPBasicSuite, AegpPlugin, Error,
-    PicaBasicSuite,
+    aegp::suites::Utility,
+    define_general_plugin,
+    sys::{AEGP_PluginID, SPBasicSuite},
+    AegpPlugin, Error, PicaBasicSuite,
 };
 
 define_general_plugin!(Grabber);
@@ -12,8 +14,12 @@ impl AegpPlugin for Grabber {
         basic_suite: after_effects::PicaBasicSuite,
         major_version: i32,
         minor_version: i32,
-        aegp_plugin_id: i32,
+        aegp_plugin_id: AEGP_PluginID,
     ) -> Result<Self, after_effects::Error> {
+        log::debug!(
+            "Aegp Demo Entry Point: v{major_version}.{minor_version} - id : {aegp_plugin_id}"
+        );
+
         let util_suite = Utility::new()?;
         util_suite.report_info_unicode(aegp_plugin_id, "Succesfully Loaded Test AEGP")?;
         Ok(Grabber {})

--- a/examples/aegp/src/lib.rs
+++ b/examples/aegp/src/lib.rs
@@ -1,12 +1,21 @@
-use after_effects::{sys::SPBasicSuite, Error};
+use after_effects::{
+    aegp::suites::Utility, define_general_plugin, sys::SPBasicSuite, AegpPlugin, Error,
+    PicaBasicSuite,
+};
 
-#[no_mangle]
-pub unsafe extern "C" fn EntryPointFunc(
-    _pica_basic: *const SPBasicSuite,
-    _major_version: i32,
-    _minor_version: i32,
-    _aegp_plugin_id: i32,
-    _global_refcon: *mut *mut std::ffi::c_void,
-) -> Error {
-    Error::None
+define_general_plugin!(Grabber);
+
+struct Grabber {}
+
+impl AegpPlugin for Grabber {
+    fn entry_point(
+        basic_suite: after_effects::PicaBasicSuite,
+        major_version: i32,
+        minor_version: i32,
+        aegp_plugin_id: i32,
+    ) -> Result<Self, after_effects::Error> {
+        let util_suite = Utility::new()?;
+        util_suite.report_info_unicode(aegp_plugin_id, "Succesfully Loaded Test AEGP")?;
+        Ok(Grabber {})
+    }
 }

--- a/examples/aegp/src/lib.rs
+++ b/examples/aegp/src/lib.rs
@@ -1,0 +1,12 @@
+use after_effects::{sys::SPBasicSuite, Error};
+
+#[no_mangle]
+pub unsafe extern "C" fn EntryPointFunc(
+    _pica_basic: *const SPBasicSuite,
+    _major_version: i32,
+    _minor_version: i32,
+    _aegp_plugin_id: i32,
+    _global_refcon: *mut *mut std::ffi::c_void,
+) -> Error {
+    Error::None
+}

--- a/examples/aegp/src/lib.rs
+++ b/examples/aegp/src/lib.rs
@@ -1,5 +1,8 @@
 use after_effects::{
-    aegp::suites::Utility,
+    aegp::{
+        suites::{Command, Register, Utility},
+        CommandHookStatus, HookPriority, MenuOrder,
+    },
     define_general_plugin,
     sys::{AEGP_PluginID, SPBasicSuite},
     AegpPlugin, Error, PicaBasicSuite,
@@ -7,11 +10,11 @@ use after_effects::{
 
 define_general_plugin!(Grabber);
 
+#[derive(Clone, Debug)]
 struct Grabber {}
 
 impl AegpPlugin for Grabber {
     fn entry_point(
-        _basic_suite: after_effects::PicaBasicSuite,
         major_version: i32,
         minor_version: i32,
         aegp_plugin_id: AEGP_PluginID,
@@ -20,8 +23,53 @@ impl AegpPlugin for Grabber {
             "Aegp Demo Entry Point: v{major_version}.{minor_version} - id : {aegp_plugin_id}"
         );
 
-        let util_suite = Utility::new()?;
-        util_suite.report_info_unicode(aegp_plugin_id, "Succesfully Loaded Test AEGP")?;
+        let res: Result<(), Error> = (|| {
+            let command_suite = Command::new()?;
+            let register_suite = Register::new()?;
+            let grabba_cmd = command_suite.get_unique_command()?;
+
+            command_suite.insert_command(
+                "Grabber",
+                grabba_cmd,
+                after_effects::aegp::MenuId::Export,
+                MenuOrder::Sorted,
+            )?;
+
+            register_suite.register_command_hook::<Grabber, _>(
+                aegp_plugin_id,
+                HookPriority::BeforeAE,
+                grabba_cmd,
+                Box::new(|_, _, _, _, _| {
+                    // todo: print screen here
+                    Ok(CommandHookStatus::Handled)
+                }),
+                (),
+            )?;
+
+            register_suite.register_update_menu_hook::<Grabber, _>(
+                aegp_plugin_id,
+                Box::new(move |_, _, _| {
+                    let command_suite = Command::new().unwrap();
+                    command_suite.enable_command(grabba_cmd)?;
+                    Ok(())
+                }),
+                (),
+            )?;
+
+            Ok(())
+        })();
+
+        match res {
+            Ok(_) => {}
+            Err(e) => {
+                let util_suite = Utility::new()?;
+                util_suite.report_info_unicode(
+                    aegp_plugin_id,
+                    &format!("Error while loading AegpDemo {e:?}"),
+                )?;
+            }
+        }
+
         Ok(Grabber {})
     }
 }

--- a/examples/aegp/src/lib.rs
+++ b/examples/aegp/src/lib.rs
@@ -11,7 +11,7 @@ struct Grabber {}
 
 impl AegpPlugin for Grabber {
     fn entry_point(
-        basic_suite: after_effects::PicaBasicSuite,
+        _basic_suite: after_effects::PicaBasicSuite,
         major_version: i32,
         minor_version: i32,
         aegp_plugin_id: AEGP_PluginID,

--- a/examples/aegp/src/window_handle.rs
+++ b/examples/aegp/src/window_handle.rs
@@ -1,0 +1,32 @@
+use raw_window_handle::{
+    DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle, RawWindowHandle, WindowHandle,
+};
+
+use after_effects::Error;
+
+pub struct WindowAndDisplayHandle {
+    raw_handle: raw_window_handle::Win32WindowHandle,
+}
+
+impl WindowAndDisplayHandle {
+    /// Safety: The window handle must be valid for however long you intend to use it for
+    pub fn try_get_main_handles() -> Result<Self, Error> {
+        let suite = after_effects::aegp::suites::Utility::new()?;
+        let win = suite.main_hwnd()?;
+        let handle = std::num::NonZeroIsize::new(win as usize as isize).ok_or(Error::Generic)?;
+        let raw_handle = raw_window_handle::Win32WindowHandle::new(handle);
+        let handle = WindowAndDisplayHandle { raw_handle };
+        Ok(handle)
+    }
+}
+impl HasWindowHandle for WindowAndDisplayHandle {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+        Ok(unsafe { WindowHandle::borrow_raw(RawWindowHandle::Win32(self.raw_handle)) })
+    }
+}
+
+impl HasDisplayHandle for WindowAndDisplayHandle {
+    fn display_handle(&self) -> Result<raw_window_handle::DisplayHandle<'_>, HandleError> {
+        Ok(DisplayHandle::windows())
+    }
+}

--- a/pipl/src/lib.rs
+++ b/pipl/src/lib.rs
@@ -32,6 +32,7 @@ pub enum PIPLType {
     AEImageFormat,
     AEAccelerator,
     AEGeneral,
+    AEGP,
     PrEffect,
     PrVideoFilter,
     PrAudioFilter,
@@ -90,7 +91,8 @@ impl PIPLType {
             Self::AEEffect       => fourcc(b"eFKT"),
             Self::AEImageFormat  => fourcc(b"FXIF"),
             Self::AEAccelerator  => fourcc(b"eFST"),
-            Self::AEGeneral      => fourcc(b"AEgx"),
+            Self::AEGeneral      => fourcc(b"AEgp"),
+            Self::AEGP           => fourcc(b"AEgx"),
             // Premiere plug-in typefourcc
             Self::PrEffect       => fourcc(b"SPFX"),
             Self::PrVideoFilter  => fourcc(b"VFlt"),
@@ -370,27 +372,27 @@ bitflags::bitflags! {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
 pub enum FilterCaseInfoIn {
-    CantFilter = 0,
-    StraightData = 1,
-    BlackMat = 2,
-    GrayMat = 3,
-    WhiteMat = 4,
-    Defringe = 5,
-    BlackZap = 6,
-    GrayZap = 7,
-    WhiteZap = 8,
+    CantFilter    = 0,
+    StraightData  = 1,
+    BlackMat      = 2,
+    GrayMat       = 3,
+    WhiteMat      = 4,
+    Defringe      = 5,
+    BlackZap      = 6,
+    GrayZap       = 7,
+    WhiteZap      = 8,
     BackgroundZap = 10,
     ForegroundZap = 11,
 }
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
 pub enum FilterCaseInfoOut {
-    CantFilter = 0,
+    CantFilter   = 0,
     StraightData = 1,
-    BlackMat = 2,
-    GrayMat = 3,
-    WhiteMat = 4,
-    FillMask = 9,
+    BlackMat     = 2,
+    GrayMat      = 3,
+    WhiteMat     = 4,
+    FillMask     = 9,
 }
 #[derive(Debug)]
 pub struct FilterCaseInfoStruct {
@@ -405,20 +407,20 @@ pub struct FilterCaseInfoStruct {
 #[repr(u8)]
 #[derive(Debug, Clone, Copy)]
 pub enum BitTypes {
-    None = 0x00,
-    Top = 0x01,
-    Right = 0x02,
-    Bottom = 0x04,
-    Left = 0x08,
+    None       = 0x00,
+    Top        = 0x01,
+    Right      = 0x02,
+    Bottom     = 0x04,
+    Left       = 0x08,
     UpperRight = 0x10,
     LowerRight = 0x20,
-    LowerLeft = 0x40,
-    UpperLeft = 0x80,
+    LowerLeft  = 0x40,
+    UpperLeft  = 0x80,
 }
 #[repr(u32)]
 #[derive(Debug, Clone, Copy)]
 pub enum PixelAspectRatio {
-    AnyPAR = 0x10000,
+    AnyPAR   = 0x10000,
     UnityPAR = 0x20000,
 }
 
@@ -1580,7 +1582,10 @@ pub fn plugin_build(properties: Vec<Property>) {
                 if x.contains(OutFlags::IDoDialog) {
                     println!("cargo:rustc-cfg=does_dialog");
                 }
-                if x.contains(OutFlags::IUseAudio) || x.contains(OutFlags::AudioEffectToo) || x.contains(OutFlags::AudioEffectOnly) {
+                if x.contains(OutFlags::IUseAudio)
+                    || x.contains(OutFlags::AudioEffectToo)
+                    || x.contains(OutFlags::AudioEffectOnly)
+                {
                     println!("cargo:rustc-cfg=uses_audio");
                 }
                 if x.contains(OutFlags::SendUpdateParamsUI) {

--- a/pipl/src/lib.rs
+++ b/pipl/src/lib.rs
@@ -90,7 +90,7 @@ impl PIPLType {
             Self::AEEffect       => fourcc(b"eFKT"),
             Self::AEImageFormat  => fourcc(b"FXIF"),
             Self::AEAccelerator  => fourcc(b"eFST"),
-            Self::AEGeneral      => fourcc(b"AEgp"),
+            Self::AEGeneral      => fourcc(b"AEgx"),
             // Premiere plug-in typefourcc
             Self::PrEffect       => fourcc(b"SPFX"),
             Self::PrVideoFilter  => fourcc(b"VFlt"),


### PR DESCRIPTION
currently the demo under `examples/aegp` compiles and runs on macos, it has kinks to iron out but currently adds a menu item "grabber" that creates a file dialog and saves a frame as PNG provided it has 8bit channel depth. I will update this as I have more time. 

---

notes: I have implemented `Register` suite twice, once for AEGPs and once for effects. The difference being that effects will never reserve a global refcon, so the argument is useless. I have also omitted the AEIO and Artisan plugin callbacks from the register suite for now, they would represent a time commitment I do not have right now.