### PR TITLE
fix justfiles bundle string concat syntax

### DIFF
--- a/examples/checkout/Justfile
+++ b/examples/checkout/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "Checkout"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/color_grid/Justfile
+++ b/examples/color_grid/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "ColorGrid"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/convolutrix/Justfile
+++ b/examples/convolutrix/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "Convolutrix"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/custom_comp_ui/Justfile
+++ b/examples/custom_comp_ui/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "Custom_Comp_UI"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/custom_ecw_ui/Justfile
+++ b/examples/custom_ecw_ui/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "Custom_ECW_UI"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/gamma_table/Justfile
+++ b/examples/gamma_table/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "GammaTable"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/histo_grid/Justfile
+++ b/examples/histo_grid/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "HistoGrid"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/paramarama/Justfile
+++ b/examples/paramarama/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "Paramarama"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/portable/Justfile
+++ b/examples/portable/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "Portable"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/resizer/Justfile
+++ b/examples/resizer/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "Resizer"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/rust_gpu/Justfile
+++ b/examples/rust_gpu/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "RustGPU"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/sdk_noise/Justfile
+++ b/examples/sdk_noise/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "SDK_Noise"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/simplest/Justfile
+++ b/examples/simplest/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "Simplest"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/supervisor/Justfile
+++ b/examples/supervisor/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "Supervisor"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'

--- a/examples/transformer/Justfile
+++ b/examples/transformer/Justfile
@@ -1,5 +1,5 @@
 PluginName       := "Transformer"
-BundleIdentifier := "com.adobe.AfterEffects.{{PluginName}}"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
 BinaryName       := lowercase(PluginName)
 
 import '../../AdobePlugin.just'


### PR DESCRIPTION
The syntax from before didn't work, the bundle identifier would end up literally being `com.adobe.AfterEffects.{{PluginName}}`. This is the correct syntax in just.