### PR TITLE
Fix #93

### DIFF
--- a/after-effects/src/plugin_base.rs
+++ b/after-effects/src/plugin_base.rs
@@ -551,9 +551,7 @@ macro_rules! define_general_plugin {
         // Static Assertion
         const _: () = {
             fn assert_implements_aegp_plugin<T: AegpPlugin>() {}
-            fn call_with_main_type() {
-                assert_implements_aegp_plugin::<$main_type>();
-            }
+            fn call_with_main_type() { assert_implements_aegp_plugin::<$main_type>(); }
         };
 
         unsafe impl $crate::AegpSeal for $main_type {}


### PR DESCRIPTION
I am uncertain why this works. But I am assuming it's a bug on adobes part wherein allocating a handle of length 0 underflows and asks for a `u64::MAX` sized block granted that this prevents an OOM. 