### PR TITLE
feat: add render queue, render queue item and output module suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Extensive portions of Ae and Pr SDKs are wrapped:
 | ✅ Mask                 | ✅ Param Utils                    |             |                       |
 | 🔳 Math                 | ✅ Path Data                      |             |                       |
 | ✅ Memory               | ✅ Path Query                     |             |                       |
-| 🔳 Output Module        | ✅ Pixel Data                     |             |                       |
+| ✅ Output Module        | ✅ Pixel Data                     |             |                       |
 | ✅ Persistent Data      | ✅ Pixel Format                   |             |                       |
 | ✅ PF Interface         | ✅ PointParam                     |             |                       |
 | ✅ Proj                 | 🔳 Sampling8                      |             |                       |
@@ -157,8 +157,8 @@ Extensive portions of Ae and Pr SDKs are wrapped:
 | ✅ Register             | 🔳 SamplingFloat                  |             |                       |
 | ✅ Render Asyc Manager  | ✅ Source Settings                |             |                       |
 | ✅ Render Options       | ✅ Transition                     |             |                       |
-| 🔳 Render Queue Item    | ✅ Utility                        |             |                       |
-| 🔳 Render Queue         | ✅ World                          |             |                       |
+| ✅ Render Queue Item    | ✅ Utility                        |             |                       |
+| ✅ Render Queue         | ✅ World                          |             |                       |
 | ✅ Render               | ✅ World Transform                |             |                       |
 | 🔳 RenderQueue Monitor  |                                   |             |                       |
 | ✅ Sound Data           |                                   |             |                       |

--- a/after-effects/src/aegp/mod.rs
+++ b/after-effects/src/aegp/mod.rs
@@ -34,6 +34,9 @@ pub mod suites {
     pub(crate) mod render_async_manager; pub use render_async_manager::RenderAsyncManagerSuite as RenderAsyncManager;
     pub(crate) mod render_options;       pub use render_options      ::RenderOptionsSuite      as RenderOptions;
     pub(crate) mod render;               pub use render              ::RenderSuite             as Render;
+    pub(crate) mod output_module;        pub use output_module       ::OutputModuleSuite       as OutputModule;
+    pub(crate) mod render_queue;         pub use render_queue        ::RenderQueueSuite        as RenderQueue;
+    pub(crate) mod render_queue_item;    pub use render_queue_item   ::RenderQueueItemSuite    as RenderQueueItem;
     pub(crate) mod sound_data;           pub use sound_data          ::SoundDataSuite          as SoundData;
     pub(crate) mod stream;               pub use stream              ::{ StreamSuite           as Stream,
                                                                          DynamicStreamSuite    as DynamicStream };
@@ -146,6 +149,20 @@ pub use suites::render_options::{
     RenderOptionsHandle,
     ItemQuality,
     ChannelOrder
+};
+pub use suites::output_module::{
+    EmbeddingType,
+    OutputTypes,
+    PostRenderAction,
+    StretchQuality,
+    VideoChannels,
+};
+pub use suites::render_queue::RenderQueueState;
+pub use suites::render_queue_item::{
+    LogType,
+    OutputModuleRefHandle,
+    RenderItemStatus,
+    RQItemRefHandle,
 };
 pub use suites::sound_data::SoundDataHandle;
 pub use suites::stream::{

--- a/after-effects/src/aegp/suites/output_module.rs
+++ b/after-effects/src/aegp/suites/output_module.rs
@@ -1,0 +1,436 @@
+use crate::*;
+use crate::aegp::*;
+
+define_suite!(
+    /// Output Module Suite provides information about and control over output modules
+    /// attached to render queue items.
+    ///
+    /// NOTE: All `OutputModuleRefHandle`s are invalidated by ANY re-ordering, addition or removal
+    /// of output modules from a render item. DO NOT CACHE THEM.
+    OutputModuleSuite,
+    AEGP_OutputModuleSuite4,
+    kAEGPOutputModuleSuite,
+    kAEGPOutputModuleSuiteVersion4
+);
+
+impl OutputModuleSuite {
+    /// Acquire this suite from the host. Returns error if the suite is not available.
+    /// Suite is released on drop.
+    pub fn new() -> Result<Self, Error> {
+        crate::Suite::new()
+    }
+
+    /// Retrieves an output module by index from a render queue item.
+    pub fn output_module_by_index(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        index: i32,
+    ) -> Result<OutputModuleRefHandle, Error> {
+        Ok(OutputModuleRefHandle::from_raw(
+            call_suite_fn_single!(
+                self,
+                AEGP_GetOutputModuleByIndex -> ae_sys::AEGP_OutputModuleRefH,
+                rq_item.as_ptr(),
+                index as ae_sys::A_long
+            )?
+        ))
+    }
+
+    /// Retrieves the embedding options for an output module.
+    pub fn embed_options(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+    ) -> Result<EmbeddingType, Error> {
+        Ok(
+            call_suite_fn_single!(
+                self,
+                AEGP_GetEmbedOptions -> ae_sys::AEGP_EmbeddingType,
+                rq_item.as_ptr(),
+                output_module.as_ptr()
+            )?
+            .into()
+        )
+    }
+
+    /// Sets the embedding options for an output module.
+    pub fn set_embed_options(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+        embed_options: EmbeddingType,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetEmbedOptions,
+            rq_item.as_ptr(),
+            output_module.as_ptr(),
+            embed_options.into()
+        )
+    }
+
+    /// Retrieves the post-render action for an output module.
+    pub fn post_render_action(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+    ) -> Result<PostRenderAction, Error> {
+        Ok(
+            call_suite_fn_single!(
+                self,
+                AEGP_GetPostRenderAction -> ae_sys::AEGP_PostRenderAction,
+                rq_item.as_ptr(),
+                output_module.as_ptr()
+            )?
+            .into()
+        )
+    }
+
+    /// Sets the post-render action for an output module.
+    pub fn set_post_render_action(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+        action: PostRenderAction,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetPostRenderAction,
+            rq_item.as_ptr(),
+            output_module.as_ptr(),
+            action.into()
+        )
+    }
+
+    /// Retrieves which output types (video, audio) are enabled for an output module.
+    pub fn enabled_outputs(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+    ) -> Result<OutputTypes, Error> {
+        Ok(OutputTypes::from_bits_truncate(
+            call_suite_fn_single!(
+                self,
+                AEGP_GetEnabledOutputs -> ae_sys::AEGP_OutputTypes,
+                rq_item.as_ptr(),
+                output_module.as_ptr()
+            )?
+        ))
+    }
+
+    /// Sets which output types (video, audio) are enabled for an output module.
+    pub fn set_enabled_outputs(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+        enabled_types: OutputTypes,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetEnabledOutputs,
+            rq_item.as_ptr(),
+            output_module.as_ptr(),
+            enabled_types.bits()
+        )
+    }
+
+    /// Retrieves the output channels setting for an output module.
+    pub fn output_channels(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+    ) -> Result<VideoChannels, Error> {
+        Ok(
+            call_suite_fn_single!(
+                self,
+                AEGP_GetOutputChannels -> ae_sys::AEGP_VideoChannels,
+                rq_item.as_ptr(),
+                output_module.as_ptr()
+            )?
+            .into()
+        )
+    }
+
+    /// Sets the output channels for an output module.
+    pub fn set_output_channels(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+        channels: VideoChannels,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetOutputChannels,
+            rq_item.as_ptr(),
+            output_module.as_ptr(),
+            channels.into()
+        )
+    }
+
+    /// Retrieves the stretch info for an output module.
+    ///
+    /// Returns a tuple of (is_enabled, stretch_quality, is_locked).
+    pub fn stretch_info(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+    ) -> Result<(bool, StretchQuality, bool), Error> {
+        let mut is_enabled: ae_sys::A_Boolean = 0;
+        let mut stretch_quality: ae_sys::AEGP_StretchQuality = 0;
+        let mut locked: ae_sys::A_Boolean = 0;
+
+        call_suite_fn!(
+            self,
+            AEGP_GetStretchInfo,
+            rq_item.as_ptr(),
+            output_module.as_ptr(),
+            &mut is_enabled,
+            &mut stretch_quality,
+            &mut locked
+        )?;
+
+        Ok((is_enabled != 0, stretch_quality.into(), locked != 0))
+    }
+
+    /// Sets the stretch info for an output module.
+    pub fn set_stretch_info(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+        is_enabled: bool,
+        stretch_quality: StretchQuality,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetStretchInfo,
+            rq_item.as_ptr(),
+            output_module.as_ptr(),
+            is_enabled as ae_sys::A_Boolean,
+            stretch_quality.into()
+        )
+    }
+
+    /// Retrieves the crop info for an output module.
+    ///
+    /// Returns a tuple of (is_enabled, crop_rect).
+    pub fn crop_info(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+    ) -> Result<(bool, ae_sys::A_Rect), Error> {
+        let mut is_enabled: ae_sys::A_Boolean = 0;
+        let mut crop_rect: ae_sys::A_Rect = unsafe { std::mem::zeroed() };
+
+        call_suite_fn!(
+            self,
+            AEGP_GetCropInfo,
+            rq_item.as_ptr(),
+            output_module.as_ptr(),
+            &mut is_enabled,
+            &mut crop_rect
+        )?;
+
+        Ok((is_enabled != 0, crop_rect))
+    }
+
+    /// Sets the crop info for an output module.
+    pub fn set_crop_info(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+        enable: bool,
+        crop_rect: ae_sys::A_Rect,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetCropInfo,
+            rq_item.as_ptr(),
+            output_module.as_ptr(),
+            enable as ae_sys::A_Boolean,
+            crop_rect
+        )
+    }
+
+    /// Retrieves the sound format info for an output module.
+    ///
+    /// Returns a tuple of (sound_format, audio_enabled).
+    pub fn sound_format_info(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+    ) -> Result<(ae_sys::AEGP_SoundDataFormat, bool), Error> {
+        let mut sound_format: ae_sys::AEGP_SoundDataFormat = unsafe { std::mem::zeroed() };
+        let mut audio_enabled: ae_sys::A_Boolean = 0;
+
+        call_suite_fn!(
+            self,
+            AEGP_GetSoundFormatInfo,
+            rq_item.as_ptr(),
+            output_module.as_ptr(),
+            &mut sound_format,
+            &mut audio_enabled
+        )?;
+
+        Ok((sound_format, audio_enabled != 0))
+    }
+
+    /// Sets the sound format info for an output module.
+    pub fn set_sound_format_info(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+        sound_format: ae_sys::AEGP_SoundDataFormat,
+        audio_enabled: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetSoundFormatInfo,
+            rq_item.as_ptr(),
+            output_module.as_ptr(),
+            sound_format,
+            audio_enabled as ae_sys::A_Boolean
+        )
+    }
+
+    /// Retrieves the output file path for an output module.
+    /// Returns an empty string if not specified.
+    pub fn output_file_path(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+    ) -> Result<String, Error> {
+        let mem_handle = call_suite_fn_single!(
+            self,
+            AEGP_GetOutputFilePath -> ae_sys::AEGP_MemHandle,
+            rq_item.as_ptr(),
+            output_module.as_ptr()
+        )?;
+        unsafe {
+            Ok(
+                U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
+                    .to_string_lossy()
+            )
+        }
+    }
+
+    /// Sets the output file path for an output module.
+    /// The path should use platform-native separators.
+    pub fn set_output_file_path(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+        path: &str,
+    ) -> Result<(), Error> {
+        let path_utf16 = U16CString::from_str(path).map_err(|_| Error::InvalidParms)?;
+        call_suite_fn!(
+            self,
+            AEGP_SetOutputFilePath,
+            rq_item.as_ptr(),
+            output_module.as_ptr(),
+            path_utf16.as_ptr()
+        )
+    }
+
+    /// Adds a default output module to a render queue item.
+    /// Returns a handle to the newly created output module.
+    pub fn add_default_output_module(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+    ) -> Result<OutputModuleRefHandle, Error> {
+        Ok(OutputModuleRefHandle::from_raw(
+            call_suite_fn_single!(
+                self,
+                AEGP_AddDefaultOutputModule -> ae_sys::AEGP_OutputModuleRefH,
+                rq_item.as_ptr()
+            )?
+        ))
+    }
+
+    /// Retrieves extra information about an output module.
+    ///
+    /// Returns a tuple of (format_name, info, is_sequence, is_multi_frame).
+    pub fn extra_output_module_info(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+    ) -> Result<(String, String, bool, bool), Error> {
+        let mut format_handle: ae_sys::AEGP_MemHandle = std::ptr::null_mut();
+        let mut info_handle: ae_sys::AEGP_MemHandle = std::ptr::null_mut();
+        let mut is_sequence: ae_sys::A_Boolean = 0;
+        let mut multi_frame: ae_sys::A_Boolean = 0;
+
+        call_suite_fn!(
+            self,
+            AEGP_GetExtraOutputModuleInfo,
+            rq_item.as_ptr(),
+            output_module.as_ptr(),
+            &mut format_handle,
+            &mut info_handle,
+            &mut is_sequence,
+            &mut multi_frame
+        )?;
+
+        unsafe {
+            let format = U16CString::from_ptr_str(
+                MemHandle::<u16>::from_raw(format_handle)?.lock()?.as_ptr()
+            ).to_string_lossy();
+
+            let info = U16CString::from_ptr_str(
+                MemHandle::<u16>::from_raw(info_handle)?.lock()?.as_ptr()
+            ).to_string_lossy();
+
+            Ok((format, info, is_sequence != 0, multi_frame != 0))
+        }
+    }
+}
+
+// ――――――――――――――――――――――――――――――――――――――― Types ―――――――――――――――――――――――――――――――――――――――
+
+define_enum! {
+    ae_sys::AEGP_EmbeddingType,
+    EmbeddingType {
+        None        = ae_sys::AEGP_Embedding_NONE,
+        Nothing     = ae_sys::AEGP_Embedding_NOTHING,
+        Link        = ae_sys::AEGP_Embedding_LINK,
+        LinkAndCopy = ae_sys::AEGP_Embedding_LINK_AND_COPY,
+    }
+}
+
+define_enum! {
+    ae_sys::AEGP_PostRenderAction,
+    PostRenderAction {
+        None              = ae_sys::AEGP_PostRenderOptions_NONE,
+        Import            = ae_sys::AEGP_PostRenderOptions_IMPORT,
+        ImportAndReplace  = ae_sys::AEGP_PostRenderOptions_IMPORT_AND_REPLACE_USAGE,
+        SetProxy          = ae_sys::AEGP_PostRenderOptions_SET_PROXY,
+    }
+}
+
+bitflags::bitflags! {
+    /// Output type flags for specifying which types of output to render.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct OutputTypes: ae_sys::AEGP_OutputTypes {
+        const NONE  = ae_sys::AEGP_OutputType_NONE  as ae_sys::AEGP_OutputTypes;
+        const VIDEO = ae_sys::AEGP_OutputType_VIDEO as ae_sys::AEGP_OutputTypes;
+        const AUDIO = ae_sys::AEGP_OutputType_AUDIO as ae_sys::AEGP_OutputTypes;
+    }
+}
+
+define_enum! {
+    ae_sys::AEGP_VideoChannels,
+    VideoChannels {
+        None  = ae_sys::AEGP_VideoChannels_NONE,
+        Rgb   = ae_sys::AEGP_VideoChannels_RGB,
+        Rgba  = ae_sys::AEGP_VideoChannels_RGBA,
+        Alpha = ae_sys::AEGP_VideoChannels_ALPHA,
+    }
+}
+
+define_enum! {
+    ae_sys::AEGP_StretchQuality,
+    StretchQuality {
+        None = ae_sys::AEGP_StretchQual_NONE,
+        Low  = ae_sys::AEGP_StretchQual_LOW,
+        High = ae_sys::AEGP_StretchQual_HIGH,
+    }
+}

--- a/after-effects/src/aegp/suites/render_queue.rs
+++ b/after-effects/src/aegp/suites/render_queue.rs
@@ -1,0 +1,69 @@
+use crate::*;
+
+define_enum!(
+    ae_sys::AEGP_RenderQueueState,
+    RenderQueueState {
+        Paused        = ae_sys::AEGP_RenderQueueState_PAUSED,
+        Rendering  = ae_sys::AEGP_RenderQueueState_RENDERING,
+        Stopped       = ae_sys::AEGP_RenderQueueState_STOPPED,
+    }
+);
+
+define_suite!(
+    RenderQueueSuite,
+    AEGP_RenderQueueSuite1,
+    kAEGPRenderQueueSuite,
+    kAEGPRenderQueueSuiteVersion1
+);
+
+impl RenderQueueSuite {
+    /// Acquire this suite from the host. Returns error if the suite is not available.
+    /// Suite is released on drop.
+    pub fn new() -> Result<Self, Error> {
+        crate::Suite::new()
+    }
+
+    /*
+        AEGP_AddCompToRenderQueue(
+            AEGP_CompH     compH,
+            const A_char*  pathZ);
+    */
+    /// Adds a composition to the render queue, using default options.
+    pub fn add_comp_to_render_queue(
+        &self,
+        comp_handle: impl AsPtr<after_effects_sys::AEGP_CompH>,
+        path: &str,
+    ) -> Result<(), Error> {
+        let path = std::ffi::CString::new(path).map_err(|_| Error::InvalidParms)?;
+        call_suite_fn!(
+            self,
+            AEGP_AddCompToRenderQueue,
+            comp_handle.as_ptr(),
+            path.as_ptr()
+        )?;
+
+        Ok(())
+    }
+
+    /*
+       AEGP_SetRenderQueueState(
+           AEGP_RenderQueueState  state);
+    */
+    /// Sets the render queue to one of three valid states. It is not possible to go from stopped to paused.
+    pub fn set_render_queue_state(&self, state: RenderQueueState) -> Result<(), Error> {
+        call_suite_fn!(self, AEGP_SetRenderQueueState, state.into())?;
+        Ok(())
+    }
+
+    /*
+        AEGP_GetRenderQueueState(
+            AEGP_RenderQueueState  *stateP);
+    */
+    /// Obtains the current render queue state.
+    pub fn get_render_queue_state(&self) -> Result<RenderQueueState, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetRenderQueueState -> ae_sys::AEGP_RenderQueueState)?
+                .into(),
+        )
+    }
+}

--- a/after-effects/src/aegp/suites/render_queue_item.rs
+++ b/after-effects/src/aegp/suites/render_queue_item.rs
@@ -1,0 +1,173 @@
+use crate::*;
+use crate::aegp::*;
+
+define_suite!(
+    /// Render Queue Item Suite provides information about items in the render queue.
+    ///
+    /// NOTE: All `RQItemRefHandle`s are invalidated by ANY re-ordering, addition or removal
+    /// of render items. DO NOT CACHE THEM.
+    RenderQueueItemSuite,
+    AEGP_RQItemSuite4,
+    kAEGPRQItemSuite,
+    kAEGPRQItemSuiteVersion4
+);
+
+impl RenderQueueItemSuite {
+    /// Acquire this suite from the host. Returns error if the suite is not available.
+    /// Suite is released on drop.
+    pub fn new() -> Result<Self, Error> {
+        crate::Suite::new()
+    }
+
+    /// Returns the number of items currently in the render queue.
+    pub fn num_items(&self) -> Result<i32, Error> {
+        Ok(call_suite_fn_single!(self, AEGP_GetNumRQItems -> ae_sys::A_long)? as i32)
+    }
+
+    /// Retrieves a render queue item by index.
+    pub fn item_by_index(&self, index: i32) -> Result<RQItemRefHandle, Error> {
+        Ok(RQItemRefHandle::from_raw(
+            call_suite_fn_single!(self, AEGP_GetRQItemByIndex -> ae_sys::AEGP_RQItemRefH, index as ae_sys::A_long)?
+        ))
+    }
+
+    /// Retrieves the next render queue item.
+    /// Pass `None` for `current_item` to get the first item.
+    pub fn next_item(&self, current_item: Option<RQItemRefHandle>) -> Result<Option<RQItemRefHandle>, Error> {
+        let current = current_item.map_or(std::ptr::null_mut(), |h| h.as_ptr());
+        let next = call_suite_fn_single!(self, AEGP_GetNextRQItem -> ae_sys::AEGP_RQItemRefH, current)?;
+        if next.is_null() {
+            Ok(None)
+        } else {
+            Ok(Some(RQItemRefHandle::from_raw(next)))
+        }
+    }
+
+    /// Returns the number of output modules attached to the given render queue item.
+    pub fn num_output_modules(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<i32, Error> {
+        Ok(call_suite_fn_single!(self, AEGP_GetNumOutputModulesForRQItem -> ae_sys::A_long, rq_item.as_ptr())? as i32)
+    }
+
+    /// Returns the render state of the given render queue item.
+    pub fn render_state(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<RenderItemStatus, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetRenderState -> ae_sys::AEGP_RenderItemStatusType, rq_item.as_ptr())?
+                .into()
+        )
+    }
+
+    /// Sets the render state of the given render queue item.
+    ///
+    /// Will return an error if called while `RenderQueueState` is not `Stopped`.
+    ///
+    /// Returns `Err_RANGE` if you pass a status that is illegal in any case.
+    /// Returns `Err_PARAMETER` if you try to pass a status that doesn't make sense
+    /// (e.g., trying to queue something for which you haven't set the output path).
+    pub fn set_render_state(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>, status: RenderItemStatus) -> Result<(), Error> {
+        call_suite_fn!(self, AEGP_SetRenderState, rq_item.as_ptr(), status.into())
+    }
+
+    /// Returns the time at which the given render queue item started rendering.
+    /// Returns `Time { value: 0, scale: 1 }` if not started.
+    pub fn started_time(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<Time, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetStartedTime -> ae_sys::A_Time, rq_item.as_ptr())?
+                .into()
+        )
+    }
+
+    /// Returns the elapsed rendering time for the given render queue item.
+    /// Returns `Time { value: 0, scale: 1 }` if not rendered.
+    pub fn elapsed_time(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<Time, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetElapsedTime -> ae_sys::A_Time, rq_item.as_ptr())?
+                .into()
+        )
+    }
+
+    /// Returns the log type for the given render queue item.
+    pub fn log_type(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<LogType, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetLogType -> ae_sys::AEGP_LogType, rq_item.as_ptr())?
+                .into()
+        )
+    }
+
+    /// Sets the log type for the given render queue item.
+    pub fn set_log_type(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>, log_type: LogType) -> Result<(), Error> {
+        call_suite_fn!(self, AEGP_SetLogType, rq_item.as_ptr(), log_type.into())
+    }
+
+    /// Removes an output module from a render queue item.
+    pub fn remove_output_module(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(self, AEGP_RemoveOutputModule, rq_item.as_ptr(), output_module.as_ptr())
+    }
+
+    /// Retrieves the comment for the given render queue item.
+    pub fn comment(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<String, Error> {
+        let mem_handle = call_suite_fn_single!(self, AEGP_GetComment -> ae_sys::AEGP_MemHandle, rq_item.as_ptr())?;
+        unsafe {
+            Ok(
+                U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
+                    .to_string_lossy()
+            )
+        }
+    }
+
+    /// Sets the comment for the given render queue item.
+    pub fn set_comment(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>, comment: &str) -> Result<(), Error> {
+        let comment_utf16 = U16CString::from_str(comment).map_err(|_| Error::InvalidParms)?;
+        call_suite_fn!(self, AEGP_SetComment, rq_item.as_ptr(), comment_utf16.as_ptr())
+    }
+
+    /// Retrieves the composition associated with the given render queue item.
+    pub fn comp(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<CompHandle, Error> {
+        Ok(CompHandle::from_raw(
+            call_suite_fn_single!(self, AEGP_GetCompFromRQItem -> ae_sys::AEGP_CompH, rq_item.as_ptr())?
+        ))
+    }
+
+    /// Deletes a render queue item. This is undoable.
+    pub fn delete_item(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<(), Error> {
+        call_suite_fn!(self, AEGP_DeleteRQItem, rq_item.as_ptr())
+    }
+}
+
+// ――――――――――――――――――――――――――――――――――――――― Types ―――――――――――――――――――――――――――――――――――――――
+
+register_handle!(AEGP_RQItemRefH);
+define_handle_wrapper!(RQItemRefHandle, AEGP_RQItemRefH);
+
+register_handle!(AEGP_OutputModuleRefH);
+define_handle_wrapper!(OutputModuleRefHandle, AEGP_OutputModuleRefH);
+
+define_enum! {
+    ae_sys::AEGP_RenderItemStatusType,
+    RenderItemStatus {
+        None         = ae_sys::AEGP_RenderItemStatus_NONE,
+        WillContinue = ae_sys::AEGP_RenderItemStatus_WILL_CONTINUE,
+        NeedsOutput  = ae_sys::AEGP_RenderItemStatus_NEEDS_OUTPUT,
+        /// Ready to be rendered, but not included in the queue.
+        Unqueued     = ae_sys::AEGP_RenderItemStatus_UNQUEUED,
+        /// Ready AND queued.
+        Queued       = ae_sys::AEGP_RenderItemStatus_QUEUED,
+        Rendering    = ae_sys::AEGP_RenderItemStatus_RENDERING,
+        UserStopped  = ae_sys::AEGP_RenderItemStatus_USER_STOPPED,
+        ErrStopped   = ae_sys::AEGP_RenderItemStatus_ERR_STOPPED,
+        Done         = ae_sys::AEGP_RenderItemStatus_DONE,
+    }
+}
+
+define_enum! {
+    ae_sys::AEGP_LogType,
+    LogType {
+        None         = ae_sys::AEGP_LogType_NONE,
+        ErrorsOnly   = ae_sys::AEGP_LogType_ERRORS_ONLY,
+        PlusSettings = ae_sys::AEGP_LogType_PLUS_SETTINGS,
+        PerFrameInfo = ae_sys::AEGP_LogType_PER_FRAME_INFO,
+    }
+}

--- a/examples/queuebert/Cargo.toml
+++ b/examples/queuebert/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "queuebert"
+version = "0.0.1"
+description = "Rust port of Adobe's QueueBert AEGP sample - demonstrates Render Queue and Output Module suites"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+log = "0.4"
+after-effects = { path = "../../after-effects" }
+
+[build-dependencies]
+pipl = { path = "../../pipl" }

--- a/examples/queuebert/Justfile
+++ b/examples/queuebert/Justfile
@@ -1,0 +1,5 @@
+PluginName       := "QueueBert"
+BundleIdentifier := "com.adobe.AfterEffects." + PluginName
+BinaryName       := lowercase(PluginName)
+
+import '../../AdobePlugin.just'

--- a/examples/queuebert/build.rs
+++ b/examples/queuebert/build.rs
@@ -1,0 +1,17 @@
+use pipl::*;
+
+#[rustfmt::skip]
+fn main() {
+    pipl::plugin_build(vec![
+        Property::Kind(PIPLType::AEGP),
+        Property::Name("QueueBert"),
+        Property::Category("General Plugin"),
+        #[cfg(target_os = "windows")]
+        #[cfg(target_arch = "x86_64")]
+        Property::CodeWin64X86("EntryPointFunc"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacIntel64("EntryPointFunc"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacARM64("EntryPointFunc"),
+    ])
+}

--- a/examples/queuebert/src/lib.rs
+++ b/examples/queuebert/src/lib.rs
@@ -1,0 +1,304 @@
+//! QueueBert - Rust port of Adobe's QueueBert AEGP sample
+//!
+//! This plugin demonstrates the use of Render Queue and Output Module suites.
+//! It adds a menu item under File that, when clicked, manipulates the render queue
+//! by adding compositions, modifying output module settings, and more.
+
+use after_effects::{
+    AegpPlugin, Error,
+    aegp::{
+        CommandHookStatus, EmbeddingType, HookPriority, LogType, MenuOrder, OutputTypes,
+        PostRenderAction, StretchQuality, VideoChannels,
+        suites::{Command, OutputModule, Register, RenderQueue, RenderQueueItem, Utility},
+    },
+    define_general_plugin,
+    sys::AEGP_PluginID,
+};
+
+define_general_plugin!(QueueBert);
+
+#[derive(Clone, Debug)]
+struct QueueBert;
+
+impl AegpPlugin for QueueBert {
+    fn entry_point(
+        major_version: i32,
+        minor_version: i32,
+        aegp_plugin_id: AEGP_PluginID,
+    ) -> Result<Self, Error> {
+        log::info!(
+            "QueueBert Entry Point: v{major_version}.{minor_version} - id: {aegp_plugin_id}"
+        );
+
+        let res: Result<(), Error> = (|| {
+            let command_suite = Command::new()?;
+            let register_suite = Register::new()?;
+            let queuebert_cmd = command_suite.get_unique_command()?;
+
+            command_suite.insert_command(
+                "QueueBert",
+                queuebert_cmd,
+                after_effects::aegp::MenuId::File,
+                MenuOrder::Sorted,
+            )?;
+
+            // Register command hook - this is called when the menu item is clicked
+            register_suite.register_command_hook::<QueueBert, _>(
+                aegp_plugin_id,
+                HookPriority::BeforeAE,
+                queuebert_cmd,
+                Box::new(move |_, _, command, _, _| {
+                    if command != queuebert_cmd {
+                        return Ok(CommandHookStatus::Unhandled);
+                    }
+
+                    if let Err(e) = handle_queuebert_command() {
+                        log::error!("QueueBert command failed: {:?}", e);
+                    }
+
+                    Ok(CommandHookStatus::Handled)
+                }),
+                (),
+            )?;
+
+            // Register update menu hook - enable/disable menu based on render queue state
+            register_suite.register_update_menu_hook::<QueueBert, _>(
+                aegp_plugin_id,
+                Box::new(move |_, _, _| {
+                    let command_suite = Command::new()?;
+                    let rq_item_suite = RenderQueueItem::new()?;
+
+                    let num_rq_items = rq_item_suite.num_items()?;
+
+                    if num_rq_items > 0 {
+                        command_suite.enable_command(queuebert_cmd)?;
+                    } else {
+                        command_suite.disable_command(queuebert_cmd)?;
+                    }
+
+                    Ok(())
+                }),
+                (),
+            )?;
+
+            Ok(())
+        })();
+
+        if let Err(e) = res {
+            let util_suite = Utility::new()?;
+            util_suite.report_info_unicode(
+                aegp_plugin_id,
+                &format!(
+                    "QueueBert: Problems encountered during initialization: {:?}",
+                    e
+                ),
+            )?;
+        }
+
+        Ok(QueueBert)
+    }
+}
+
+/// Main command handler - demonstrates Render Queue and Output Module suite functionality
+fn handle_queuebert_command() -> Result<(), Error> {
+    let rq_suite = RenderQueue::new()?;
+    let rq_item_suite = RenderQueueItem::new()?;
+    let output_module_suite = OutputModule::new()?;
+
+    let rq_item_count = rq_item_suite.num_items()?;
+    log::info!("QueueBert: Found {} render queue items", rq_item_count);
+
+    if rq_item_count == 0 {
+        log::info!("QueueBert: No items in render queue, nothing to do");
+        return Ok(());
+    }
+
+    // Get the composition from the first render queue item
+    let first_item = rq_item_suite.item_by_index(0)?;
+    let comp = rq_item_suite.comp(&first_item)?;
+
+    // Add the composition to the render queue multiple times (like the original sample)
+    for i in 0..6 {
+        // Note: The original sample uses a hardcoded path - we use a platform-appropriate one
+        #[cfg(target_os = "windows")]
+        let output_path = format!("C:\\temp\\queuebert_output_{}.mov", i);
+        #[cfg(not(target_os = "windows"))]
+        let output_path = format!("/tmp/queuebert_output_{}.mov", i);
+
+        if let Err(e) = rq_suite.add_comp_to_render_queue(&comp, &output_path) {
+            log::warn!("Failed to add comp to render queue: {:?}", e);
+        }
+    }
+
+    // Re-fetch the item count after adding
+    let rq_item_count = rq_item_suite.num_items()?;
+
+    // Now work with the first render queue item
+    if rq_item_count > 0 {
+        let rq_item = rq_item_suite.item_by_index(0)?;
+        let outmod_count = rq_item_suite.num_output_modules(&rq_item)?;
+
+        log::info!("QueueBert: First item has {} output modules", outmod_count);
+
+        if outmod_count > 0 {
+            // Get and set log type
+            let log_type = rq_item_suite.log_type(&rq_item)?;
+            log::info!("QueueBert: Current log type: {:?}", log_type);
+            rq_item_suite.set_log_type(&rq_item, LogType::PlusSettings)?;
+
+            // Get and set render state
+            let status = rq_item_suite.render_state(&rq_item)?;
+            log::info!("QueueBert: Current render state: {:?}", status);
+
+            // Get timing info
+            let started_time = rq_item_suite.started_time(&rq_item)?;
+            let elapsed_time = rq_item_suite.elapsed_time(&rq_item)?;
+            log::info!(
+                "QueueBert: Started: {:?}, Elapsed: {:?}",
+                started_time,
+                elapsed_time
+            );
+
+            // Now work with the first output module
+            let output_module = output_module_suite.output_module_by_index(&rq_item, 0)?;
+
+            // Enable both video and audio output
+            let current_outputs = output_module_suite.enabled_outputs(&rq_item, &output_module)?;
+            log::info!("QueueBert: Current enabled outputs: {:?}", current_outputs);
+
+            let new_outputs = OutputTypes::VIDEO | OutputTypes::AUDIO;
+            output_module_suite.set_enabled_outputs(&rq_item, &output_module, new_outputs)?;
+
+            // Set output channels to RGBA
+            let vid_channels = output_module_suite.output_channels(&rq_item, &output_module)?;
+            log::info!("QueueBert: Current video channels: {:?}", vid_channels);
+            output_module_suite.set_output_channels(
+                &rq_item,
+                &output_module,
+                VideoChannels::Rgba,
+            )?;
+
+            // Get and set stretch info
+            let (stretch_enabled, stretch_qual, locked) =
+                output_module_suite.stretch_info(&rq_item, &output_module)?;
+            log::info!(
+                "QueueBert: Stretch - enabled: {}, quality: {:?}, locked: {}",
+                stretch_enabled,
+                stretch_qual,
+                locked
+            );
+            output_module_suite.set_stretch_info(
+                &rq_item,
+                &output_module,
+                true,
+                StretchQuality::High,
+            )?;
+
+            // Get and set crop info
+            let (crop_enabled, crop_rect) =
+                output_module_suite.crop_info(&rq_item, &output_module)?;
+            log::info!(
+                "QueueBert: Crop - enabled: {}, rect: {:?}",
+                crop_enabled,
+                crop_rect
+            );
+
+            // Set a crop rectangle
+            let new_crop_rect = after_effects::sys::A_Rect {
+                left: 0,
+                top: 0,
+                right: 200,
+                bottom: 100,
+            };
+            output_module_suite.set_crop_info(&rq_item, &output_module, true, new_crop_rect)?;
+
+            // Get and set sound format info
+            let (sound_format, audio_enabled) =
+                output_module_suite.sound_format_info(&rq_item, &output_module)?;
+            log::info!(
+                "QueueBert: Audio - enabled: {}, sample_rate: {}, channels: {}, bytes_per_sample: {}",
+                audio_enabled,
+                sound_format.sample_rateF,
+                sound_format.num_channelsL,
+                sound_format.bytes_per_sampleL
+            );
+
+            // If audio is not configured, set up default audio settings
+            if !audio_enabled || sound_format.sample_rateF == 0.0 {
+                let new_sound_format = after_effects::sys::AEGP_SoundDataFormat {
+                    sample_rateF: 44100.0,
+                    encoding: after_effects::sys::AEGP_SoundEncoding_FLOAT,
+                    bytes_per_sampleL: 4,
+                    num_channelsL: 1,
+                };
+                output_module_suite.set_sound_format_info(
+                    &rq_item,
+                    &output_module,
+                    new_sound_format,
+                    true,
+                )?;
+            }
+
+            // Get and set embed options
+            let embed_type = output_module_suite.embed_options(&rq_item, &output_module)?;
+            log::info!("QueueBert: Embed type: {:?}", embed_type);
+            output_module_suite.set_embed_options(
+                &rq_item,
+                &output_module,
+                EmbeddingType::LinkAndCopy,
+            )?;
+
+            // Get and set post-render action
+            let post_action = output_module_suite.post_render_action(&rq_item, &output_module)?;
+            log::info!("QueueBert: Post-render action: {:?}", post_action);
+            output_module_suite.set_post_render_action(
+                &rq_item,
+                &output_module,
+                PostRenderAction::ImportAndReplace,
+            )?;
+
+            // Add a new default output module
+            let new_outmod = output_module_suite.add_default_output_module(&rq_item)?;
+            let new_outmod_count = rq_item_suite.num_output_modules(&rq_item)?;
+            log::info!(
+                "QueueBert: Added new output module, now have {} modules",
+                new_outmod_count
+            );
+
+            // Set output file path on the new module
+            #[cfg(target_os = "windows")]
+            let output_path = "C:\\temp\\queuebert_new_output.mov";
+            #[cfg(not(target_os = "windows"))]
+            let output_path = "/tmp/queuebert_new_output.mov";
+
+            output_module_suite.set_output_file_path(&rq_item, &new_outmod, output_path)?;
+
+            // Get extra output module info
+            if let Ok((format, info, is_sequence, multi_frame)) =
+                output_module_suite.extra_output_module_info(&rq_item, &output_module)
+            {
+                log::info!(
+                    "QueueBert: Format: {}, Info: {}, Sequence: {}, Multi-frame: {}",
+                    format,
+                    info,
+                    is_sequence,
+                    multi_frame
+                );
+            }
+
+            // Set a comment on the render queue item
+            rq_item_suite.set_comment(&rq_item, "That's pronounced cue-BARE!")?;
+
+            // Read the comment back
+            let comment = rq_item_suite.comment(&rq_item)?;
+            log::info!("QueueBert: Item comment: {}", comment);
+        }
+    }
+
+    // Log the current render queue state
+    let rq_state = rq_suite.get_render_queue_state()?;
+    log::info!("QueueBert: Render queue state: {:?}", rq_state);
+
+    log::info!("QueueBert: Command completed successfully");
+    Ok(())
+}


### PR DESCRIPTION
Includes a port of the Queuebert plugin that uses the new suites.

Most of this was created using Claude, but the code is in keeping with the style of the existing bindings and we've been successfully using the new suites for a little while internally.