### PR TITLE
[codex] Remove Effect filter instance ID shortcut

### DIFF
--- a/after-effects/src/pf/effect.rs
+++ b/after-effects/src/pf/effect.rs
@@ -39,8 +39,6 @@ define_suite_item_wrapper!(
 
         // ―――――――――――――――――――――――――――― Utility suite functions ――――――――――――――――――――――――――――
 
-        /// Gets the filter ID for the current effect reference.
-        filter_instance_id()                                            ->  i32 => pf_utility.filter_instance_id,
         /// Retrieves formatted timecode, as well as the currently active video frame.
         ///
         /// Returns a tuple containing `(current_frame, time_display)`


### PR DESCRIPTION
## Summary

Remove the high-level `Effect::filter_instance_id()` convenience wrapper from `after-effects/src/pf/effect.rs`.

The lower-level `pf::suites::Utility::filter_instance_id()` API remains available for callers that intentionally acquire and handle the Premiere utility suite. This avoids presenting the filter instance ID path as a generally available `Effect` method, since the underlying `PF_UtilitySuite` can be unavailable in some AE selectors/hosts and return `MissingSuite`.

## Validation

- `cargo test -p after-effects`
