### PR TITLE
Apply system code-page encoding to CheckBox and Popup strings on Windows

### DIFF
--- a/after-effects/src/macros.rs
+++ b/after-effects/src/macros.rs
@@ -347,8 +347,15 @@ macro_rules! define_param_wrapper {
             pub fn [<set_ $name>](&mut self, v: &str) -> &mut Self {
                 let cstr = encode_to_system_cstring(v);
                 let slice = cstr.to_bytes_with_nul();
-                assert!(slice.len() <= 32);
-                self.def.$name[0..slice.len()].copy_from_slice(unsafe { std::mem::transmute(slice) });
+                let len = slice.len().min(32);
+                // Gracefully truncate when the encoded string including NUL
+                // exceeds the 32-byte fixed buffer.
+                self.def.$name[0..len].copy_from_slice(unsafe { std::mem::transmute(&slice[0..len]) });
+                if len < 32 {
+                    self.def.$name[len] = 0;
+                } else {
+                    self.def.$name[31] = 0;
+                }
                 self
             }
         }

--- a/after-effects/src/macros.rs
+++ b/after-effects/src/macros.rs
@@ -333,7 +333,7 @@ macro_rules! define_param_wrapper {
     (impl String, $name:ident) => {
         paste::item! {
             pub fn [<set_ $name>](&mut self, v: &str) -> &mut Self {
-                self.$name = CString::new(v).unwrap();
+                self.$name = encode_to_system_cstring(v);
                 { self.def.u.namesptr = self.$name.as_ptr(); }
                 self
             }
@@ -345,9 +345,9 @@ macro_rules! define_param_wrapper {
     (impl ShortString, $name:ident) => {
         paste::item! {
             pub fn [<set_ $name>](&mut self, v: &str) -> &mut Self {
-                assert!(v.len() < 32);
-                let cstr = CString::new(v).unwrap();
+                let cstr = encode_to_system_cstring(v);
                 let slice = cstr.to_bytes_with_nul();
+                assert!(slice.len() <= 32);
                 self.def.$name[0..slice.len()].copy_from_slice(unsafe { std::mem::transmute(slice) });
                 self
             }

--- a/after-effects/src/pf/parameters.rs
+++ b/after-effects/src/pf/parameters.rs
@@ -7,59 +7,80 @@ use objc2_core_foundation::{CFRange, CFString};
 
 const MAX_NAME_LEN: usize = 32;
 
-/// Convert a UTF-8 string to a `CString` encoded in the system code page
-/// (e.g. CP936/GBK on Chinese Windows). On macOS this is a no-op since the
-/// system uses UTF-8 natively.
+/// Convert a UTF-8 string to system-code-page bytes (no trailing NUL).
 ///
-/// Uses [`CP_OEMCP`] on Windows to match the existing behaviour in
-/// [`ParamDef::set_name()`]; on CJK Windows this is equivalent to [`CP_ACP`].
-fn encode_to_system_cstring(s: &str) -> CString {
+/// On Windows this encodes via [`CP_OEMCP`] (same code page used by
+/// [`ParamDef::set_name()`]); on macOS it uses the system encoding reported
+/// by Core Foundation. On other platforms falls back to UTF-8.
+fn encode_to_system_bytes(s: &str) -> Vec<u8> {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        let cfstr = CFString::from_str(s);
+        let encoding = CFString::system_encoding();
+        let length = cfstr.length();
+        let max_size = CFString::maximum_size_for_encoding(length, encoding);
+
+        let mut buffer = vec![0u8; max_size as usize];
+        let mut used_len = 0;
+
+        CFString::bytes(
+            &cfstr,
+            CFRange::new(0, length),
+            encoding,
+            b'?',  // replacement for unconvertible characters
+            false,
+            buffer.as_mut_ptr(),
+            max_size,
+            &mut used_len,
+        );
+
+        buffer.truncate(used_len as usize);
+        buffer
+    }
     #[cfg(target_os = "windows")]
     {
-        let bytes = encode_to_system_bytes(s);
-        CString::new(bytes).unwrap_or_else(|e| {
-            log::error!("encode_to_system_cstring: {e}");
-            CString::new("").unwrap()
-        })
+        use std::ffi::OsStr;
+        use std::os::windows::ffi::OsStrExt;
+        unsafe {
+            use windows_sys::Win32::Globalization::{WideCharToMultiByte, CP_OEMCP};
+            let wstr: Vec<u16> = OsStr::new(s).encode_wide().collect();
+            if wstr.is_empty() {
+                return Vec::new();
+            }
+            let wlen = wstr.len() as i32;
+            let len = WideCharToMultiByte(
+                CP_OEMCP, 0, wstr.as_ptr(), wlen,
+                std::ptr::null_mut(), 0, std::ptr::null(), std::ptr::null_mut(),
+            );
+            if len <= 0 {
+                return Vec::new();
+            }
+            let mut bytes: Vec<u8> = Vec::with_capacity(len as usize);
+            let len = WideCharToMultiByte(
+                CP_OEMCP, 0, wstr.as_ptr(), wlen,
+                bytes.as_mut_ptr(), len, std::ptr::null(), std::ptr::null_mut(),
+            );
+            if len > 0 {
+                bytes.set_len(len as usize);
+            }
+            bytes
+        }
     }
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        CString::new(s).unwrap_or_else(|e| {
-            log::error!("encode_to_system_cstring: {e}");
-            CString::new("").unwrap()
-        })
+        s.as_bytes().to_vec()
     }
 }
 
-/// Convert a UTF-8 string to system-code-page bytes (no trailing NUL).
-#[cfg(target_os = "windows")]
-fn encode_to_system_bytes(s: &str) -> Vec<u8> {
-    use std::ffi::OsStr;
-    use std::os::windows::ffi::OsStrExt;
-    unsafe {
-        use windows_sys::Win32::Globalization::{WideCharToMultiByte, CP_OEMCP};
-        let wstr: Vec<u16> = OsStr::new(s).encode_wide().collect();
-        if wstr.is_empty() {
-            return Vec::new();
-        }
-        let wlen = wstr.len() as i32;
-        let len = WideCharToMultiByte(
-            CP_OEMCP, 0, wstr.as_ptr(), wlen,
-            std::ptr::null_mut(), 0, std::ptr::null(), std::ptr::null_mut(),
-        );
-        if len <= 0 {
-            return Vec::new();
-        }
-        let mut bytes: Vec<u8> = Vec::with_capacity(len as usize);
-        let len = WideCharToMultiByte(
-            CP_OEMCP, 0, wstr.as_ptr(), wlen,
-            bytes.as_mut_ptr(), len, std::ptr::null(), std::ptr::null_mut(),
-        );
-        if len > 0 {
-            bytes.set_len(len as usize);
-        }
-        bytes
-    }
+/// Convert a UTF-8 string to a `CString` encoded in the system code page.
+///
+/// Uses [`encode_to_system_bytes`] on all platforms.
+fn encode_to_system_cstring(s: &str) -> CString {
+    let bytes = encode_to_system_bytes(s);
+    CString::new(bytes).unwrap_or_else(|e| {
+        log::error!("encode_to_system_cstring: {e}");
+        CString::new("").unwrap()
+    })
 }
 
 define_enum! {
@@ -1138,65 +1159,18 @@ impl<'p> ParamDef<'p> {
         }
         // According to Adobe docs, the encoding expected for the name is the system encoding.
         // Reference: https://ae-plugins.docsforadobe.dev/intro/localization/
-        let mut bytes = {
-            #[cfg(target_os = "macos")]
-            unsafe {
-                let cfstr = CFString::from_str(name);
-                let encoding = CFString::system_encoding(); 
-                let length = cfstr.length();
-                let max_size = CFString::maximum_size_for_encoding(length, encoding);
-                
-                let mut buffer = vec![0u8; max_size as usize];
-                let mut used_len = 0;
-                
-                 CFString::bytes(
-                    &cfstr,
-                    CFRange::new(0, length),
-                    encoding,
-                    b'?',  // replacement for unconvertible characters
-                    false,
-                    buffer.as_mut_ptr(),
-                    max_size,
-                    &mut used_len,
-                );
-                
-                buffer.truncate(used_len as usize);
-                buffer
-            }
-            #[cfg(target_os = "windows")]
-            unsafe {
-                use std::ffi::OsStr;
-                use std::os::windows::ffi::OsStrExt;
-                use windows_sys::Win32::Globalization::{WideCharToMultiByte, CP_OEMCP};
-                let mut wstr: Vec<u16> = OsStr::new(name).encode_wide().collect();
-                if !wstr.is_empty() {
-                    wstr.push(0); // Null-terminate
-                    let len = WideCharToMultiByte(CP_OEMCP, 0, wstr.as_ptr(), wstr.len() as i32, std::ptr::null_mut(), 0, std::ptr::null(), std::ptr::null_mut());
-                    if len > 0 {
-                        let mut bytes: Vec<u8> = Vec::with_capacity(len as usize);
-                        let len = WideCharToMultiByte(CP_OEMCP, 0, wstr.as_ptr(), wstr.len() as i32, bytes.as_mut_ptr() as _, len, std::ptr::null(), std::ptr::null_mut());
-                        if len > 0 {
-                            bytes.set_len(len as usize);
-                            bytes
-                        } else {
-                            Vec::new()
-                        }
-                    } else {
-                        Vec::new()
-                    }
-                } else {
-                    Vec::new()
-                }
-            }
-        };
+        let bytes = encode_to_system_bytes(name);
 
         let to_copy = bytes.len().min(MAX_NAME_LEN);
         if to_copy > 0 {
-            bytes.resize(to_copy, 0);
-            if let Some(last_elem) = bytes.get_mut(MAX_NAME_LEN - 1) {
-                *last_elem = 0;
+            self.param_def.name_do_not_use_directly[0..to_copy]
+                .copy_from_slice(unsafe { std::mem::transmute(&bytes[0..to_copy]) });
+            // Ensure null termination in the fixed-size buffer
+            if to_copy < MAX_NAME_LEN {
+                self.param_def.name_do_not_use_directly[to_copy] = 0;
+            } else {
+                self.param_def.name_do_not_use_directly[MAX_NAME_LEN - 1] = 0;
             }
-            self.param_def.name_do_not_use_directly[0..bytes.len()].copy_from_slice(unsafe { std::mem::transmute(bytes.as_slice()) });
             return Ok(());
         }
 

--- a/after-effects/src/pf/parameters.rs
+++ b/after-effects/src/pf/parameters.rs
@@ -7,6 +7,52 @@ use objc2_core_foundation::{CFRange, CFString};
 
 const MAX_NAME_LEN: usize = 32;
 
+/// Convert a UTF-8 string to a `CString` encoded in the system code page
+/// (e.g. CP936/GBK on Chinese Windows). On macOS this is a no-op since the
+/// system uses UTF-8 natively.
+fn encode_to_system_cstring(s: &str) -> CString {
+    #[cfg(target_os = "windows")]
+    {
+        let bytes = encode_to_system_bytes(s);
+        CString::new(bytes).unwrap_or_else(|_| CString::new("").unwrap())
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        CString::new(s).unwrap_or_else(|_| CString::new("").unwrap())
+    }
+}
+
+/// Convert a UTF-8 string to system-code-page bytes (no trailing NUL).
+#[cfg(target_os = "windows")]
+fn encode_to_system_bytes(s: &str) -> Vec<u8> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    unsafe {
+        use windows_sys::Win32::Globalization::{WideCharToMultiByte, CP_OEMCP};
+        let wstr: Vec<u16> = OsStr::new(s).encode_wide().collect();
+        if wstr.is_empty() {
+            return Vec::new();
+        }
+        let wlen = wstr.len() as i32;
+        let len = WideCharToMultiByte(
+            CP_OEMCP, 0, wstr.as_ptr(), wlen,
+            std::ptr::null_mut(), 0, std::ptr::null(), std::ptr::null_mut(),
+        );
+        if len <= 0 {
+            return Vec::new();
+        }
+        let mut bytes: Vec<u8> = Vec::with_capacity(len as usize);
+        let len = WideCharToMultiByte(
+            CP_OEMCP, 0, wstr.as_ptr(), wlen,
+            bytes.as_mut_ptr(), len, std::ptr::null(), std::ptr::null_mut(),
+        );
+        if len > 0 {
+            bytes.set_len(len as usize);
+        }
+        bytes
+    }
+}
+
 define_enum! {
     ae_sys::PF_ParamType,
     ParamType {
@@ -189,7 +235,7 @@ impl<'a> CheckBoxDef<'_> {
         self.def.dephault != 0
     }
     pub fn set_label(&mut self, v: &str) -> &mut Self {
-        self.label = CString::new(v).unwrap();
+        self.label = encode_to_system_cstring(v);
         self.def.u.nameptr = self.label.as_ptr();
         self
     }
@@ -413,7 +459,23 @@ define_param_wrapper! {
 impl<'a> PopupDef<'a> {
     pub fn set_options(&mut self, options: &[&str]) {
         // Build a string in the format "list|of|choices|", the format Ae expects.
-        self.options = CString::new(options.join("|")).unwrap();
+        // Encode each option in the system code page before joining, so non-ASCII
+        // translations render correctly on Windows.
+        #[cfg(target_os = "windows")]
+        {
+            let mut encoded: Vec<u8> = Vec::new();
+            for (i, opt) in options.iter().enumerate() {
+                if i > 0 {
+                    encoded.push(b'|');
+                }
+                encoded.extend_from_slice(&encode_to_system_bytes(opt));
+            }
+            self.options = CString::new(encoded).unwrap();
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            self.options = CString::new(options.join("|")).unwrap();
+        }
         self.def.u.namesptr = self.options.as_ptr();
         self.def.num_choices = options.len().try_into().unwrap();
     }

--- a/after-effects/src/pf/parameters.rs
+++ b/after-effects/src/pf/parameters.rs
@@ -10,15 +10,24 @@ const MAX_NAME_LEN: usize = 32;
 /// Convert a UTF-8 string to a `CString` encoded in the system code page
 /// (e.g. CP936/GBK on Chinese Windows). On macOS this is a no-op since the
 /// system uses UTF-8 natively.
+///
+/// Uses [`CP_OEMCP`] on Windows to match the existing behaviour in
+/// [`ParamDef::set_name()`]; on CJK Windows this is equivalent to [`CP_ACP`].
 fn encode_to_system_cstring(s: &str) -> CString {
     #[cfg(target_os = "windows")]
     {
         let bytes = encode_to_system_bytes(s);
-        CString::new(bytes).unwrap_or_else(|_| CString::new("").unwrap())
+        CString::new(bytes).unwrap_or_else(|e| {
+            log::error!("encode_to_system_cstring: {e}");
+            CString::new("").unwrap()
+        })
     }
     #[cfg(not(target_os = "windows"))]
     {
-        CString::new(s).unwrap_or_else(|_| CString::new("").unwrap())
+        CString::new(s).unwrap_or_else(|e| {
+            log::error!("encode_to_system_cstring: {e}");
+            CString::new("").unwrap()
+        })
     }
 }
 
@@ -470,7 +479,10 @@ impl<'a> PopupDef<'a> {
                 }
                 encoded.extend_from_slice(&encode_to_system_bytes(opt));
             }
-            self.options = CString::new(encoded).unwrap();
+            self.options = CString::new(encoded).unwrap_or_else(|e| {
+                log::error!("PopupDef::set_options: {e}");
+                CString::new("").unwrap()
+            });
         }
         #[cfg(not(target_os = "windows"))]
         {


### PR DESCRIPTION
Hi,

I'm the maintainer of [VideoFX-rs](https://github.com/zzzEffect/VideoFX-rs) and [zzzFX](https://github.com/zzzEffect/zzzFX), downstream projects that use this crate to build After Effects / Premiere Pro plugins with localized parameter UI.

## The bug
When the plugin runs on Chinese (or Japanese / Korean) Windows, parameter names on the left side of the Effect Controls panel display correctly, but checkbox labels and popup menu items on the right side show garbled text. e.g. `反转颜色` becomes `鍙嶈浆棰滆壊`.

Wrong text:
<img width="1920" height="1020" alt="wrong text" src="https://github.com/user-attachments/assets/b24444f0-4090-488f-b307-4a43be3b40d1" />

Correct text after the fix:
<img width="1920" height="1020" alt="correct text" src="https://github.com/user-attachments/assets/3278913b-6d14-432e-9004-4776a6ec7577" />

## Root cause
`ParamDef::set_name()` has always applied system-code-page encoding for the inline `name[32]` array — on Windows it goes through `WideCharToMultiByte(CP_OEMCP, ...)`, so the host receives bytes it can interpret correctly.

`CheckBoxDef::set_label()`, `PopupDef::set_options()`, and the `impl String` setter generated by `define_param_wrapper!` do **not** apply this conversion. They pass raw UTF-8 bytes to the host via `CString::new()`. The host interprets those bytes as system-code-page (e.g. CP936/GBK on Chinese Windows), so each multi-byte UTF-8 sequence maps to multiple wrong characters.

This is a Windows-only issue. macOS uses UTF-8 natively.

## The fix

Added two helpers (`encode_to_system_cstring()` and `encode_to_system_bytes()`) that replicate the existing encoding logic from `set_name()`, then applied them where they're needed.

## Caveats

This is still a draft because:
- Tested on: Windows, Adobe After Effects 25.6.4 only.
- Expected to work: all versions before AE 26.2. I've heard that AE 26.2 changed the plugin parameter string parsing in a way that may cause additional encoding issues even for plugins that were previously correct. Given that Adobe may potentially fix the new issue brought about by 26.2, my fix targets the pre-26.2 behaviour.
- Not yet tested on: Premiere Pro, or AE 26.2+.

When I have free time later, I'll conduct tests on other versions and eventually change the status from `draft` to `ready for review`.