### PR TITLE
Fix PluginDataEntryFunction2 reserved info

### DIFF
--- a/after-effects/src/plugin_base.rs
+++ b/after-effects/src/plugin_base.rs
@@ -404,7 +404,9 @@ macro_rules! define_effect {
                         env!("PIPL_KIND")              .parse().unwrap(),
                         env!("PIPL_AE_SPEC_VER_MAJOR") .parse().unwrap(),
                         env!("PIPL_AE_SPEC_VER_MINOR") .parse().unwrap(),
-                        env!("PIPL_AE_RESERVED")       .parse().unwrap(),
+                        // PluginDataEntryFunction2 registration metadata is
+                        // distinct from the PiPL AE_Reserved_Info property.
+                        8,
                         cstr!(env!("PIPL_SUPPORT_URL")).as_ptr() as *const u8, // Support url
                     )
                 }


### PR DESCRIPTION
## Summary

Pass Adobe's required `AE_RESERVED_INFO` callback value (`8`) to `PF_PluginDataCB2` instead of reusing the embedded PiPL `AE_Reserved_Info` property.

## Root cause

`AE_Reserved_Info` in the PiPL and `inReservedInfo` passed by `PluginDataEntryFunction2` are separate fields. A PiPL may correctly contain `AE_Reserved_Info { 0 }`, while the standard registration callback requires `8`.

With the current wrapper, After Effects 26.2 normalizes loader metadata by removing `PF_OutFlag2_SUPPORTS_THREADED_RENDERING`. A plugin whose raw PiPL and `GlobalSetup` both advertise `0x18921409` is then reported as:

```
Code flags: 18921409
PiPL flags: 10921409
(25::16)
```

The difference is exactly the MFR bit `0x08000000`. Setting the PiPL property itself to `8` is not a valid workaround and can crash when applying the effect.

## Verification

- `cargo check -p after-effects`
- `cargo test -p after-effects`
- `git diff --check`

The workspace-wide rustfmt check currently reports pre-existing formatting differences outside this patch.