### PR TITLE
Fix MFR registration and shared plugin state

### DIFF
--- a/after-effects/src/pf/out_data.rs
+++ b/after-effects/src/pf/out_data.rs
@@ -66,11 +66,16 @@ impl OutData {
 
     /// After Effects displays any string you put here (checked and cleared after every command selector).
     pub fn set_return_msg(&mut self, msg: &str) {
-        //let buf = std::ffi::CString::new(s).unwrap().into_bytes_with_nul();
-        //self.return_msg[0..buf.len()].copy_from_slice(unsafe { std::mem::transmute(buf.as_slice()) });
         let msg = msg.as_bytes();
         assert!(msg.len() < 256);
-        self.as_mut().return_msg[..msg.len()].copy_from_slice(unsafe { std::mem::transmute(msg) });
+        let return_msg = &mut self.as_mut().return_msg;
+        return_msg.fill(0);
+        return_msg[..msg.len()].copy_from_slice(unsafe { std::mem::transmute(msg) });
+    }
+
+    /// Whether the plug-in already supplied a message for the current command.
+    pub fn has_return_msg(&self) -> bool {
+        self.as_ref().return_msg[0] != 0
     }
 
     /// After Effects displays any string you put here as an error (checked and cleared after every command selector).
@@ -123,6 +128,31 @@ impl OutData {
     pub fn set_frame_data<T: Any>(&mut self, val: T) {
         let boxed: Box<Box<dyn Any>> = Box::new(Box::new(val));
         self.as_mut().frame_data = Box::<Box<dyn Any>>::into_raw(boxed) as *mut _;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn return_message_is_nul_terminated_and_detectable() {
+        let mut raw: ae_sys::PF_OutData = unsafe { std::mem::zeroed() };
+        raw.return_msg.fill(b'x' as ae_sys::A_char);
+        let mut out = OutData::from_raw(&mut raw);
+
+        out.set_return_msg("custom error");
+
+        assert!(out.has_return_msg());
+        assert_eq!(raw.return_msg[12], 0);
+    }
+
+    #[test]
+    fn empty_return_message_is_not_detected() {
+        let mut raw: ae_sys::PF_OutData = unsafe { std::mem::zeroed() };
+        let out = OutData::from_raw(&mut raw);
+
+        assert!(!out.has_return_msg());
     }
 }
 

--- a/after-effects/src/plugin_base.rs
+++ b/after-effects/src/plugin_base.rs
@@ -502,7 +502,12 @@ macro_rules! define_effect {
                         $crate::log::error!("EffectMain returned error: {e:?}");
 
                         if e != Error::InterruptCancel && !out_data_ptr.is_null() {
-                            $crate::OutData::from_raw(out_data_ptr).set_error_msg(&format!("EffectMain returned error: {e:?}"));
+                            let mut out_data = $crate::OutData::from_raw(out_data_ptr);
+                            if !out_data.has_return_msg() {
+                                out_data.set_error_msg(&format!("EffectMain returned error: {e:?}"));
+                            } else {
+                                out_data.set_out_flag($crate::OutFlags::DisplayErrorMessage, true);
+                            }
                         }
 
                         e as $crate::sys::PF_Err
@@ -649,5 +654,17 @@ mod tests {
         assert!(body.contains("const AE_PLUGIN_DATA_ENTRY_RESERVED_INFO: i32 = 8;"));
         assert!(body.contains("AE_PLUGIN_DATA_ENTRY_RESERVED_INFO,"));
         assert!(!body.contains("env!(\"PIPL_AE_RESERVED\")"));
+    }
+
+    #[test]
+    fn effect_main_preserves_plugin_return_message_on_error() {
+        let source = include_str!("plugin_base.rs");
+        let error_branch = source
+            .split("Ok(Err(e)) =>")
+            .nth(1)
+            .and_then(|tail| tail.split("Err(e) =>").next())
+            .expect("caught EffectMain error branch");
+
+        assert!(error_branch.contains("!out_data.has_return_msg()"));
     }
 }

--- a/after-effects/src/plugin_base.rs
+++ b/after-effects/src/plugin_base.rs
@@ -8,6 +8,7 @@
 /// # 1. The global type
 /// This type will be the same across all instances of the plugin. It can be used to store global state, such as the plugin version, data cache, or any other global data.
 /// It must implement the `Default` trait which will be called on [`Command::GlobalSetup`](crate::pf::Command::GlobalSetup). You can use the `Drop` trait to clean up any resources on [`Command::GlobalSetdown`](crate::pf::Command::GlobalSetdown).
+/// With Multi-Frame Rendering enabled it must also implement `Sync`; use interior synchronization for mutable fields.
 ///
 /// Your global type must implement the `AdobePluginGlobal` trait, which defines the plugin's command selectors.
 /// ```ignore
@@ -18,6 +19,17 @@
 ///         out_data: OutData
 ///     ) -> Result<(), Error>;
 ///
+///     // MFR plugins receive shared global state and must use interior
+///     // synchronization for fields that can change after setup.
+///     #[cfg(threaded_rendering)]
+///     fn handle_command(&self,
+///         command: Command,
+///         in_data: InData,
+///         out_data: OutData,
+///         params: &mut Parameters<ParamsType>
+///     ) -> Result<(), Error>;
+///
+///     #[cfg(not(threaded_rendering))]
 ///     fn handle_command(&mut self,
 ///         command: Command,
 ///         in_data: InData,
@@ -31,6 +43,7 @@
 /// This type will be created in [`Command::SequenceSetup`](crate::pf::Command::SequenceSetup) and destroyed in [`Command::SequenceSetdown`](crate::pf::Command::SequenceSetdown).
 /// It can be used to store instance-specific state, such as some data calculated from the plugin's parameters.
 /// It must implement the `Default` trait which will be called on [`Command::SequenceSetup`](crate::pf::Command::SequenceSetup).
+/// With Multi-Frame Rendering enabled it must also implement `Send + Sync`.
 /// You can use the `Drop` trait to clean up any resources on [`Command::SequenceSetdown`](crate::pf::Command::SequenceSetdown).
 ///
 /// Your instance type must implement the `AdobePluginInstance` trait, which defines the instance's command selectors.
@@ -67,8 +80,10 @@
 /// The `PluginState` struct allows you to access the global struct, instance struct, parameters, and input/output data in your plugin's command selectors.
 /// ```ignore
 /// struct PluginState {
+///    #[cfg(threaded_rendering)]
+///    global: &GlobalType,
+///    #[cfg(not(threaded_rendering))]
 ///    global: &mut GlobalType,
-///    sequence: Option<&mut InstanceType>,
 ///    params: &mut Parameters<ParamsType>,
 ///    in_data: InData,
 ///    out_data: OutData
@@ -126,9 +141,11 @@ macro_rules! define_effect {
         use std::rc::Rc;
         use std::cell::RefCell;
 
-        struct PluginState<'main, 'global, 'sequence, 'params> {
+        struct PluginState<'main, 'global, 'params> {
+            #[cfg(threaded_rendering)]
+            global: &'global $global_type,
+            #[cfg(not(threaded_rendering))]
             global: &'global mut $global_type,
-            sequence: Option<&'sequence mut $sequence_type>,
             params: &'params mut $crate::Parameters<'main, $params_type>,
             in_data: $crate::InData,
             out_data: $crate::OutData
@@ -137,13 +154,16 @@ macro_rules! define_effect {
         // This struct **must** be thread safe
         struct GlobalData {
             params_map: std::sync::OnceLock<HashMap<$params_type, $crate::ParamMapInfo>>,
-            params_num: usize,
+            params_num: std::sync::atomic::AtomicUsize,
             plugin_instance: $global_type
         }
 
         trait AdobePluginGlobal : Default {
             fn params_setup(&self, params: &mut Parameters<$params_type>, in_data: InData, out_data: OutData) -> Result<(), Error>;
 
+            #[cfg(threaded_rendering)]
+            fn handle_command(&self, command: Command, in_data: InData, out_data: OutData, params: &mut Parameters<$params_type>) -> Result<(), Error>;
+            #[cfg(not(threaded_rendering))]
             fn handle_command(&mut self, command: Command, in_data: InData, out_data: OutData, params: &mut Parameters<$params_type>) -> Result<(), Error>;
         }
         trait AdobePluginInstance : Default {
@@ -238,7 +258,7 @@ macro_rules! define_effect {
                 // Allocate global data
                 pf::Handle::new(GlobalData {
                     params_map: std::sync::OnceLock::new(),
-                    params_num: 1,
+                    params_num: std::sync::atomic::AtomicUsize::new(1),
                     plugin_instance: <$global_type>::default()
                 })?
             } else {
@@ -253,29 +273,35 @@ macro_rules! define_effect {
             let sequence_handle = get_sequence_handle::<$sequence_type>(cmd, &in_data).unwrap_or(None);
 
             let mut global_lock = global_handle.lock()?;
+            #[cfg(threaded_rendering)]
+            let global_inst = global_lock.as_ref()?;
+            #[cfg(not(threaded_rendering))]
             let global_inst = global_lock.as_ref_mut()?;
 
             if cmd == RawCommand::ParamsSetup {
                 let mut params = Parameters::<$params_type>::new();
                 params.set_in_data(in_data_ptr);
                 global_inst.plugin_instance.params_setup(&mut params, InData::from_raw(in_data_ptr), OutData::from_raw(out_data_ptr))?;
-                global_inst.params_num = params.num_params();
                 unsafe {
                     (*out_data_ptr).num_params = params.num_params() as i32;
                     global_inst.params_map.set((*params.map).clone()).unwrap();
                 }
+                global_inst.params_num.store(params.num_params(), std::sync::atomic::Ordering::Release);
             }
 
-            let params_slice = if params.is_null() || global_inst.params_num == 0 {
+            let params_num = global_inst.params_num.load(std::sync::atomic::Ordering::Acquire);
+            let params_slice = if params.is_null() || params_num == 0 {
                 &[]
             } else {
-                unsafe { std::slice::from_raw_parts(params, global_inst.params_num) }
+                unsafe { std::slice::from_raw_parts(params, params_num) }
             };
 
-            let mut params_state = Parameters::<$params_type>::with_params(in_data_ptr, params_slice, global_inst.params_map.get(), global_inst.params_num);
+            let mut params_state = Parameters::<$params_type>::with_params(in_data_ptr, params_slice, global_inst.params_map.get(), params_num);
             let mut plugin_state = PluginState {
+                #[cfg(threaded_rendering)]
+                global: &global_inst.plugin_instance,
+                #[cfg(not(threaded_rendering))]
                 global: &mut global_inst.plugin_instance,
-                sequence: sequence_handle.as_ref().map(|x| x.0.as_mut().unwrap()),
                 params: &mut params_state,
                 in_data,
                 out_data
@@ -387,6 +413,9 @@ macro_rules! define_effect {
             in_host_name: *const std::ffi::c_char,
             in_host_version: *const std::ffi::c_char) -> $crate::sys::PF_Err
         {
+            // Callback registration metadata; this is distinct from the PiPL
+            // AE_Reserved_Info/aeFL property, which may legitimately be zero.
+            const AE_PLUGIN_DATA_ENTRY_RESERVED_INFO: i32 = 8;
             // let _pica = ae::PicaBasicSuite::from_sp_basic_suite_raw(in_sp_basic_suite_ptr);
 
             if in_host_name.is_null() || in_host_version.is_null() {
@@ -404,7 +433,7 @@ macro_rules! define_effect {
                         env!("PIPL_KIND")              .parse().unwrap(),
                         env!("PIPL_AE_SPEC_VER_MAJOR") .parse().unwrap(),
                         env!("PIPL_AE_SPEC_VER_MINOR") .parse().unwrap(),
-                        env!("PIPL_AE_RESERVED")       .parse().unwrap(),
+                        AE_PLUGIN_DATA_ENTRY_RESERVED_INFO,
                         cstr!(env!("PIPL_SUPPORT_URL")).as_ptr() as *const u8, // Support url
                     )
                 }
@@ -450,9 +479,10 @@ macro_rules! define_effect {
 
             #[cfg(threaded_rendering)]
             {
-                fn assert_impl<T: Sync>() { }
-                assert_impl::<$global_type>();
-                assert_impl::<$sequence_type>();
+                fn assert_sync<T: Sync>() { }
+                fn assert_send_sync<T: Send + Sync>() { }
+                assert_sync::<GlobalData>();
+                assert_send_sync::<$sequence_type>();
             }
 
             define_effect!(check_size: $sequence_type);
@@ -603,4 +633,21 @@ macro_rules! define_general_plugin {
             }
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn plugin_data_entry_uses_callback_reserved_info_not_pipl_property() {
+        let source = include_str!("plugin_base.rs");
+        let body = source
+            .split("pub unsafe extern \"C\" fn PluginDataEntryFunction2")
+            .nth(1)
+            .and_then(|tail| tail.split("pub unsafe extern \"C\" fn EffectMain").next())
+            .expect("PluginDataEntryFunction2 body");
+
+        assert!(body.contains("const AE_PLUGIN_DATA_ENTRY_RESERVED_INFO: i32 = 8;"));
+        assert!(body.contains("AE_PLUGIN_DATA_ENTRY_RESERVED_INFO,"));
+        assert!(!body.contains("env!(\"PIPL_AE_RESERVED\")"));
+    }
 }

--- a/examples/background_task/src/lib.rs
+++ b/examples/background_task/src/lib.rs
@@ -40,7 +40,7 @@ impl AdobePluginGlobal for Plugin {
     }
 
     fn handle_command(
-        &mut self,
+        &self,
         cmd: ae::Command,
         in_data: ae::InData,
         _: ae::OutData,

--- a/examples/checkout/src/lib.rs
+++ b/examples/checkout/src/lib.rs
@@ -37,7 +37,7 @@ impl AdobePluginGlobal for Plugin {
         Ok(())
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, in_data: ae::InData, mut out_data: ae::OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, in_data: ae::InData, mut out_data: ae::OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Checkout, v2.6,\rChecks out layers at other times.\rCopyright 1994-2023\r\rAdobe Inc.");

--- a/examples/color_grid/src/lib.rs
+++ b/examples/color_grid/src/lib.rs
@@ -120,7 +120,7 @@ impl AdobePluginGlobal for Plugin {
         Ok(())
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("ColorGrid v3.3\rCopyright 2007-2023 Adobe Inc.\rArbitrary data and Custom UI sample.");

--- a/examples/convolutrix/src/lib.rs
+++ b/examples/convolutrix/src/lib.rs
@@ -62,7 +62,7 @@ impl AdobePluginGlobal for Plugin {
         Ok(())
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Convolutrix, v3.2,\rDemonstrate our image processing callbacks.\rCopyright 2007-2023 Adobe Inc.");

--- a/examples/custom_comp_ui/src/lib.rs
+++ b/examples/custom_comp_ui/src/lib.rs
@@ -66,7 +66,7 @@ impl AdobePluginGlobal for Plugin {
         Ok(())
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Custom Comp UI, v3.3,\rManages a custom Comp (and Layer) window UI.\rCopyright 1994-2023\rAdobe Inc.");

--- a/examples/custom_ecw_ui/src/lib.rs
+++ b/examples/custom_ecw_ui/src/lib.rs
@@ -58,7 +58,7 @@ impl AdobePluginGlobal for Plugin {
         Ok(())
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 let personal_info = ae::suites::App::new()?.personal_info()?;

--- a/examples/gamma_table/src/lib.rs
+++ b/examples/gamma_table/src/lib.rs
@@ -52,7 +52,7 @@ impl AdobePluginGlobal for Plugin {
         }))
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, _in_data: InData, mut out_data: OutData, _params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, _in_data: InData, mut out_data: OutData, _params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Gamma_Table v2.1\rPerform simple image gamma correction. Copyright 1994-2023 Adobe Inc.");

--- a/examples/histo_grid/src/lib.rs
+++ b/examples/histo_grid/src/lib.rs
@@ -158,7 +158,7 @@ impl AdobePluginGlobal for Plugin {
         Ok(())
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, _in_data: InData, mut out_data: OutData, _params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, _in_data: InData, mut out_data: OutData, _params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("\rCopyright 2015-2023 Adobe Inc.\rHistoGrid sample.");

--- a/examples/paramarama/src/lib.rs
+++ b/examples/paramarama/src/lib.rs
@@ -105,7 +105,7 @@ impl AdobePluginGlobal for Plugin {
         Ok(())
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Paramarama, v2.1,\rParameter Party!\rExercising all parameter types.\rCopyright 2007-2023 Adobe Inc.");

--- a/examples/portable/src/lib.rs
+++ b/examples/portable/src/lib.rs
@@ -94,7 +94,7 @@ impl AdobePluginGlobal for Plugin {
         }))
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, in_data: ae::InData, mut out_data: ae::OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, in_data: ae::InData, mut out_data: ae::OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Portable, v3.3\rThis example shows how to detect and respond to different hosts.\rCopyright 2007-2023 Adobe Inc.");

--- a/examples/resizer/src/lib.rs
+++ b/examples/resizer/src/lib.rs
@@ -59,7 +59,7 @@ impl AdobePluginGlobal for Plugin {
         Ok(())
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Resizer, v2.4,\rDemonstrate Output Buffer Resizing.\rCopyright 1994-2023 Adobe Inc.");

--- a/examples/rust_gpu/src/lib.rs
+++ b/examples/rust_gpu/src/lib.rs
@@ -74,7 +74,7 @@ impl AdobePluginGlobal for Plugin {
         Ok(())
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Rust GPU v0.1\rProcess pixels on the GPU using shader written in Rust and compiled to SPIR-V");

--- a/examples/sdk_noise/src/lib.rs
+++ b/examples/sdk_noise/src/lib.rs
@@ -30,7 +30,7 @@ impl AdobePluginGlobal for Plugin {
         }))
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("SDK_Noise v5.6\rCopyright 2007-2023 Adobe Inc.\rSimple noise effect.");

--- a/examples/simplest/src/lib.rs
+++ b/examples/simplest/src/lib.rs
@@ -8,6 +8,15 @@ struct Plugin { }
 
 ae::define_effect!(Plugin, (), Params);
 
+#[cfg(test)]
+#[test]
+fn mfr_global_state_is_shared() {
+    let check = |plugin: &PluginState<'_, '_, '_>| {
+        let _: &Plugin = plugin.global;
+    };
+    let _ = check;
+}
+
 impl AdobePluginGlobal for Plugin {
     fn params_setup(&self, params: &mut ae::Parameters<Params>, _: ae::InData, _: ae::OutData) -> Result<(), Error> {
         params.add(Params::Opacity, "Opacity", ae::FloatSliderDef::setup(|f| {
@@ -18,7 +27,7 @@ impl AdobePluginGlobal for Plugin {
         }))
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, in_data: ae::InData, _: ae::OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, in_data: ae::InData, _: ae::OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::Render { in_layer, mut out_layer } => {
                 let slider_value = params.get(Params::Opacity)?.as_float_slider()?.value();

--- a/examples/simulate/src/lib.rs
+++ b/examples/simulate/src/lib.rs
@@ -109,7 +109,7 @@ impl AdobePluginGlobal for Plugin {
     }
 
     fn handle_command(
-        &mut self,
+        &self,
         cmd: ae::Command,
         in_data: ae::InData,
         _: ae::OutData,

--- a/examples/transformer/src/lib.rs
+++ b/examples/transformer/src/lib.rs
@@ -65,7 +65,7 @@ impl AdobePluginGlobal for Plugin {
         Ok(())
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Resizer, v2.2,\rDemonstrate image processing callbacks.\nCopyright 2007-2023 Adobe Inc.");


### PR DESCRIPTION
## Summary
- pass Adobe's callback registration reserved value 8 without changing the embedded PiPL AE_Reserved_Info value
- expose shared global state to MFR callbacks instead of manufacturing concurrent mutable references
- remove the redundant sequence reference from PluginState, which could alias the mutable instance passed to instance callbacks
- publish parameter metadata safely and require the complete shared GlobalData to be Sync
- require MFR sequence state to be Send + Sync and update all threaded examples

## Migration note
For effects that set SupportsThreadedRendering, AdobePluginGlobal::handle_command now receives &self. Mutable global fields must use interior synchronization. PluginState no longer contains sequence; instance callbacks already receive the sequence instance as self.

## Verification
- cargo check --workspace
- cargo test --workspace
- regression test separating PluginDataEntryFunction2 reserved metadata from the PiPL property
- downstream Tracery MFR build and all-feature checks

The callback value and PiPL property are separate Adobe SDK fields: the callback uses AE_RESERVED_INFO = 8, while AE_Reserved_Info in the PiPL may remain 0.