### PR TITLE
Preserve plugin-supplied After Effects error messages

### DIFF
--- a/after-effects/src/pf/out_data.rs
+++ b/after-effects/src/pf/out_data.rs
@@ -66,11 +66,16 @@ impl OutData {
 
     /// After Effects displays any string you put here (checked and cleared after every command selector).
     pub fn set_return_msg(&mut self, msg: &str) {
-        //let buf = std::ffi::CString::new(s).unwrap().into_bytes_with_nul();
-        //self.return_msg[0..buf.len()].copy_from_slice(unsafe { std::mem::transmute(buf.as_slice()) });
         let msg = msg.as_bytes();
         assert!(msg.len() < 256);
-        self.as_mut().return_msg[..msg.len()].copy_from_slice(unsafe { std::mem::transmute(msg) });
+        let return_msg = &mut self.as_mut().return_msg;
+        return_msg.fill(0);
+        return_msg[..msg.len()].copy_from_slice(unsafe { std::mem::transmute(msg) });
+    }
+
+    /// Whether the plug-in already supplied a message for the current command.
+    pub fn has_return_msg(&self) -> bool {
+        self.as_ref().return_msg[0] != 0
     }
 
     /// After Effects displays any string you put here as an error (checked and cleared after every command selector).
@@ -123,6 +128,31 @@ impl OutData {
     pub fn set_frame_data<T: Any>(&mut self, val: T) {
         let boxed: Box<Box<dyn Any>> = Box::new(Box::new(val));
         self.as_mut().frame_data = Box::<Box<dyn Any>>::into_raw(boxed) as *mut _;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn return_message_is_nul_terminated_and_detectable() {
+        let mut raw: ae_sys::PF_OutData = unsafe { std::mem::zeroed() };
+        raw.return_msg.fill(b'x' as ae_sys::A_char);
+        let mut out = OutData::from_raw(&mut raw);
+
+        out.set_return_msg("custom error");
+
+        assert!(out.has_return_msg());
+        assert_eq!(raw.return_msg[12], 0);
+    }
+
+    #[test]
+    fn empty_return_message_is_not_detected() {
+        let mut raw: ae_sys::PF_OutData = unsafe { std::mem::zeroed() };
+        let out = OutData::from_raw(&mut raw);
+
+        assert!(!out.has_return_msg());
     }
 }
 

--- a/after-effects/src/plugin_base.rs
+++ b/after-effects/src/plugin_base.rs
@@ -609,18 +609,3 @@ macro_rules! define_general_plugin {
         }
     };
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn effect_main_preserves_plugin_return_message_on_error() {
-        let source = include_str!("plugin_base.rs");
-        let error_branch = source
-            .split("Ok(Err(e)) =>")
-            .nth(1)
-            .and_then(|tail| tail.split("Err(e) =>").next())
-            .expect("caught EffectMain error branch");
-
-        assert!(error_branch.contains("!out_data.has_return_msg()"));
-    }
-}

--- a/after-effects/src/plugin_base.rs
+++ b/after-effects/src/plugin_base.rs
@@ -472,7 +472,12 @@ macro_rules! define_effect {
                         $crate::log::error!("EffectMain returned error: {e:?}");
 
                         if e != Error::InterruptCancel && !out_data_ptr.is_null() {
-                            $crate::OutData::from_raw(out_data_ptr).set_error_msg(&format!("EffectMain returned error: {e:?}"));
+                            let mut out_data = $crate::OutData::from_raw(out_data_ptr);
+                            if !out_data.has_return_msg() {
+                                out_data.set_error_msg(&format!("EffectMain returned error: {e:?}"));
+                            } else {
+                                out_data.set_out_flag($crate::OutFlags::DisplayErrorMessage, true);
+                            }
                         }
 
                         e as $crate::sys::PF_Err
@@ -603,4 +608,19 @@ macro_rules! define_general_plugin {
             }
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn effect_main_preserves_plugin_return_message_on_error() {
+        let source = include_str!("plugin_base.rs");
+        let error_branch = source
+            .split("Ok(Err(e)) =>")
+            .nth(1)
+            .and_then(|tail| tail.split("Err(e) =>").next())
+            .expect("caught EffectMain error branch");
+
+        assert!(error_branch.contains("!out_data.has_return_msg()"));
+    }
 }


### PR DESCRIPTION
## Summary

Preserve a plug-in supplied After Effects error message when `EffectMain` returns an error.

## What was wrong

`OutData::set_return_msg` copied text into the fixed-size return buffer without clearing the old contents or guaranteeing a NUL terminator. The panic/error wrapper then unconditionally replaced the return message with `EffectMain returned error: Generic`, so After Effects could show the generic text joined to the tail of the plug-in's diagnostic.

## What changed

- Clear and NUL-terminate the return-message buffer when setting it.
- Add `OutData::has_return_msg()` for the wrapper to detect an existing plug-in message.
- Keep the plug-in message and set `DisplayErrorMessage` when one is present.
- Use the generic fallback only when the plug-in did not provide a message.

## Validation

- `cargo test -p after-effects`
- `cargo check -p after-effects`
