### PR TITLE
Remove host_[un]lock_handle() calls

### DIFF
--- a/after-effects/src/pf/suites/handle.rs
+++ b/after-effects/src/pf/suites/handle.rs
@@ -28,14 +28,24 @@ impl HandleSuite {
     }
 
     /// Lock the handle and return a pointer to the data.
+    ///
+    /// `host_lock_handle` has been a no-op in After Effects since CS6, so we no
+    /// longer call it. A `PF_Handle` is a pointer to the data pointer, so the
+    /// data pointer is obtained by simply dereferencing the handle. Returns a
+    /// null pointer if the handle itself is null.
     pub fn lock_handle(&self, pf_handle: PF_Handle) -> *mut std::ffi::c_void {
-        call_suite_fn_no_err!(self, host_lock_handle, pf_handle)
+        if pf_handle.is_null() {
+            return std::ptr::null_mut();
+        }
+        unsafe { *(pf_handle as *mut *mut std::ffi::c_void) }
     }
 
     /// Unlock the handle.
-    pub fn unlock_handle(&self, pf_handle: PF_Handle) {
-        call_suite_fn_no_err!(self, host_unlock_handle, pf_handle)
-    }
+    ///
+    /// `host_unlock_handle` has been a no-op in After Effects since CS6, so this
+    /// does nothing. It is kept for source compatibility and pairs with
+    /// [`Self::lock_handle`].
+    pub fn unlock_handle(&self, _pf_handle: PF_Handle) {}
 
     /// Dispose of the handle and free the memory.
     pub fn dispose_handle(&self, pf_handle: PF_Handle) {

--- a/after-effects/src/pf/util_callbacks.rs
+++ b/after-effects/src/pf/util_callbacks.rs
@@ -315,16 +315,16 @@ impl UtilCallbacks {
             if size == 0 || in_data.utils.is_null() {
                 return Err(Error::BadCallbackParameter);
             }
-            let new    = (*in_data.utils).host_new_handle   .ok_or(Error::BadCallbackParameter)?;
-            let lock   = (*in_data.utils).host_lock_handle  .ok_or(Error::BadCallbackParameter)?;
-            let unlock = (*in_data.utils).host_unlock_handle.ok_or(Error::BadCallbackParameter)?;
+            let new = (*in_data.utils).host_new_handle.ok_or(Error::BadCallbackParameter)?;
             let ptr = new(size as _);
             if ptr.is_null() {
                 return Err(Error::OutOfMemory);
             }
-            let locked = lock(ptr);
-            unlock(ptr); // we just want to check for null ptr
-            if locked.is_null() {
+            // `host_lock_handle`/`host_unlock_handle` have been no-ops in After
+            // Effects since CS6. A `PF_Handle` is a pointer to the data pointer,
+            // so we dereference it directly to check the allocation succeeded.
+            let data_ptr = *(ptr as *mut *mut c_void);
+            if data_ptr.is_null() {
                 return Err(Error::OutOfMemory);
             }
             Ok(RawHandle {
@@ -692,18 +692,21 @@ impl RawHandle {
     pub fn as_raw(&self) -> ae_sys::PF_Handle {
         self.handle
     }
+    /// Returns a guard exposing a pointer to the handle's data.
+    ///
+    /// `host_lock_handle` has been a no-op in After Effects since CS6, so we no
+    /// longer call it. A `PF_Handle` is a pointer to the data pointer, so the
+    /// data pointer is obtained by dereferencing the handle. The returned guard
+    /// borrows `self`, keeping the handle alive for the lifetime of the borrow.
     pub fn lock(&self) -> Result<RawHandleLock<'_>, Error> {
-        unsafe {
-            let lock = (*self.utils_ptr).host_lock_handle.ok_or(Error::BadCallbackParameter)?;
-            let ptr = lock(self.handle);
-            if ptr.is_null() {
-                return Err(Error::OutOfMemory);
-            }
-            Ok(RawHandleLock {
-                handle: self,
-                ptr,
-            })
+        let ptr = unsafe { *(self.handle as *mut *mut c_void) };
+        if ptr.is_null() {
+            return Err(Error::OutOfMemory);
         }
+        Ok(RawHandleLock {
+            ptr,
+            _marker: std::marker::PhantomData,
+        })
     }
     pub fn size(&self) -> Result<usize, Error> {
         unsafe {
@@ -731,20 +734,15 @@ impl Drop for RawHandle {
     }
 }
 pub struct RawHandleLock<'a> {
-    handle: &'a RawHandle,
     ptr: *mut c_void,
+    // Borrows the [`RawHandle`] so it cannot be disposed while the data pointer
+    // is in use. No unlock is needed on drop: `host_unlock_handle` has been a
+    // no-op in After Effects since CS6.
+    _marker: std::marker::PhantomData<&'a RawHandle>,
 }
 impl<'a> RawHandleLock<'a> {
     pub fn as_ptr(&self) -> *mut c_void {
         self.ptr
-    }
-}
-impl<'a> Drop for RawHandleLock<'a> {
-    fn drop(&mut self) {
-        unsafe {
-            let unlock = (*self.handle.utils_ptr).host_unlock_handle.unwrap();
-            unlock(self.handle.handle);
-        }
     }
 }
 


### PR DESCRIPTION
Fixes #6.

Per the Adobe SDK maintainers, `host_lock_handle`/`host_unlock_handle` have been no-ops in After Effects since CS6 (~10 years), so we stop calling them. A `PF_Handle` is a pointer to the data pointer, so the data pointer is obtained by dereferencing the handle directly -- exactly what the existing `Handle::as_ref`/`FlatHandle::as_slice` helpers already did without locking.

## Changes

- `after-effects/src/pf/suites/handle.rs`
  - `HandleSuite::lock_handle` now dereferences the handle (`*(pf_handle as *mut *mut c_void)`) instead of calling `host_lock_handle`; returns null if the handle is null.
  - `HandleSuite::unlock_handle` is now an empty no-op, kept for source compatibility.
- `after-effects/src/pf/util_callbacks.rs`
  - `UtilCallbacks::host_new_handle` no longer fetches `host_lock_handle`/`host_unlock_handle`; it dereferences the fresh handle to null-check the allocation.
  - `RawHandle::lock` dereferences the handle instead of calling `host_lock_handle`.
  - `RawHandleLock` drops its now-empty `Drop` impl (it only called `host_unlock_handle`) and holds a `PhantomData<&'a RawHandle>` borrow so the handle cannot be disposed while the data pointer is in use.

## Compatibility

Behavior-preserving cleanup -- the removed calls were no-ops. No public signatures changed; `lock_handle`/`unlock_handle`/`lock()`/`RawHandleLock` all remain, so downstream users are unaffected. The borrow that previously guaranteed pointer validity is preserved (`RawHandleLock` still borrows the `RawHandle`; `HandleLock`/`FlatHandleLock` are unchanged), so there is no new UB.

## Vetting

Cross-compiled for Windows from Linux, all clean (only pre-existing `unused import: crate::*` warnings):

- `cargo check -p after-effects --target x86_64-pc-windows-gnu`
- `cargo check -p after-effects --tests --target x86_64-pc-windows-gnu`
- `cargo check -p colorgrid --target x86_64-pc-windows-gnu` (exercises arbitrary-data handle locking)
- `cargo check -p persisto --target x86_64-pc-windows-gnu` (exercises `FlatHandle`)