### PR TITLE
docs: document runtime host gating in place of removed can_load (#91)

### DIFF
--- a/after-effects/src/plugin_base.rs
+++ b/after-effects/src/plugin_base.rs
@@ -102,6 +102,14 @@
 /// This is an enum which covers all parameters in your plugin. It must implement the `Eq`, `PartialEq`, `Hash`, `Clone`, `Copy`, and `Debug` traits.
 /// You will use this enum to define the parameters in `params_setup()` and to access the parameters from the [`Parameters`](crate::pf::Parameters) struct in the `handle_command()` method.
 ///
+/// # Host/version gating
+/// There is no `can_load` hook to refuse loading in a given host: Adobe ignores the
+/// return value of the `PluginDataEntryFunction2` entry point, so a plugin can never
+/// prevent itself from being registered. Gate at runtime instead -- inspect
+/// [`InData::is_after_effects()`](crate::InData::is_after_effects) (or
+/// [`InData::is_premiere()`](crate::InData::is_premiere)) in `params_setup`/render and
+/// bail out with [`OutData::set_error_msg()`](crate::OutData::set_error_msg) when running
+/// in an unsupported host.
 ///
 /// ## Refer to the [Adobe After Effects SDK](https://ae-plugins.docsforadobe.dev/effect-basics/command-selectors.html) to learn more about the plugin entry point and command selectors.
 ///


### PR DESCRIPTION
Fixes #91

## Summary

Issue #91 concluded that `can_load` serves no purpose: Adobe **ignores the return
value of the `PluginDataEntryFunction2` entry point**, so a plugin can never
prevent itself from being registered/shown in the host. The maintainers decided
to remove it from the API entirely (a breaking change, fine for the next
breaking release).

While preparing that removal I found it **has already landed on `master`** in
commit `818daee` ("Remove `can_load` function from the API. Adobe ignores the
results anyway."). The current tree has zero `can_load` references. What was
still missing was a documented replacement for users migrating off the old hook
-- this PR adds that.

## BREAKING CHANGE (already on master via `818daee`)

For the record, `can_load` was removed end-to-end:

- Trait method `AdobePluginGlobal::can_load(host_name: &str, host_version: &str) -> bool`
  (declaration + doc block in the `define_effect!` macro).
- The gate in the `PluginDataEntryFunction2` entry point that called
  `<$global_type>::can_load(...)` and early-returned `PF_Err_INVALID_CALLBACK`.
- Every example implementation (`background_task`, `checkout`, `color_grid`,
  `convolutrix`, `custom_comp_ui`, `custom_ecw_ui`, `gamma_table`, `histo_grid`,
  `paramarama`, `portable`, `resizer`, `rust_gpu`, `sdk_noise`, `simplest`,
  `supervisor`, `transformer`).

## What this PR changes

A single doc note in the `define_effect!` documentation, in the spot where
`can_load` used to be documented, pointing users to the runtime gating pattern.
No code/behavior change.

## Before / after of a plugin definition

Before:

```rust
impl AdobePluginGlobal for Plugin {
    fn can_load(_host_name: &str, _host_version: &str) -> bool { true }

    fn params_setup(&self, params: &mut ae::Parameters<Params>, in_data: ae::InData, _: ae::OutData) -> Result<(), Error> {
        // ...
    }
}
```

After:

```rust
impl AdobePluginGlobal for Plugin {
    fn params_setup(&self, params: &mut ae::Parameters<Params>, in_data: ae::InData, mut out_data: ae::OutData) -> Result<(), Error> {
        // Host gating now happens at runtime, since can_load is gone:
        if !in_data.is_after_effects() {
            out_data.set_error_msg("This plugin only runs in After Effects.");
            return Err(Error::BadCallbackParameter);
        }
        // ...
    }
}
```

## Recommended replacement

Since the plugin cannot refuse to load, gate at runtime: inspect
`InData::is_after_effects()` (or `InData::is_premiere()`) in `params_setup`/render
and bail out with `OutData::set_error_msg(...)` when running in an unsupported
host.

## Verification

Cross-compiled with `cargo check --target x86_64-pc-windows-gnu` (no linker needed):

- `after-effects` (lib) -- clean
- `after-effects --tests` -- clean
- Examples that used to implement `can_load`: `colorgrid`, `convolutrix`,
  `simplest` -- clean
- Unrelated examples `aegpdemo`, `persisto` -- clean

Only the pre-existing `unused import: crate::*` warnings remain. New intra-doc
links (`InData::is_after_effects`, `InData::is_premiere`,
`OutData::set_error_msg`) resolve without warnings.

Not merging -- for maintainer review.
