### PR TITLE
Fix reachable-panic unwraps (non-breaking) + add justfile/CI gates

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,3 +23,24 @@ jobs:
         run: |
           cargo build
           cargo test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: x86_64-pc-windows-gnu
+      # Both steps below are advisory (continue-on-error) for now: the workspace
+      # has a large pre-existing formatting and clippy backlog. They report
+      # drift without failing CI. Promote them to hard gates (drop
+      # continue-on-error / add `-- -D warnings`) once the backlog is cleared.
+      - name: Check formatting (advisory)
+        continue-on-error: true
+        run: cargo fmt --all -- --check
+      # The workspace does not build on native Linux, so clippy runs against the
+      # Windows target (check/clippy need no linker, only the installed target).
+      - name: Clippy (advisory)
+        continue-on-error: true
+        run: cargo clippy --workspace --all-targets --target x86_64-pc-windows-gnu

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ sdk/
 
 # Cargo.lock should be ignored for libraries
 Cargo.lock
+
+# Coding-standards baseline, cloned locally -- not part of the project.
+.blueprint/

--- a/after-effects/src/drawbot/suites/supplier.rs
+++ b/after-effects/src/drawbot/suites/supplier.rs
@@ -1,4 +1,3 @@
-use crate::*;
 use crate::drawbot::*;
 use ae_sys::DRAWBOT_SupplierRef;
 

--- a/after-effects/src/drawbot/suites/surface.rs
+++ b/after-effects/src/drawbot/suites/surface.rs
@@ -1,4 +1,3 @@
-use crate::*;
 use crate::drawbot::*;
 use ae_sys::DRAWBOT_SurfaceRef;
 

--- a/after-effects/src/pf/parameters.rs
+++ b/after-effects/src/pf/parameters.rs
@@ -715,7 +715,7 @@ impl ArbParamsExtra {
                 let lock = handle.lock()?;
 
                 let serialized = serde_json::to_string::<T>(lock.as_ref()?).map_err(|_| Error::InternalStructDamaged)?;
-                let cstr = std::ffi::CString::new(serialized).unwrap();
+                let cstr = std::ffi::CString::new(serialized).map_err(|_| Error::InternalStructDamaged)?;
 
                 self.as_ref().u.print_size_func_params.print_sizePLu.write(
                     cstr.as_bytes_with_nul().len() as _,
@@ -731,7 +731,7 @@ impl ArbParamsExtra {
                 let lock = handle.lock()?;
 
                 let serialized = serde_json::to_string::<T>(lock.as_ref()?).map_err(|_| Error::InternalStructDamaged)?;
-                let cstr = std::ffi::CString::new(serialized).unwrap();
+                let cstr = std::ffi::CString::new(serialized).map_err(|_| Error::InternalStructDamaged)?;
                 let cstr = cstr.as_bytes_with_nul();
 
                 if cstr.len() <= self.as_ref().u.print_func_params.print_sizeLu as _ && self.as_ref().u.print_func_params.print_flags == 0 {

--- a/after-effects/src/pf/suites/app.rs
+++ b/after-effects/src/pf/suites/app.rs
@@ -108,7 +108,7 @@ impl AppSuite {
     ///
     /// Will return `Error::InterruptCancel` if user cancels dialog. Returned color is in the project's working color space.
     pub fn color_picker_dialog(&self, dialog_title: Option<&str>, sample_color: &pf::PixelF32, use_ws_to_monitor_xform: bool) -> Result<pf::PixelF32, Error> {
-        let dialog_title = dialog_title.map(|s| CString::new(s).unwrap());
+        let dialog_title = dialog_title.map(CString::new).transpose().map_err(|_| Error::InvalidParms)?;
         call_suite_fn_single!(self, PF_AppColorPickerDialog -> ae_sys::PF_PixelFloat, dialog_title.as_ref().map_or(std::ptr::null(), |x| x.as_ptr()), sample_color, use_ws_to_monitor_xform as _)
     }
 
@@ -144,8 +144,8 @@ impl AppSuite {
     /// It won't open the dialog unless it detects a slow render. (2 seconds timeout).
     pub fn create_progress_dialog(&self, title: &str, cancel_str: Option<&str>, indeterminate: bool) -> Result<AppProgressDialog, Error> {
         let v6 = AppSuite6::new()?;
-        let title = widestring::U16CString::from_str(title).unwrap();
-        let cancel_str = cancel_str.map(|s| widestring::U16CString::from_str(s).unwrap());
+        let title = widestring::U16CString::from_str(title).map_err(|_| Error::InvalidParms)?;
+        let cancel_str = cancel_str.map(widestring::U16CString::from_str).transpose().map_err(|_| Error::InvalidParms)?;
         let mut ptr = std::ptr::null_mut();
         call_suite_fn!(v6, PF_CreateNewAppProgressDialog, title.as_ptr(), cancel_str.map_or(std::ptr::null(), |x| x.as_ptr()), indeterminate as _, &mut ptr)?;
         Ok(AppProgressDialog {
@@ -204,8 +204,8 @@ impl AdvAppSuite {
 
     /// Writes text into the After Effects info palette.
     pub fn info_draw_text(&self, line1: &str, line2: &str) -> Result<(), Error> {
-        let line1 = CString::new(line1).unwrap();
-        let line2 = CString::new(line2).unwrap();
+        let line1 = CString::new(line1).map_err(|_| Error::InvalidParms)?;
+        let line2 = CString::new(line2).map_err(|_| Error::InvalidParms)?;
         call_suite_fn!(self, PF_InfoDrawText, line1.as_ptr(), line2.as_ptr())
     }
 
@@ -216,25 +216,25 @@ impl AdvAppSuite {
 
     /// Writes three lines of text into the After Effects info palette.
     pub fn info_draw_text3(&self, line1: &str, line2: &str, line3: &str) -> Result<(), Error> {
-        let line1 = CString::new(line1).unwrap();
-        let line2 = CString::new(line2).unwrap();
-        let line3 = CString::new(line3).unwrap();
+        let line1 = CString::new(line1).map_err(|_| Error::InvalidParms)?;
+        let line2 = CString::new(line2).map_err(|_| Error::InvalidParms)?;
+        let line3 = CString::new(line3).map_err(|_| Error::InvalidParms)?;
         call_suite_fn!(self, PF_InfoDrawText3, line1.as_ptr(), line2.as_ptr(), line3.as_ptr())
     }
 
     /// Writes three lines of text into the After Effects info palette, with portions of the second and third lines left and right justified.
     pub fn info_draw_text3_plus(&self, line1: &str, line2_jr: &str, line2_jl: &str, line3_jr: &str, line3_jl: &str) -> Result<(), Error> {
-        let line1 = CString::new(line1).unwrap();
-        let line2_jr = CString::new(line2_jr).unwrap();
-        let line2_jl = CString::new(line2_jl).unwrap();
-        let line3_jr = CString::new(line3_jr).unwrap();
-        let line3_jl = CString::new(line3_jl).unwrap();
+        let line1 = CString::new(line1).map_err(|_| Error::InvalidParms)?;
+        let line2_jr = CString::new(line2_jr).map_err(|_| Error::InvalidParms)?;
+        let line2_jl = CString::new(line2_jl).map_err(|_| Error::InvalidParms)?;
+        let line3_jr = CString::new(line3_jr).map_err(|_| Error::InvalidParms)?;
+        let line3_jl = CString::new(line3_jl).map_err(|_| Error::InvalidParms)?;
         call_suite_fn!(self, PF_InfoDrawText3Plus, line1.as_ptr(), line2_jr.as_ptr(), line2_jl.as_ptr(), line3_jr.as_ptr(), line3_jl.as_ptr())
     }
 
     /// Appends characters to the currently-displayed info text.
     pub fn append_info_text(&self, append: &str) -> Result<(), Error> {
-        let append = CString::new(append).unwrap();
+        let append = CString::new(append).map_err(|_| Error::InvalidParms)?;
         call_suite_fn!(self, PF_AppendInfoText, append.as_ptr())
     }
 }
@@ -507,6 +507,9 @@ impl AppProgressDialog {
 }
 impl Drop for AppProgressDialog {
     fn drop(&mut self) {
-        call_suite_fn!(self, PF_DisposeAppProgressDialog, self.ptr).unwrap();
+        // `Drop::drop` cannot return a `Result`, so a real FFI error here cannot
+        // be propagated. Ignore it rather than `.unwrap()`, which would panic
+        // (potentially during unwinding, aborting the process).
+        let _ = call_suite_fn!(self, PF_DisposeAppProgressDialog, self.ptr);
     }
 }

--- a/justfile
+++ b/justfile
@@ -1,0 +1,46 @@
+# after-effects justfile
+# Run `just --list` to see all available commands.
+#
+# NOTE: this workspace does NOT build on native Linux (the Adobe SDK FFI
+# targets Windows/macOS). The compiling recipes therefore default to the
+# Windows target `x86_64-pc-windows-gnu`, which only needs the target
+# installed (`rustup target add x86_64-pc-windows-gnu`) -- no linker/SDK.
+# Override the target from the command line, e.g.:
+#   just TARGET=x86_64-apple-darwin check
+TARGET := "x86_64-pc-windows-gnu"
+
+# Default recipe: show available commands.
+default:
+    @just --list
+
+# Common aliases.
+alias c := check
+alias f := fmt
+alias l := lint
+
+# Aggregate: what CI runs. Uses non-fixing variants.
+ci: fmt-check check lint-check test
+
+# Type-check the whole workspace (all targets) for the chosen target.
+check:
+    cargo check --workspace --all-targets --target {{TARGET}}
+
+# Run clippy with autofix (modifies working tree).
+lint:
+    cargo clippy --fix --allow-dirty --allow-staged --workspace --all-targets --target {{TARGET}} -- -D warnings
+
+# Advisory today (pre-existing backlog): does not yet pass with `-D warnings`.
+lint-check:
+    cargo clippy --workspace --all-targets --target {{TARGET}}
+
+# Format code (modifies working tree). Needs no compile, so no target.
+fmt:
+    cargo fmt --all
+
+# Verify formatting without writing (CI-safe). Needs no compile.
+fmt-check:
+    cargo fmt --all -- --check
+
+# Run the test suite for the chosen target.
+test:
+    cargo test --workspace --target {{TARGET}}


### PR DESCRIPTION
## Summary

Non-breaking blueprint-vet cleanup. Every change is source-compatible: no
public signature changed, no public items added/removed/renamed, no enum
variants added.

## 1. Reachable-panic unwraps -> error propagation

Replaced `.unwrap()` on fallible string conversions with `?` into existing
`Error` variants (no new variants). All the enclosing functions already
returned `Result<_, Error>`, so this is purely internal.

Before/after (representative):

```rust
// before -- panics on an interior NUL byte in caller-supplied text
let append = CString::new(append).unwrap();
// after
let append = CString::new(append).map_err(|_| Error::InvalidParms)?;
```

Sites fixed (all non-breaking):

- `pf/suites/app.rs`: `color_picker_dialog`, `create_progress_dialog`
  (`U16CString::from_str`), `info_draw_text`, `info_draw_text3`,
  `info_draw_text3_plus`, `append_info_text` -> `Error::InvalidParms`.
- `pf/parameters.rs`: the two `CString::new(serialized)` sites in
  `ArbParamsExtra` -> `Error::InternalStructDamaged`.
- `pf/suites/app.rs` `AppProgressDialog::drop`: `Drop` cannot return a
  `Result`, so `.unwrap()` there could panic during unwinding. The FFI result
  is now ignored explicitly (`let _ = ...`) with a comment. (Propagating with
  `?` is impossible in `Drop`.)

## 2. Unused imports

Removed the unused `use crate::*;` from `drawbot/suites/supplier.rs` and
`drawbot/suites/surface.rs` (verified unused on the Windows target). Clears the
two outstanding `unused_imports` warnings.

## 3. Tooling/CI

- Added a root `justfile` (`check`, `lint`, `lint-check`, `fmt`, `fmt-check`,
  `test`, `ci`). Compiling recipes default to `x86_64-pc-windows-gnu` because
  the workspace does not build on native Linux; override with `TARGET=...`.
- Added a `lint` job to `.github/workflows/test.yaml` running
  `cargo fmt --all -- --check` and `cargo clippy` against the Windows target.
  Both are **advisory** (`continue-on-error`) for now -- see deferred section.
- Ignored the locally-cloned `.blueprint/` baseline in `.gitignore`.

## Deferred (needs breaking change/larger scope)

- **Unwrap sites whose fix would be breaking** (enclosing fn returns a plain
  value, so adding `?` would change the signature). Left untouched:
  - `pf/parameters.rs` `CheckBoxDef::set_label` (`-> &mut Self`, l.192) and
    `CheckBoxDef::label` (`-> &str`, l.197, `CStr::from_ptr(..).to_str()`).
  - `pf/parameters.rs` `PopupDef::set_options` (`-> ()`, l.416 + the
    `try_into().unwrap()` at l.418) and `PopupDef::options`
    (`-> Vec<&str>`, l.421, `CStr::from_ptr(..).to_str()`).
- **`cargo fmt --all -- --check` hard gate**: the committed tree is not
  rustfmt-clean under the available toolchains (~1699 diff hunks even on the
  pinned nightly; `rustfmt.toml` uses unstable options the code never matched).
  Reformatting would touch ~126 files / ~46k lines -- out of scope for a
  minimal non-breaking PR -- so the fmt step is advisory for now.
- **`cargo clippy -- -D warnings` hard gate**: ~184 pre-existing warnings in
  `after-effects` plus 4 deny-by-default `clippy::mut_from_ref` correctness
  errors (`pf/handles.rs`, `pf/layer.rs` x3), and more in `pipl`/`premiere`.
  Fixing these (and the `mut_from_ref` ones likely need signature changes) is a
  separate effort; clippy is advisory for now.
- **`get_*` getter renames, multi-bool param ergonomics, and a full
  microtypography pass**: intentionally out of scope here.

Do not merge without review.
