### PR TITLE
refactor(api): rename get_* getters per Rust API Guidelines (deprecation path)

### DIFF
--- a/after-effects/src/aegp/suites/command.rs
+++ b/after-effects/src/aegp/suites/command.rs
@@ -59,8 +59,16 @@ impl CommandSuite {
     /// Obtain a unique command identifier. Use the Register Suite to register a handler for the command.
     ///
     /// Note: On occasion After Effects will send command 0 (zero), so don't use that as part of your command handling logic.
-    pub fn get_unique_command(&self) -> Result<AEGP_Command, Error> {
+    pub fn unique_command(&self) -> Result<AEGP_Command, Error> {
         call_suite_fn_single!(self, AEGP_GetUniqueCommand -> ae_sys::AEGP_Command)
+    }
+
+    /// Obtain a unique command identifier. Use the Register Suite to register a handler for the command.
+    ///
+    /// Note: On occasion After Effects will send command 0 (zero), so don't use that as part of your command handling logic.
+    #[deprecated(since = "0.5.0", note = "renamed to `unique_command`")]
+    pub fn get_unique_command(&self) -> Result<AEGP_Command, Error> {
+        self.unique_command()
     }
 
     /// Set menu name of a command.

--- a/after-effects/src/aegp/suites/persistent_data.rs
+++ b/after-effects/src/aegp/suites/persistent_data.rs
@@ -131,7 +131,7 @@ impl PersistentDataSuite {
         buffer_to_string(out_data)
     }
 
-    pub fn get_data_handle<'a, T>(
+    pub fn data_handle<'a, T>(
         &self,
         plugin_id: PluginId,
         blob_handle: PersistentBlobHandle,
@@ -152,8 +152,20 @@ impl PersistentDataSuite {
         MemHandle::from_raw(handle)
     }
 
+    #[deprecated(since = "0.5.0", note = "renamed to `data_handle`")]
+    pub fn get_data_handle<'a, T>(
+        &self,
+        plugin_id: PluginId,
+        blob_handle: PersistentBlobHandle,
+        section_key: &str,
+        value_key: &str,
+        default: MemHandle<'a, T>,
+    ) -> Result<MemHandle<'_, T>, Error> {
+        self.data_handle(plugin_id, blob_handle, section_key, value_key, default)
+    }
+
     /// Obtains the data located at a given section's value.
-    pub fn get_data(
+    pub fn data(
         &self,
         blob_handle: PersistentBlobHandle,
         section_key: &str,
@@ -180,11 +192,24 @@ impl PersistentDataSuite {
         Ok(ptr)
     }
 
+    /// Obtains the data located at a given section's value.
+    #[deprecated(since = "0.5.0", note = "renamed to `data`")]
+    pub fn get_data(
+        &self,
+        blob_handle: PersistentBlobHandle,
+        section_key: &str,
+        value_key: &str,
+        data_size: u32,
+        default: *const c_void,
+    ) -> Result<*mut c_void, Error> {
+        self.data(blob_handle, section_key, value_key, data_size, default)
+    }
+
     /// Obtains the string for a given section key's value
     ///
     /// Note: This interperets all stored strings as UTF-8. This is safe if you are retrieving
     /// strings stored from rust, which must be UTF-8.
-    pub fn get_string(
+    pub fn string(
         &self,
         blob_handle: PersistentBlobHandle,
         section_key: &str,
@@ -215,7 +240,23 @@ impl PersistentDataSuite {
         buffer_to_string(out_data)
     }
 
-    pub fn get_long(
+    /// Obtains the string for a given section key's value
+    ///
+    /// Note: This interperets all stored strings as UTF-8. This is safe if you are retrieving
+    /// strings stored from rust, which must be UTF-8.
+    #[deprecated(since = "0.5.0", note = "renamed to `string`")]
+    pub fn get_string(
+        &self,
+        blob_handle: PersistentBlobHandle,
+        section_key: &str,
+        value_key: &str,
+        default: &str,
+        max_result_length: usize,
+    ) -> Result<String, Error> {
+        self.string(blob_handle, section_key, value_key, default, max_result_length)
+    }
+
+    pub fn long(
         &self,
         blob_handle: PersistentBlobHandle,
         section_key: &str,
@@ -235,7 +276,18 @@ impl PersistentDataSuite {
         )
     }
 
-    pub fn get_fp_long(
+    #[deprecated(since = "0.5.0", note = "renamed to `long`")]
+    pub fn get_long(
+        &self,
+        blob_handle: PersistentBlobHandle,
+        section_key: &str,
+        value_key: &str,
+        default: i32,
+    ) -> Result<i32, Error> {
+        self.long(blob_handle, section_key, value_key, default)
+    }
+
+    pub fn fp_long(
         &self,
         blob_handle: PersistentBlobHandle,
         section_key: &str,
@@ -255,7 +307,18 @@ impl PersistentDataSuite {
         )
     }
 
-    pub fn get_time(
+    #[deprecated(since = "0.5.0", note = "renamed to `fp_long`")]
+    pub fn get_fp_long(
+        &self,
+        blob_handle: PersistentBlobHandle,
+        section_key: &str,
+        value_key: &str,
+        default: f64,
+    ) -> Result<f64, Error> {
+        self.fp_long(blob_handle, section_key, value_key, default)
+    }
+
+    pub fn time(
         &self,
         blob_handle: PersistentBlobHandle,
         section_key: &str,
@@ -281,7 +344,18 @@ impl PersistentDataSuite {
         .map(|t| t.into())
     }
 
-    pub fn get_argb(
+    #[deprecated(since = "0.5.0", note = "renamed to `time`")]
+    pub fn get_time(
+        &self,
+        blob_handle: PersistentBlobHandle,
+        section_key: &str,
+        value_key: &str,
+        default: Time,
+    ) -> Result<Time, Error> {
+        self.time(blob_handle, section_key, value_key, default)
+    }
+
+    pub fn argb(
         &self,
         blob_handle: PersistentBlobHandle,
         section_key: &str,
@@ -299,6 +373,17 @@ impl PersistentDataSuite {
             value_key.as_ptr(),
             &default
         )
+    }
+
+    #[deprecated(since = "0.5.0", note = "renamed to `argb`")]
+    pub fn get_argb(
+        &self,
+        blob_handle: PersistentBlobHandle,
+        section_key: &str,
+        value_key: &str,
+        default: PF_PixelFloat,
+    ) -> Result<PF_PixelFloat, Error> {
+        self.argb(blob_handle, section_key, value_key, default)
     }
 
     // Sets the given section key's value to the handle passed in.

--- a/after-effects/src/aegp/suites/render_queue.rs
+++ b/after-effects/src/aegp/suites/render_queue.rs
@@ -60,10 +60,16 @@ impl RenderQueueSuite {
             AEGP_RenderQueueState  *stateP);
     */
     /// Obtains the current render queue state.
-    pub fn get_render_queue_state(&self) -> Result<RenderQueueState, Error> {
+    pub fn render_queue_state(&self) -> Result<RenderQueueState, Error> {
         Ok(
             call_suite_fn_single!(self, AEGP_GetRenderQueueState -> ae_sys::AEGP_RenderQueueState)?
                 .into(),
         )
+    }
+
+    /// Obtains the current render queue state.
+    #[deprecated(since = "0.5.0", note = "renamed to `render_queue_state`")]
+    pub fn get_render_queue_state(&self) -> Result<RenderQueueState, Error> {
+        self.render_queue_state()
     }
 }

--- a/examples/aegp/src/lib.rs
+++ b/examples/aegp/src/lib.rs
@@ -29,7 +29,7 @@ impl AegpPlugin for Grabber {
         let res: Result<(), Error> = (|| {
             let command_suite = Command::new()?;
             let register_suite = Register::new()?;
-            let grabba_cmd = command_suite.get_unique_command()?;
+            let grabba_cmd = command_suite.unique_command()?;
 
             command_suite.insert_command(
                 "Grabber",

--- a/examples/persisto/src/lib.rs
+++ b/examples/persisto/src/lib.rs
@@ -36,7 +36,7 @@ impl AegpPlugin for Persisto {
         let register_suite = Register::new()?;
 
         // Get unique command ID
-        let persisto_cmd = command_suite.get_unique_command()?;
+        let persisto_cmd = command_suite.unique_command()?;
 
         // Insert menu command
         command_suite.insert_command(MENU_ITEM, persisto_cmd, MenuId::File, MenuOrder::Sorted)?;
@@ -106,7 +106,7 @@ fn handle_persisto_command(plugin_id: AEGP_PluginID) -> Result<(), Error> {
     let found_my_stuff = persistent_suite.does_key_exist(blob, SECTION_KEY, VALUE_KEY_1)?;
 
     // Get or set the float value
-    let value = persistent_suite.get_fp_long(blob, SECTION_KEY, VALUE_KEY_1, DEFAULT_FUZZINESS)?;
+    let value = persistent_suite.fp_long(blob, SECTION_KEY, VALUE_KEY_1, DEFAULT_FUZZINESS)?;
 
     // Report status to user
     let message = if found_my_stuff && (value - DEFAULT_FUZZINESS).abs() < 0.0001 {
@@ -121,7 +121,7 @@ fn handle_persisto_command(plugin_id: AEGP_PluginID) -> Result<(), Error> {
 
     let buffer_size = 256;
     let string_value =
-        persistent_suite.get_string(blob, SECTION_KEY, VALUE_KEY_2, DEFAULT_STRING, buffer_size)?;
+        persistent_suite.string(blob, SECTION_KEY, VALUE_KEY_2, DEFAULT_STRING, buffer_size)?;
 
     log::debug!("String value: {}", string_value);
 
@@ -157,11 +157,11 @@ fn demonstrate_persistence_features(
 
     // Get String
     let string =
-        persistent_suite.get_string(blob, demo_section, "name", "Error - Key should exist", 256)?;
+        persistent_suite.string(blob, demo_section, "name", "Error - Key should exist", 256)?;
 
     log::debug!("Inserted string `Persisto Demo` into `name` --- retrieved: {string}");
 
-    let string = persistent_suite.get_string(
+    let string = persistent_suite.string(
         blob,
         demo_section,
         "utf-8",
@@ -171,7 +171,7 @@ fn demonstrate_persistence_features(
 
     log::debug!("Inserted string `utf-8 牛奶` into key `utf-8` --- retrieved: {string}");
 
-    let string = persistent_suite.get_string(
+    let string = persistent_suite.string(
         blob,
         demo_section,
         "whitespace",

--- a/examples/queuebert/src/lib.rs
+++ b/examples/queuebert/src/lib.rs
@@ -33,7 +33,7 @@ impl AegpPlugin for QueueBert {
         let res: Result<(), Error> = (|| {
             let command_suite = Command::new()?;
             let register_suite = Register::new()?;
-            let queuebert_cmd = command_suite.get_unique_command()?;
+            let queuebert_cmd = command_suite.unique_command()?;
 
             command_suite.insert_command(
                 "QueueBert",
@@ -296,7 +296,7 @@ fn handle_queuebert_command() -> Result<(), Error> {
     }
 
     // Log the current render queue state
-    let rq_state = rq_suite.get_render_queue_state()?;
+    let rq_state = rq_suite.render_queue_state()?;
     log::info!("QueueBert: Render queue state: {:?}", rq_state);
 
     log::info!("QueueBert: Command completed successfully");

--- a/premiere/src/suites/window.rs
+++ b/premiere/src/suites/window.rs
@@ -17,8 +17,15 @@ impl WindowSuite {
 
     /// Returns a handle to the main application window-- a `HWND` on Windows and a `*mut NSView` on macOS.
     /// These correspond to the `Win32WindowHandle` and `AppKitWindowHandle` types in the `raw-window-handle` crate.
-    pub fn get_main_window(&self) -> prWnd {
+    pub fn main_window(&self) -> prWnd {
         call_suite_fn_no_err!(self, GetMainWindow, )
+    }
+
+    /// Returns a handle to the main application window-- a `HWND` on Windows and a `*mut NSView` on macOS.
+    /// These correspond to the `Win32WindowHandle` and `AppKitWindowHandle` types in the `raw-window-handle` crate.
+    #[deprecated(since = "0.5.0", note = "renamed to `main_window`")]
+    pub fn get_main_window(&self) -> prWnd {
+        self.main_window()
     }
 
     /// Updates all windows. Windows only, doesn’t work on Mac OS.


### PR DESCRIPTION
## API change -- deprecations (source-compatible)

The blueprint vet flagged 13 `pub fn get_*` methods that violate the Rust
API Guidelines (getters omit the `get_` prefix). Per `api-changes.md`, a
breaking API change needs a deprecation path rather than a silent rename,
so this PR renames the getters **and keeps the old names working** as
`#[deprecated]` wrappers.

### Renames (old -> new)

PersistentDataSuite (`after-effects/src/aegp/suites/persistent_data.rs`):
- `get_data_handle` -> `data_handle`
- `get_data` -> `data`
- `get_string` -> `string`
- `get_long` -> `long`
- `get_fp_long` -> `fp_long`
- `get_time` -> `time`
- `get_argb` -> `argb`

RenderQueueSuite (`after-effects/src/aegp/suites/render_queue.rs`):
- `get_render_queue_state` -> `render_queue_state`

CommandSuite (`after-effects/src/aegp/suites/command.rs`):
- `get_unique_command` -> `unique_command`

WindowSuite (`premiere/src/suites/window.rs`):
- `get_main_window` -> `main_window`

### Left unchanged (intentionally)

Collection/index-style accessors in `after-effects/src/pf/parameters.rs`
keep their names, which the API Guidelines explicitly permit:
- `get`, `get_mut`, `get_at`, `get_mut_at`

### Compatibility

- The old `get_*` names still compile and work; they are now
  `#[deprecated(since = "0.5.0", note = "renamed to \`<new>\`")]` thin
  wrappers that forward to the new methods.
- They will be removed in a future breaking release.
- `since` uses `0.5.0` -- the next release after the current `0.4.0`
  crate version, per the public-API-change versioning in `api-changes.md`.

### Migration

All internal callers and every `examples/*` use of these methods have
been updated to the new names, so the workspace builds **without emitting
any deprecation warnings**.

### Verification

- `cargo check --workspace --target x86_64-pc-windows-gnu` -- passes
- `cargo check --workspace --tests --target x86_64-pc-windows-gnu` -- passes
- No `deprecated` warnings from workspace or examples
- New/changed lines are rustfmt-clean (`rustfmt --edition 2024 --check`
  reports no diffs on any renamed method or wrapper)

Note: the diff is deliberately scoped to the rename. Generated
`bindings_*.rs` are exempt and untouched.

Refs: blueprint vet (Rust API Guidelines, C-GETTER) + `api-changes.md`.