### PR TITLE
Add behavioral coverage for error message fallback

### DIFF
--- a/after-effects/src/pf/out_data.rs
+++ b/after-effects/src/pf/out_data.rs
@@ -84,6 +84,15 @@ impl OutData {
         self.set_out_flag(OutFlags::DisplayErrorMessage, true);
     }
 
+    /// Sets an error message only if the plug-in has not already supplied one.
+    pub fn set_error_msg_if_empty(&mut self, msg: &str) {
+        if self.has_return_msg() {
+            self.set_out_flag(OutFlags::DisplayErrorMessage, true);
+        } else {
+            self.set_error_msg(msg);
+        }
+    }
+
     /// Set this flag to the version of your plug-in code. After Effects uses this data to decide which of duplicate effects to load.
     pub fn set_version(&mut self, v: u32) {
         self.as_mut().my_version = v as ae_sys::A_u_long;
@@ -135,6 +144,12 @@ impl OutData {
 mod tests {
     use super::*;
 
+    fn return_msg(raw: &ae_sys::PF_OutData) -> &str {
+        unsafe { std::ffi::CStr::from_ptr(raw.return_msg.as_ptr()) }
+            .to_str()
+            .unwrap()
+    }
+
     #[test]
     fn return_message_is_nul_terminated_and_detectable() {
         let mut raw: ae_sys::PF_OutData = unsafe { std::mem::zeroed() };
@@ -153,6 +168,26 @@ mod tests {
         let out = OutData::from_raw(&mut raw);
 
         assert!(!out.has_return_msg());
+    }
+
+    #[test]
+    fn error_fallback_preserves_existing_message_and_fills_empty_buffer() {
+        let display_error: ae_sys::PF_OutFlags = OutFlags::DisplayErrorMessage.into();
+
+        let mut existing: ae_sys::PF_OutData = unsafe { std::mem::zeroed() };
+        let mut out = OutData::from_raw(&mut existing);
+        out.set_return_msg("custom error");
+        out.set_error_msg_if_empty("fallback");
+
+        assert_eq!(return_msg(&existing), "custom error");
+        assert_ne!(existing.out_flags & display_error, 0);
+
+        let mut empty: ae_sys::PF_OutData = unsafe { std::mem::zeroed() };
+        let mut out = OutData::from_raw(&mut empty);
+        out.set_error_msg_if_empty("fallback");
+
+        assert_eq!(return_msg(&empty), "fallback");
+        assert_ne!(empty.out_flags & display_error, 0);
     }
 }
 

--- a/after-effects/src/plugin_base.rs
+++ b/after-effects/src/plugin_base.rs
@@ -511,11 +511,7 @@ macro_rules! define_effect {
 
                         if e != Error::InterruptCancel && !out_data_ptr.is_null() {
                             let mut out_data = $crate::OutData::from_raw(out_data_ptr);
-                            if !out_data.has_return_msg() {
-                                out_data.set_error_msg(&format!("EffectMain returned error: {e:?}"));
-                            } else {
-                                out_data.set_out_flag($crate::OutFlags::DisplayErrorMessage, true);
-                            }
+                            out_data.set_error_msg_if_empty(&format!("EffectMain returned error: {e:?}"));
                         }
 
                         e as $crate::sys::PF_Err
@@ -662,17 +658,5 @@ mod tests {
         assert!(body.contains("const AE_PLUGIN_DATA_ENTRY_RESERVED_INFO: i32 = 8;"));
         assert!(body.contains("AE_PLUGIN_DATA_ENTRY_RESERVED_INFO,"));
         assert!(!body.contains("env!(\"PIPL_AE_RESERVED\")"));
-    }
-
-    #[test]
-    fn effect_main_preserves_plugin_return_message_on_error() {
-        let source = include_str!("plugin_base.rs");
-        let error_branch = source
-            .split("Ok(Err(e)) =>")
-            .nth(1)
-            .and_then(|tail| tail.split("Err(e) =>").next())
-            .expect("caught EffectMain error branch");
-
-        assert!(error_branch.contains("!out_data.has_return_msg()"));
     }
 }


### PR DESCRIPTION
## Summary

Add behavioral regression coverage for the plug-in error-message preservation introduced in #111.

## Why

The previous test inspected `plugin_base.rs` as text and asserted on one implementation string. It was reintroduced when #110 merged and now fails on harmless refactoring without proving the runtime policy works.

## What changed

- Move the existing preserve-or-fallback policy into `OutData::set_error_msg_if_empty`.
- Keep `has_return_msg` public and backward compatible.
- Exercise both populated and empty return buffers and verify the exact message plus `DisplayErrorMessage`.
- Remove only the source-scraping error-message test; the unrelated reserved-info test remains.

There is no intended runtime behavior change.

## Validation

- `cargo test -p after-effects`
- `cargo check -p after-effects`
- Independent code review found no remaining Critical or Important issues.
