### PR TITLE
refactor(api): replace multi-bool params with descriptive enums [BREAKING]

### DIFF
--- a/after-effects/src/aegp/mod.rs
+++ b/after-effects/src/aegp/mod.rs
@@ -105,6 +105,8 @@ pub use suites::item::{
     ItemHandle,
     ItemType,
     LabelId,
+    ItemSelection,
+    DeselectOthers,
 };
 pub use suites::keyframe::{
     Keyframes,
@@ -181,6 +183,8 @@ pub use suites::stream::{
     StreamType,
     StreamValue,
     TextDocumentHandle,
+    Undoable,
+    FlagValue,
 };
 pub use suites::utility::GetPathTypes;
 pub use suites::world::{

--- a/after-effects/src/aegp/suites/item.rs
+++ b/after-effects/src/aegp/suites/item.rs
@@ -2,6 +2,20 @@ use crate::*;
 use crate::aegp::*;
 use ae_sys::AEGP_ItemH;
 
+/// Whether to select or deselect the item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ItemSelection { Select, Deselect }
+impl From<bool> for ItemSelection {
+    fn from(b: bool) -> Self { if b { Self::Select } else { Self::Deselect } }
+}
+
+/// Whether to deselect all other items first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeselectOthers { Yes, No }
+impl From<bool> for DeselectOthers {
+    fn from(b: bool) -> Self { if b { Self::Yes } else { Self::No } }
+}
+
 define_suite!(
     /// Accesses and modifies items within a project or composition.
     ///
@@ -60,8 +74,8 @@ impl ItemSuite {
     /// This call selects items in the Project panel.
     ///
     /// To make selections in the Composition panel, use [`suites::Comp:set_selection()`](aegp::suites::Comp::set_selection).
-    pub fn select_item(&self, item_handle: impl AsPtr<AEGP_ItemH>, select: bool, deselect_others: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SelectItem, item_handle.as_ptr(), select.into(), deselect_others.into())
+    pub fn select_item(&self, item_handle: impl AsPtr<AEGP_ItemH>, select: ItemSelection, deselect_others: DeselectOthers) -> Result<(), Error> {
+        call_suite_fn!(self, AEGP_SelectItem, item_handle.as_ptr(), matches!(select, ItemSelection::Select).into(), matches!(deselect_others, DeselectOthers::Yes).into())
     }
 
     /// Gets type of an item. Note: solids don't appear in the project, but can be the source to a layer.
@@ -280,7 +294,7 @@ define_suite_item_wrapper!(
         /// This call selects items in the Project panel.
         ///
         /// To make selections in the Composition panel, use [`suites::Comp:set_selection()`](aegp::suites::Comp::set_selection).
-        select(select: bool, deselect_others: bool) -> () => suite.select_item,
+        select(select: ItemSelection, deselect_others: DeselectOthers) -> () => suite.select_item,
 
         /// Gets type of an item. Note: solids don't appear in the project, but can be the source to a layer.
         item_type() -> ItemType => suite.item_type,

--- a/after-effects/src/aegp/suites/stream.rs
+++ b/after-effects/src/aegp/suites/stream.rs
@@ -2,6 +2,20 @@ use crate::*;
 use crate::aegp::*;
 use ae_sys::{ AEGP_LayerH, AEGP_MaskRefH, AEGP_StreamRefH, AEGP_EffectRefH};
 
+/// Whether a stream change is added to the undo stack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Undoable { Undoable, NotUndoable }
+impl From<bool> for Undoable {
+    fn from(b: bool) -> Self { if b { Self::Undoable } else { Self::NotUndoable } }
+}
+
+/// Whether a dynamic stream flag is set (enabled) or cleared (disabled).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlagValue { Enabled, Disabled }
+impl From<bool> for FlagValue {
+    fn from(b: bool) -> Self { if b { Self::Enabled } else { Self::Disabled } }
+}
+
 define_suite!(
     /// Access and manipulate the values of a layer's streams. For paint and text streams, use [`DynamicStreamSuite`] instead.
     StreamSuite,
@@ -276,9 +290,9 @@ impl DynamicStreamSuite {
     ///
     /// This call may be used to dynamically show or hide parameters, by setting and clearing [`DynamicStreamFlags::Hidden`].
     /// However, [`DynamicStreamFlags::Disabled`] may not be set.
-    pub fn set_dynamic_stream_flag(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, flag: DynamicStreamFlags, undoable: bool, enabled: bool) -> Result<(), Error> {
+    pub fn set_dynamic_stream_flag(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, flag: DynamicStreamFlags, undoable: Undoable, enabled: FlagValue) -> Result<(), Error> {
         debug_assert_eq!(flag.bits().count_ones(), 1, "AEGP_SetDynamicStreamFlag expects a single flag");
-        call_suite_fn!(self, AEGP_SetDynamicStreamFlag, stream_ref.as_ptr(), flag.bits(), undoable as _, enabled as _)
+        call_suite_fn!(self, AEGP_SetDynamicStreamFlag, stream_ref.as_ptr(), flag.bits(), matches!(undoable, Undoable::Undoable) as _, matches!(enabled, FlagValue::Enabled) as _)
     }
 
     /// Retrieves a sub-stream by index from a given [`StreamReferenceHandle`]. Cannot be used on streams of type [`StreamGroupingType::Leaf`].
@@ -1033,7 +1047,7 @@ define_suite_item_wrapper!(
         ///
         /// This call may be used to dynamically show or hide parameters, by setting and clearing [`DynamicStreamFlags::Hidden`].
         /// However, [`DynamicStreamFlags::Disabled`] may not be set.
-        set_dynamic_stream_flag(flag: DynamicStreamFlags, undoable: bool, enabled: bool) -> () => dynamic.set_dynamic_stream_flag,
+        set_dynamic_stream_flag(flag: DynamicStreamFlags, undoable: Undoable, enabled: FlagValue) -> () => dynamic.set_dynamic_stream_flag,
 
         /// Retrieves a sub-stream by index from a given [`Stream`]. Cannot be used on streams of type [`StreamGroupingType::Leaf`].
         new_stream_by_index(plugin_id: PluginId, index: i32) -> StreamReferenceHandle => dynamic.new_stream_ref_by_index,

--- a/after-effects/src/pf/effect.rs
+++ b/after-effects/src/pf/effect.rs
@@ -76,7 +76,7 @@ define_suite_item_wrapper!(
         /// Retrieves the original (non-interpreted, un-re-timed) frame rate, of the media to which the effect instance is applied.
         original_clip_frame_rate()                                      ->  PrTime => pf_utility.original_clip_frame_rate,
         /// Retrieves the source media timecode for the specified frame within the specified layer, with or without transforms and start time offsets applied.
-        source_track_media_timecode(layer_param_index: u32, apply_transform: bool, add_start_time_offset: bool)  ->  A_long => pf_utility.source_track_media_timecode,
+        source_track_media_timecode(layer_param_index: u32, apply_transform: pf::suites::utility::ApplyTransform, add_start_time_offset: pf::suites::utility::AddStartTimeOffset)  ->  A_long => pf_utility.source_track_media_timecode,
         /// Retrieves the name of the layer in use by the effect instance.
         source_track_clip_name(layer_param_index: u32, get_master_clip_name: bool)                               ->  String => pf_utility.source_track_clip_name,
         /// Retrieves the file name of the source track item for the specified layer parameter.
@@ -88,7 +88,7 @@ define_suite_item_wrapper!(
         /// Returns a tuple containing `(current_frame, time_display)`
         media_timecode2(apply_trim: bool)                                                                        ->  (i32, PF_TimeDisplay) => pf_utility.media_timecode2,
         /// Given a specific sequence time, retrieves the source track media timecode for the specified layer parameter.
-        source_track_media_timecode2(layer_param_index: u32, apply_transform: bool, add_start_time_offset: bool, sequence_time: PrTime) -> A_long => pf_utility.source_track_media_timecode2,
+        source_track_media_timecode2(layer_param_index: u32, apply_transform: pf::suites::utility::ApplyTransform, add_start_time_offset: pf::suites::utility::AddStartTimeOffset, sequence_time: PrTime) -> A_long => pf_utility.source_track_media_timecode2,
         /// Retrieves the clip name used by the specific layer parameter.
         source_track_clip_name2(layer_param_index: u32, get_master_clip_name: bool, sequence_time: PrTime)       ->  String => pf_utility.source_track_clip_name2,
         /// Retrieves the clip name in use by the specified layer parameter.

--- a/after-effects/src/pf/mod.rs
+++ b/after-effects/src/pf/mod.rs
@@ -58,6 +58,7 @@ pub mod suites {
 }
 
 pub use suites::adv_item::Step;
+pub use suites::utility::{ ApplyTransform, AddStartTimeOffset };
 pub use suites::app::{
     AppColorType,
     AppPersonalTextInfo,

--- a/after-effects/src/pf/suites/utility.rs
+++ b/after-effects/src/pf/suites/utility.rs
@@ -1,6 +1,20 @@
 use crate::*;
 use ae_sys::*;
 
+/// Whether layer transforms are applied to the returned timecode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyTransform { Yes, No }
+impl From<bool> for ApplyTransform {
+    fn from(b: bool) -> Self { if b { Self::Yes } else { Self::No } }
+}
+
+/// Whether the layer's start-time offset is added to the returned timecode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddStartTimeOffset { Yes, No }
+impl From<bool> for AddStartTimeOffset {
+    fn from(b: bool) -> Self { if b { Self::Yes } else { Self::No } }
+}
+
 define_suite!(
     /// Utility functions for use by AE style effect plugins, running in Premiere Pro.
     UtilitySuite,
@@ -103,8 +117,8 @@ impl UtilitySuite {
     }
 
     /// Retrieves the source media timecode for the specified frame within the specified layer, with or without transforms and start time offsets applied.
-    pub fn source_track_media_timecode(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, apply_transform: bool, add_start_time_offset: bool) -> Result<A_long, Error> {
-        call_suite_fn_single!(self, GetSourceTrackMediaTimecode -> A_long, effect_ref.as_ptr(), layer_param_index, apply_transform, add_start_time_offset)
+    pub fn source_track_media_timecode(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, apply_transform: ApplyTransform, add_start_time_offset: AddStartTimeOffset) -> Result<A_long, Error> {
+        call_suite_fn_single!(self, GetSourceTrackMediaTimecode -> A_long, effect_ref.as_ptr(), layer_param_index, matches!(apply_transform, ApplyTransform::Yes), matches!(add_start_time_offset, AddStartTimeOffset::Yes))
     }
 
     /// Retrieves the name of the layer in use by the effect instance.
@@ -130,8 +144,8 @@ impl UtilitySuite {
     }
 
     /// Given a specific sequence time, retrieves the source track media timecode for the specified layer parameter.
-    pub fn source_track_media_timecode2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, apply_transform: bool, add_start_time_offset: bool, sequence_time: PrTime) -> Result<A_long, Error> {
-        call_suite_fn_single!(self, GetSourceTrackMediaTimecode2 -> A_long, effect_ref.as_ptr(), layer_param_index, apply_transform, add_start_time_offset, sequence_time)
+    pub fn source_track_media_timecode2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, apply_transform: ApplyTransform, add_start_time_offset: AddStartTimeOffset, sequence_time: PrTime) -> Result<A_long, Error> {
+        call_suite_fn_single!(self, GetSourceTrackMediaTimecode2 -> A_long, effect_ref.as_ptr(), layer_param_index, matches!(apply_transform, ApplyTransform::Yes), matches!(add_start_time_offset, AddStartTimeOffset::Yes), sequence_time)
     }
 
     /// Retrieves the clip name used by the specific layer parameter.

--- a/examples/supervisor/src/lib.rs
+++ b/examples/supervisor/src/lib.rs
@@ -325,9 +325,9 @@ impl AdobePluginInstance for Instance {
                         let checkbox_stream = me.new_stream_by_index(plugin_id, params.index(Params::Checkbox).unwrap() as _)?;
 
                         // Toggle visibility of parameters
-                        color_stream   .set_dynamic_stream_flag(ae::aegp::DynamicStreamFlags::Hidden, false, hide_them)?;
-                        slider_stream  .set_dynamic_stream_flag(ae::aegp::DynamicStreamFlags::Hidden, false, hide_them)?;
-                        checkbox_stream.set_dynamic_stream_flag(ae::aegp::DynamicStreamFlags::Hidden, false, hide_them)?;
+                        color_stream   .set_dynamic_stream_flag(ae::aegp::DynamicStreamFlags::Hidden, false.into(), hide_them.into())?;
+                        slider_stream  .set_dynamic_stream_flag(ae::aegp::DynamicStreamFlags::Hidden, false.into(), hide_them.into())?;
+                        checkbox_stream.set_dynamic_stream_flag(ae::aegp::DynamicStreamFlags::Hidden, false.into(), hide_them.into())?;
 
                         // Change popup menu items
                         let param_union = me.param_union_by_index(plugin_id, params.index(Params::Flavor).unwrap() as _)?;

--- a/premiere/src/pf_suites/utility.rs
+++ b/premiere/src/pf_suites/utility.rs
@@ -1,6 +1,20 @@
 use crate::*;
 use pr_sys::*;
 
+/// Whether layer transforms are applied to the returned timecode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyTransform { Yes, No }
+impl From<bool> for ApplyTransform {
+    fn from(b: bool) -> Self { if b { Self::Yes } else { Self::No } }
+}
+
+/// Whether the layer's start-time offset is added to the returned timecode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddStartTimeOffset { Yes, No }
+impl From<bool> for AddStartTimeOffset {
+    fn from(b: bool) -> Self { if b { Self::Yes } else { Self::No } }
+}
+
 define_suite!(
     /// Utility functions for use by AE style effect plugins, running in Premiere Pro.
     UtilitySuite,
@@ -103,8 +117,8 @@ impl UtilitySuite {
     }
 
     /// Retrieves the source media timecode for the specified frame within the specified layer, with or without transforms and start time offsets applied.
-    pub fn source_track_media_timecode(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, apply_transform: bool, add_start_time_offset: bool) -> Result<A_long, Error> {
-        call_suite_fn_single!(self, GetSourceTrackMediaTimecode -> A_long, effect_ref.as_ptr(), layer_param_index, apply_transform, add_start_time_offset)
+    pub fn source_track_media_timecode(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, apply_transform: ApplyTransform, add_start_time_offset: AddStartTimeOffset) -> Result<A_long, Error> {
+        call_suite_fn_single!(self, GetSourceTrackMediaTimecode -> A_long, effect_ref.as_ptr(), layer_param_index, matches!(apply_transform, ApplyTransform::Yes), matches!(add_start_time_offset, AddStartTimeOffset::Yes))
     }
 
     /// Retrieves the name of the layer in use by the effect instance.
@@ -130,8 +144,8 @@ impl UtilitySuite {
     }
 
     /// Given a specific sequence time, retrieves the source track media timecode for the specified layer parameter.
-    pub fn source_track_media_timecode2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, apply_transform: bool, add_start_time_offset: bool, sequence_time: PrTime) -> Result<A_long, Error> {
-        call_suite_fn_single!(self, GetSourceTrackMediaTimecode2 -> A_long, effect_ref.as_ptr(), layer_param_index, apply_transform, add_start_time_offset, sequence_time)
+    pub fn source_track_media_timecode2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, apply_transform: ApplyTransform, add_start_time_offset: AddStartTimeOffset, sequence_time: PrTime) -> Result<A_long, Error> {
+        call_suite_fn_single!(self, GetSourceTrackMediaTimecode2 -> A_long, effect_ref.as_ptr(), layer_param_index, matches!(apply_transform, ApplyTransform::Yes), matches!(add_start_time_offset, AddStartTimeOffset::Yes), sequence_time)
     }
 
     /// Retrieves the clip name used by the specific layer parameter.


### PR DESCRIPTION
Addresses the blueprint vet's `fn_params_excessive_bools`/Rust API Guidelines finding: replace adjacent `bool` parameters with descriptive enums so call sites are self-documenting.

**BREAKING** (targets 0.5.0). Each new enum implements `From<bool>` so migration stays ergonomic (`x.into()` at call sites that hold a bool).

## Changes
| Function | Old params | New enums |
|---|---|---|
| `aegp` `set_dynamic_stream_flag` | `undoable: bool, enabled: bool` | `Undoable`, `FlagValue` |
| `aegp` `select_item` | `select: bool, deselect_others: bool` | `ItemSelection`, `DeselectOthers` |
| `pf`/`premiere` `source_track_media_timecode[2]` | `apply_transform: bool, add_start_time_offset: bool` | `ApplyTransform`, `AddStartTimeOffset` |

Enums are re-exported from `aegp`/`pf` alongside the existing public types, and the higher-level `Effect`/`Item`/`Stream` wrapper methods were updated to match. All internal callers + the `supervisor` example migrated.

## Verification
`cargo check --workspace --all-targets --target x86_64-pc-windows-gnu` -> clean (exit 0). Vetted on the Windows target; the crate does not build on native Linux.

## Honest note
This is the lowest-value item from the cleanup set: each fn had only **two, already descriptively-named** bools (below clippy's default `fn_params_excessive_bools` threshold of 3), and enum params are slightly more verbose at call sites that compute a bool.