### PR TITLE
style: cargo fmt --all across the workspace

### DIFF
--- a/after-effects-sys/build.rs
+++ b/after-effects-sys/build.rs
@@ -15,12 +15,15 @@ fn main() {
         return;
     }
 
-    let ae_sdk_path = &env::var("AESDK_ROOT").ok().filter(|x| !x.is_empty()).expect(
-        "AESDK_ROOT environment variable not set – cannot find AfterEffects SDK.\n\
+    let ae_sdk_path = &env::var("AESDK_ROOT")
+        .ok()
+        .filter(|x| !x.is_empty())
+        .expect(
+            "AESDK_ROOT environment variable not set – cannot find AfterEffects SDK.\n\
         Please set AESDK_ROOT to the root folder of your AfterEffects SDK\n\
         installation (this folder contains the Examples folder & the SDK\n\
         Guide PDF).",
-    );
+        );
 
     if !Path::new(ae_sdk_path).exists() {
         panic!("AESDK_ROOT environment variable points to non-existent path: {ae_sdk_path}");
@@ -109,9 +112,16 @@ fn main() {
     // Let's just rewrite the bindings here and pretend it never happened
     if let Ok(mut content) = std::fs::read_to_string(out_path.join("bindings.rs")) {
         if content.contains("pub __bindgen_anon_1: PF_Point__bindgen_ty_1,") {
-            content = content.replace("pub __bindgen_anon_1: PF_Point__bindgen_ty_1,", "pub h: A_long,");
-            content = content.replace("pub __bindgen_anon_2: PF_Point__bindgen_ty_2,", "pub v: A_long,");
-            std::fs::write(out_path.join("bindings.rs"), content).expect("Couldn't rewrite AfterEffects bindings!");
+            content = content.replace(
+                "pub __bindgen_anon_1: PF_Point__bindgen_ty_1,",
+                "pub h: A_long,",
+            );
+            content = content.replace(
+                "pub __bindgen_anon_2: PF_Point__bindgen_ty_2,",
+                "pub v: A_long,",
+            );
+            std::fs::write(out_path.join("bindings.rs"), content)
+                .expect("Couldn't rewrite AfterEffects bindings!");
         }
     }
 }

--- a/after-effects-sys/src/lib.rs
+++ b/after-effects-sys/src/lib.rs
@@ -4,7 +4,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 #![allow(unused_attributes)]
-
 #![doc = include_str!("../README.md")]
 
 // Included bindings are generated from After Effects SDK 25.6 dated Sep 2025

--- a/after-effects/src/aegp/mod.rs
+++ b/after-effects/src/aegp/mod.rs
@@ -1,6 +1,6 @@
 use crate::ae_sys;
 
-use std::{ convert::TryFrom, ffi::CString, marker::PhantomData };
+use std::{convert::TryFrom, ffi::CString, marker::PhantomData};
 use widestring::U16CString;
 
 #[cfg(feature = "artisan-2-api")]
@@ -9,184 +9,123 @@ mod scene_3d;
 pub use scene_3d::*;
 
 pub mod suites {
-    pub(crate) mod camera;               pub use camera              ::CameraSuite             as Camera;
-    pub(crate) mod canvas;               pub use canvas              ::CanvasSuite             as Canvas;
-    pub(crate) mod color_settings;       pub use color_settings      ::ColorSettingsSuite      as ColorSettings;
-    pub(crate) mod command;              pub use command             ::CommandSuite            as Command;
-    pub(crate) mod comp;                 pub use comp                ::CompSuite               as Comp;
-    pub(crate) mod composite;            pub use composite           ::CompositeSuite          as Composite;
-    pub(crate) mod effect;               pub use effect              ::EffectSuite             as Effect;
-    pub(crate) mod footage;              pub use footage             ::FootageSuite            as Footage;
-    pub(crate) mod io_in;                pub use io_in               ::IOInSuite               as IOIn;
-    pub(crate) mod item;                 pub use item                ::ItemSuite               as Item;
-    pub(crate) mod keyframe;             pub use keyframe            ::KeyframeSuite           as Keyframe;
-    pub(crate) mod layer_render_options; pub use layer_render_options::LayerRenderOptionsSuite as LayerRenderOptions;
-    pub(crate) mod layer;                pub use layer               ::LayerSuite              as Layer;
-    pub(crate) mod light;                pub use light               ::LightSuite              as Light;
-    pub(crate) mod mask;                 pub use mask                ::{ MaskSuite             as Mask,
-                                                                         MaskOutlineSuite      as MaskOutline };
-    pub(crate) mod memory;               pub use memory              ::MemorySuite             as Memory;
-    pub(crate) mod persistent_data;      pub use persistent_data     ::PersistentDataSuite     as PersistentData;
-    pub(crate) mod pf_interface;         pub use pf_interface        ::PFInterfaceSuite        as PFInterface;
-    pub(crate) mod project;              pub use project             ::ProjectSuite            as Project;
-    pub(crate) mod register;             pub use register            ::{ RegisterSuite         as Register,
-                                                                         RegisterNonAegpSuite  as RegisterNonAegp };
-    pub(crate) mod render_async_manager; pub use render_async_manager::RenderAsyncManagerSuite as RenderAsyncManager;
-    pub(crate) mod render_options;       pub use render_options      ::RenderOptionsSuite      as RenderOptions;
-    pub(crate) mod render;               pub use render              ::RenderSuite             as Render;
-    pub(crate) mod output_module;        pub use output_module       ::OutputModuleSuite       as OutputModule;
-    pub(crate) mod render_queue;         pub use render_queue        ::RenderQueueSuite        as RenderQueue;
-    pub(crate) mod render_queue_item;    pub use render_queue_item   ::RenderQueueItemSuite    as RenderQueueItem;
-    pub(crate) mod sound_data;           pub use sound_data          ::SoundDataSuite          as SoundData;
-    pub(crate) mod stream;               pub use stream              ::{ StreamSuite           as Stream,
-                                                                         DynamicStreamSuite    as DynamicStream };
-    pub(crate) mod utility;              pub use utility             ::UtilitySuite            as Utility;
-    pub(crate) mod world;                pub use world               ::WorldSuite              as World;
-    pub(crate) mod compute_cache;        pub use compute_cache       ::ComputeCacheSuite       as ComputeCache;
-    pub(crate) mod hash;                 pub use hash                ::HashSuite               as Hash;
+    pub(crate) mod camera;
+    pub use camera::CameraSuite as Camera;
+    pub(crate) mod canvas;
+    pub use canvas::CanvasSuite as Canvas;
+    pub(crate) mod color_settings;
+    pub use color_settings::ColorSettingsSuite as ColorSettings;
+    pub(crate) mod command;
+    pub use command::CommandSuite as Command;
+    pub(crate) mod comp;
+    pub use comp::CompSuite as Comp;
+    pub(crate) mod composite;
+    pub use composite::CompositeSuite as Composite;
+    pub(crate) mod effect;
+    pub use effect::EffectSuite as Effect;
+    pub(crate) mod footage;
+    pub use footage::FootageSuite as Footage;
+    pub(crate) mod io_in;
+    pub use io_in::IOInSuite as IOIn;
+    pub(crate) mod item;
+    pub use item::ItemSuite as Item;
+    pub(crate) mod keyframe;
+    pub use keyframe::KeyframeSuite as Keyframe;
+    pub(crate) mod layer_render_options;
+    pub use layer_render_options::LayerRenderOptionsSuite as LayerRenderOptions;
+    pub(crate) mod layer;
+    pub use layer::LayerSuite as Layer;
+    pub(crate) mod light;
+    pub use light::LightSuite as Light;
+    pub(crate) mod mask;
+    pub use mask::{MaskOutlineSuite as MaskOutline, MaskSuite as Mask};
+    pub(crate) mod memory;
+    pub use memory::MemorySuite as Memory;
+    pub(crate) mod persistent_data;
+    pub use persistent_data::PersistentDataSuite as PersistentData;
+    pub(crate) mod pf_interface;
+    pub use pf_interface::PFInterfaceSuite as PFInterface;
+    pub(crate) mod project;
+    pub use project::ProjectSuite as Project;
+    pub(crate) mod register;
+    pub use register::{RegisterNonAegpSuite as RegisterNonAegp, RegisterSuite as Register};
+    pub(crate) mod render_async_manager;
+    pub use render_async_manager::RenderAsyncManagerSuite as RenderAsyncManager;
+    pub(crate) mod render_options;
+    pub use render_options::RenderOptionsSuite as RenderOptions;
+    pub(crate) mod render;
+    pub use render::RenderSuite as Render;
+    pub(crate) mod output_module;
+    pub use output_module::OutputModuleSuite as OutputModule;
+    pub(crate) mod render_queue;
+    pub use render_queue::RenderQueueSuite as RenderQueue;
+    pub(crate) mod render_queue_item;
+    pub use render_queue_item::RenderQueueItemSuite as RenderQueueItem;
+    pub(crate) mod sound_data;
+    pub use sound_data::SoundDataSuite as SoundData;
+    pub(crate) mod stream;
+    pub use stream::{DynamicStreamSuite as DynamicStream, StreamSuite as Stream};
+    pub(crate) mod utility;
+    pub use utility::UtilitySuite as Utility;
+    pub(crate) mod world;
+    pub use world::WorldSuite as World;
+    pub(crate) mod compute_cache;
+    pub use compute_cache::ComputeCacheSuite as ComputeCache;
+    pub(crate) mod hash;
+    pub use hash::HashSuite as Hash;
 }
 
 pub type PluginId = ae_sys::AEGP_PluginID;
 pub type ItemId = i32;
 pub type LayerId = u32;
 
-pub use suites::command::{MenuId, MenuOrder};
-pub use suites::register::{HookPriority, CommandHookStatus};
-pub use suites::project::{
-    ProjectHandle,
-    ProjectBitDepth,
-};
-pub use suites::camera::{
-    Camera,
-    CameraType,
-    FilmSizeUnits,
-};
+pub use suites::camera::{Camera, CameraType, FilmSizeUnits};
 pub use suites::canvas::{
-    Canvas,
-    BinType,
-    DisplayChannel,
-    RenderHints,
-    RenderLayerContextHandle,
-    RenderNumEffects,
-    RenderReceiptHandle,
-    RenderReceiptStatus,
+    BinType, Canvas, DisplayChannel, RenderHints, RenderLayerContextHandle, RenderNumEffects,
+    RenderReceiptHandle, RenderReceiptStatus,
 };
-pub use suites::color_settings::{
-    ColorProfileHandle,
-    ConstColorProfileHandle,
-    ItemViewHandle,
-};
-pub use suites::comp::{
-    Composition,
-    Collection2Handle,
-    CompFlags,
-    CompHandle,
-};
-pub use suites::compute_cache:: {
-    ComputeClassId
-};
-pub use suites::effect::{
-    Effect,
-    EffectFlags,
-    EffectRefHandle,
-    InstalledEffectKey,
-};
+pub use suites::color_settings::{ColorProfileHandle, ConstColorProfileHandle, ItemViewHandle};
+pub use suites::command::{MenuId, MenuOrder};
+pub use suites::comp::{Collection2Handle, CompFlags, CompHandle, Composition};
+pub use suites::compute_cache::ComputeClassId;
+pub use suites::effect::{Effect, EffectFlags, EffectRefHandle, InstalledEffectKey};
 pub use suites::footage::{
-    Footage,
-    FootageHandle,
-    FootageSignature,
-    InterpretationStyle,
-    Platform,
+    Footage, FootageHandle, FootageSignature, InterpretationStyle, Platform,
 };
+pub use suites::hash::Guid;
 pub use suites::io_in::InputSpecification;
-pub use suites::item::{
-    Item,
-    ItemFlags,
-    ItemHandle,
-    ItemType,
-    LabelId,
-};
+pub use suites::item::{Item, ItemFlags, ItemHandle, ItemType, LabelId};
 pub use suites::keyframe::{
+    AddKeyframesInfoHandle, KeyframeFlags, KeyframeInterpolation, KeyframeInterpolationMask,
     Keyframes,
-    AddKeyframesInfoHandle,
-    KeyframeFlags,
-    KeyframeInterpolation,
-    KeyframeInterpolationMask,
-};
-pub use suites::layer_render_options::{
-    LayerRenderOptions,
-    LayerRenderOptionsHandle,
-    MatteMode
 };
 pub use suites::layer::{
-    Layer,
-    LayerFlags,
-    LayerHandle,
-    LayerQuality,
-    LayerSamplingQuality,
-    ObjectType,
-    TimeMode,
+    Layer, LayerFlags, LayerHandle, LayerQuality, LayerSamplingQuality, ObjectType, TimeMode,
     TrackMatte,
 };
+pub use suites::layer_render_options::{LayerRenderOptions, LayerRenderOptionsHandle, MatteMode};
 pub use suites::light::LightType;
 pub use suites::mask::{
-    Mask,
-    MaskOutline,
-    MaskFeatherFalloff,
-    MaskFeatherInterp,
-    MaskFeatherType,
-    MaskMBlur,
-    MaskMode,
-    MaskOutlineHandle,
-    MaskRefHandle,
+    Mask, MaskFeatherFalloff, MaskFeatherInterp, MaskFeatherType, MaskMBlur, MaskMode, MaskOutline,
+    MaskOutlineHandle, MaskRefHandle,
 };
-pub use suites::memory::{
-    MemHandle,
-    MemHandleLock,
-};
-pub use suites::persistent_data::{
-   PersistentType,
-   PersistentBlobHandle
-};
-pub use suites::render_async_manager::AsyncManager;
-pub use suites::render_options::{
-    RenderOptions,
-    RenderOptionsHandle,
-    ItemQuality,
-    ChannelOrder
-};
+pub use suites::memory::{MemHandle, MemHandleLock};
 pub use suites::output_module::{
-    EmbeddingType,
-    OutputTypes,
-    PostRenderAction,
-    StretchQuality,
-    VideoChannels,
+    EmbeddingType, OutputTypes, PostRenderAction, StretchQuality, VideoChannels,
 };
+pub use suites::persistent_data::{PersistentBlobHandle, PersistentType};
+pub use suites::project::{ProjectBitDepth, ProjectHandle};
+pub use suites::register::{CommandHookStatus, HookPriority};
+pub use suites::render_async_manager::AsyncManager;
+pub use suites::render_options::{ChannelOrder, ItemQuality, RenderOptions, RenderOptionsHandle};
 pub use suites::render_queue::RenderQueueState;
 pub use suites::render_queue_item::{
-    LogType,
-    OutputModuleRefHandle,
-    RenderItemStatus,
-    RQItemRefHandle,
+    LogType, OutputModuleRefHandle, RQItemRefHandle, RenderItemStatus,
 };
 pub use suites::sound_data::SoundDataHandle;
 pub use suites::stream::{
-    Stream,
-    DynamicStreamFlags,
-    LayerStream,
-    MaskStream,
-    StreamFlags,
-    StreamGroupingType,
-    StreamReferenceHandle,
-    StreamType,
-    StreamValue,
-    TextDocumentHandle,
+    DynamicStreamFlags, LayerStream, MaskStream, Stream, StreamFlags, StreamGroupingType,
+    StreamReferenceHandle, StreamType, StreamValue, TextDocumentHandle,
 };
 pub use suites::utility::GetPathTypes;
-pub use suites::world::{
-    PlatformWorldHandle,
-    World,
-    WorldHandle,
-    WorldType,
-};
-pub use suites::hash::Guid;
+pub use suites::world::{PlatformWorldHandle, World, WorldHandle, WorldType};

--- a/after-effects/src/aegp/scene_3d.rs
+++ b/after-effects/src/aegp/scene_3d.rs
@@ -1,4 +1,4 @@
-use crate::{ae_sys, borrow_pica_basic_as_ptr, pr, Error, Matrix4, Suite, Time, WorldHandle};
+use crate::{Error, Matrix4, Suite, Time, WorldHandle, ae_sys, borrow_pica_basic_as_ptr, pr};
 
 // TDOO: finish wrapping the entire scene 3d
 
@@ -62,14 +62,10 @@ impl Scene3D {
     }
 
     #[inline]
-    pub fn scene3d_ptr(&self) -> *mut ae_sys::AEGP_Scene3D {
-        self.scene3d_ptr
-    }
+    pub fn scene3d_ptr(&self) -> *mut ae_sys::AEGP_Scene3D { self.scene3d_ptr }
 
     #[inline]
-    pub fn scene3d_suite_ptr(&self) -> *const ae_sys::AEGP_Scene3DSuite2 {
-        self
-    }
+    pub fn scene3d_suite_ptr(&self) -> *const ae_sys::AEGP_Scene3DSuite2 { self }
 
     #[inline]
     pub fn setup_motion_blur_samples(
@@ -243,9 +239,7 @@ impl Scene3DLayerHandle {
     }
 
     #[inline]
-    pub fn as_ptr(&self) -> *const ae_sys::AEGP_Scene3DLayer {
-        self.scene3d_layer_ptr
-    }
+    pub fn as_ptr(&self) -> *const ae_sys::AEGP_Scene3DLayer { self.scene3d_layer_ptr }
 }
 
 pub struct Scene3DTextureCacheHandle {

--- a/after-effects/src/aegp/suites/camera.rs
+++ b/after-effects/src/aegp/suites/camera.rs
@@ -1,6 +1,6 @@
-use crate::*;
 use crate::aegp::*;
-use ae_sys::{ AEGP_LayerH, PR_RenderContextH };
+use crate::*;
+use ae_sys::{AEGP_LayerH, PR_RenderContextH};
 
 define_suite!(
     /// Obtains the camera geometry, including camera properties (type, lens, depth of field, focal distance, aperture, et cetera).
@@ -37,12 +37,14 @@ define_suite!(
 impl CameraSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Given a layer handle and time, returns the current camera layer handle.
-    pub fn camera(&self, render_context_handle: impl AsPtr<PR_RenderContextH>, time: Time) -> Result<LayerHandle, Error> {
+    pub fn camera(
+        &self,
+        render_context_handle: impl AsPtr<PR_RenderContextH>,
+        time: Time,
+    ) -> Result<LayerHandle, Error> {
         let camera_layer_handle = call_suite_fn_single!(self, AEGP_GetCamera -> ae_sys::AEGP_LayerH, render_context_handle.as_ptr(), &time as *const _ as *const ae_sys::A_Time)?;
         if camera_layer_handle.is_null() {
             Err(Error::Generic)
@@ -52,27 +54,53 @@ impl CameraSuite {
     }
 
     /// Given a layer, returns the camera type of the layer.
-    pub fn camera_type(&self, camera_layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<CameraType, Error> {
+    pub fn camera_type(
+        &self,
+        camera_layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<CameraType, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetCameraType -> ae_sys::AEGP_CameraType, camera_layer_handle.as_ptr())?.into())
     }
 
     /// Retrieves the size (and units used to measure that size) of the film used by the designated camera.
-    pub fn camera_film_size(&self, camera_layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<(FilmSizeUnits, f64), Error> {
+    pub fn camera_film_size(
+        &self,
+        camera_layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<(FilmSizeUnits, f64), Error> {
         let mut film_size_units: ae_sys::AEGP_FilmSizeUnits = 0;
         let mut film_size: ae_sys::A_FpLong = 0.0;
 
-        call_suite_fn!(self, AEGP_GetCameraFilmSize, camera_layer_handle.as_ptr(), &mut film_size_units, &mut film_size)?;
+        call_suite_fn!(
+            self,
+            AEGP_GetCameraFilmSize,
+            camera_layer_handle.as_ptr(),
+            &mut film_size_units,
+            &mut film_size
+        )?;
 
         Ok((film_size_units.into(), film_size))
     }
 
     /// Sets the size (and unites used to measure that size) of the film used by the designated camera.
-    pub fn set_camera_film_size(&self, camera_layer_handle: impl AsPtr<AEGP_LayerH>, film_size_units: FilmSizeUnits, mut film_size: f64) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetCameraFilmSize, camera_layer_handle.as_ptr(), film_size_units.into(), &mut film_size)
+    pub fn set_camera_film_size(
+        &self,
+        camera_layer_handle: impl AsPtr<AEGP_LayerH>,
+        film_size_units: FilmSizeUnits,
+        mut film_size: f64,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetCameraFilmSize,
+            camera_layer_handle.as_ptr(),
+            film_size_units.into(),
+            &mut film_size
+        )
     }
 
     /// Given a composition handle, returns the camera distance to the image plane.
-    pub fn default_camera_distance_to_image_plane(&self, comp_handle: &CompHandle) -> Result<f64, Error> {
+    pub fn default_camera_distance_to_image_plane(
+        &self,
+        comp_handle: &CompHandle,
+    ) -> Result<f64, Error> {
         call_suite_fn_single!(self, AEGP_GetDefaultCameraDistanceToImagePlane -> f64, comp_handle.as_ptr())
     }
 }
@@ -141,13 +169,16 @@ define_suite_item_wrapper!(
 );
 
 impl Camera {
-    pub fn from_render_context(render_context_handle: impl AsPtr<PR_RenderContextH>, time: Time) -> Result<Self, Error> {
+    pub fn from_render_context(
+        render_context_handle: impl AsPtr<PR_RenderContextH>,
+        time: Time,
+    ) -> Result<Self, Error> {
         let suite = CameraSuite::new()?;
         let handle = suite.camera(render_context_handle, time)?;
         Ok(Self {
             suite: once_cell::sync::Lazy::new(|| CameraSuite::new()),
             handle,
-            is_owned: false
+            is_owned: false,
         })
     }
 }

--- a/after-effects/src/aegp/suites/canvas.rs
+++ b/after-effects/src/aegp/suites/canvas.rs
@@ -1,6 +1,6 @@
-use crate::*;
 use crate::aegp::*;
-use ae_sys::{ PR_RenderContextH, AEGP_RenderLayerContextH };
+use crate::*;
+use ae_sys::{AEGP_RenderLayerContextH, PR_RenderContextH};
 
 define_suite!(
     /// [`render_texture()`](Self::render_texture) supplies the raw pixels of a layer, untransformed, into an arbitrarily-sized buffer.
@@ -25,24 +25,35 @@ define_suite!(
 impl CanvasSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Given the render context provided to the Artisan at render time, returns a handle to the composition.
-    pub fn comp_to_render(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<CompHandle, Error> {
+    pub fn comp_to_render(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<CompHandle, Error> {
         Ok(CompHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetCompToRender -> ae_sys::AEGP_CompH, render_ctx.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetCompToRender -> ae_sys::AEGP_CompH, render_ctx.as_ptr())?,
         ))
     }
 
     /// Given the render context, returns the number of layers the Artisan needs to render.
-    pub fn num_layers_to_render(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<u32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetNumLayersToRender -> i32, render_ctx.as_ptr())? as u32)
+    pub fn num_layers_to_render(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<u32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetNumLayersToRender -> i32, render_ctx.as_ptr())?
+                as u32,
+        )
     }
 
     /// Used to build a list of layers to render after determining the total number of layers that need rendering by the Artisan.
-    pub fn nth_layer_context_to_render(&self, render_ctx: impl AsPtr<PR_RenderContextH>, n: u32) -> Result<RenderLayerContextHandle, Error> {
+    pub fn nth_layer_context_to_render(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        n: u32,
+    ) -> Result<RenderLayerContextHandle, Error> {
         Ok(RenderLayerContextHandle::from_raw(
             call_suite_fn_single!(self,
                 AEGP_GetNthLayerContextToRender -> ae_sys::AEGP_RenderLayerContextH,
@@ -53,56 +64,75 @@ impl CanvasSuite {
     }
 
     /// Given a [`RenderContextHandle`](pr::RenderContextHandle), retrieves the associated [`LayerHandle`] (required by many suite functions).
-    pub fn layer_from_layer_context(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>) -> Result<LayerHandle, Error> {
-        Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_GetLayerFromLayerContext -> ae_sys::AEGP_LayerH,
-                render_ctx.as_ptr(),
-                layer_ctx.as_ptr()
-            )?
-        ))
+    pub fn layer_from_layer_context(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+    ) -> Result<LayerHandle, Error> {
+        Ok(LayerHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_GetLayerFromLayerContext -> ae_sys::AEGP_LayerH,
+            render_ctx.as_ptr(),
+            layer_ctx.as_ptr()
+        )?))
     }
 
     /// Allows for rendering of sub-layers (as within a Photoshop file).
-    pub fn layer_and_sub_layer_from_layer_context(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>) -> Result<(LayerHandle, u32), Error> {
+    pub fn layer_and_sub_layer_from_layer_context(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+    ) -> Result<(LayerHandle, u32), Error> {
         let (layer_handle, sub_layer) = call_suite_fn_double!(self,
             AEGP_GetLayerAndSubLayerFromLayerContext -> ae_sys::AEGP_LayerH, ae_sys::AEGP_SubLayerIndex,
             render_ctx.as_ptr(),
             layer_ctx.as_ptr()
         )?;
-        Ok((
-            LayerHandle::from_raw(layer_handle),
-            sub_layer as u32
-        ))
+        Ok((LayerHandle::from_raw(layer_handle), sub_layer as u32))
     }
 
     /// With collapsed geometrics "on" this gives the layer in the root composition containing the layer context.
     ///
     /// With collapsed geometrics off this is the same as [`layer_from_layer_context()`](Self::layer_from_layer_context).
-    pub fn top_layer_from_layer_context(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>) -> Result<LayerHandle, Error> {
+    pub fn top_layer_from_layer_context(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+    ) -> Result<LayerHandle, Error> {
         Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetTopLayerFromLayerContext -> ae_sys::AEGP_LayerH, render_ctx.as_ptr(), layer_ctx.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetTopLayerFromLayerContext -> ae_sys::AEGP_LayerH, render_ctx.as_ptr(), layer_ctx.as_ptr())?,
         ))
     }
 
     /// Given the render context, returns the current point in (composition) time to render.
-    pub fn comp_render_time(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<(Time, Time), Error> {
-        let (shutter_frame_start, shutter_frame_duration) =
-            call_suite_fn_double!(self, AEGP_GetCompRenderTime -> ae_sys::A_Time, ae_sys::A_Time, render_ctx.as_ptr())?;
+    pub fn comp_render_time(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<(Time, Time), Error> {
+        let (shutter_frame_start, shutter_frame_duration) = call_suite_fn_double!(self, AEGP_GetCompRenderTime -> ae_sys::A_Time, ae_sys::A_Time, render_ctx.as_ptr())?;
 
         Ok((shutter_frame_start.into(), shutter_frame_duration.into()))
     }
 
     /// Given the render context, returns a buffer in which to place the final rendered output.
-    pub fn comp_destination_buffer(&self, render_ctx: impl AsPtr<PR_RenderContextH>, comp_handle: CompHandle) -> Result<WorldHandle, Error> {
+    pub fn comp_destination_buffer(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        comp_handle: CompHandle,
+    ) -> Result<WorldHandle, Error> {
         Ok(WorldHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetCompDestinationBuffer -> ae_sys::AEGP_WorldH, render_ctx.as_ptr(), comp_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetCompDestinationBuffer -> ae_sys::AEGP_WorldH, render_ctx.as_ptr(), comp_handle.as_ptr())?,
         ))
     }
 
     /// Given the render context provided to the Artisan at render time, returns a handle to the composition.
-    pub fn region_of_interest(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<Rect, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetROI -> ae_sys::A_LegacyRect, render_ctx.as_ptr())?.into())
+    pub fn region_of_interest(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<Rect, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetROI -> ae_sys::A_LegacyRect, render_ctx.as_ptr())?
+                .into(),
+        )
     }
 
     /// Given the render context and layer, returns the layer texture.
@@ -110,100 +140,214 @@ impl CanvasSuite {
     /// The returned [`WorldHandle`] can be null.
     ///
     /// [`RenderHints::NoTransferMode`] prevents application of opacity & transfer mode; for use with `RenderLayer` calls.
-    pub fn render_texture(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>, render_hints: RenderHints, suggested_scale: Option<FloatPoint>, suggested_src_rect: Option<FloatRect>, src_matrix: Option<Matrix3>) -> Result<WorldHandle, Error> {
-        Ok(WorldHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_RenderTexture -> ae_sys::AEGP_WorldH,
-                render_ctx.as_ptr(),
-                layer_ctx.as_ptr(),
-                render_hints.into(),
-                suggested_scale   .map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x),
-                suggested_src_rect.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x),
-                src_matrix        .map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x)
-            )?
-        ))
+    pub fn render_texture(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+        render_hints: RenderHints,
+        suggested_scale: Option<FloatPoint>,
+        suggested_src_rect: Option<FloatRect>,
+        src_matrix: Option<Matrix3>,
+    ) -> Result<WorldHandle, Error> {
+        Ok(WorldHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_RenderTexture -> ae_sys::AEGP_WorldH,
+            render_ctx.as_ptr(),
+            layer_ctx.as_ptr(),
+            render_hints.into(),
+            suggested_scale   .map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x),
+            suggested_src_rect.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x),
+            src_matrix        .map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x)
+        )?))
     }
 
     /// Disposes of an acquired layer texture.
-    pub fn dispose_texture(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>, world_handle: WorldHandle) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_DisposeTexture, render_ctx.as_ptr(), layer_ctx.as_ptr(), world_handle.as_ptr())
+    pub fn dispose_texture(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+        world_handle: WorldHandle,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_DisposeTexture,
+            render_ctx.as_ptr(),
+            layer_ctx.as_ptr(),
+            world_handle.as_ptr()
+        )
     }
 
     /// Returns the field settings of the given [`RenderContextHandle`](pr::RenderContextHandle).
-    pub fn field_render(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<ae_sys::PF_Field, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetFieldRender -> ae_sys::PF_Field, render_ctx.as_ptr())?)
+    pub fn field_render(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<ae_sys::PF_Field, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetFieldRender -> ae_sys::PF_Field, render_ctx.as_ptr())?,
+        )
     }
 
     /// Given the render context provided to the Artisan at render time, returns a handle to the composition.
     ///
     /// Note: this is NOT thread-safe on macOS; only use this function when the current thread ID is 0.
-    pub fn report_artisan_progress(&self, render_ctx: impl AsPtr<PR_RenderContextH>, count: i32, total: i32) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_ReportArtisanProgress, render_ctx.as_ptr(), count, total)
+    pub fn report_artisan_progress(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        count: i32,
+        total: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_ReportArtisanProgress,
+            render_ctx.as_ptr(),
+            count,
+            total
+        )
     }
 
     /// Returns the downsample factor of the [`RenderContextHandle`](pr::RenderContextHandle).
-    pub fn render_downsample_factor(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<ae_sys::AEGP_DownsampleFactor, Error> {
+    pub fn render_downsample_factor(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<ae_sys::AEGP_DownsampleFactor, Error> {
         let dsf = call_suite_fn_single!(self, AEGP_GetRenderDownsampleFactor -> ae_sys::AEGP_DownsampleFactor, render_ctx.as_ptr())?;
         Ok(dsf.into())
     }
-    pub fn set_render_downsample_factor(&self, render_ctx: impl AsPtr<PR_RenderContextH>, mut dsf: ae_sys::AEGP_DownsampleFactor) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetRenderDownsampleFactor, render_ctx.as_ptr(), &mut dsf as *mut _)
+
+    pub fn set_render_downsample_factor(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        mut dsf: ae_sys::AEGP_DownsampleFactor,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetRenderDownsampleFactor,
+            render_ctx.as_ptr(),
+            &mut dsf as *mut _
+        )
     }
 
     /// Determines whether the [`RenderContextHandle`](pr::RenderContextHandle) is blank (empty).
-    pub fn is_blank_canvas(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsBlankCanvas -> ae_sys::A_Boolean, render_ctx.as_ptr())? != 0)
+    pub fn is_blank_canvas(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsBlankCanvas -> ae_sys::A_Boolean, render_ctx.as_ptr())?
+                != 0,
+        )
     }
 
     /// Given a render context and a layer (at a given time), retrieves the 4 by 4 transform to move between their coordinate spaces.
-    pub fn render_layer_to_world_xform(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>, comp_time: Time) -> Result<Matrix4, Error> {
+    pub fn render_layer_to_world_xform(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+        comp_time: Time,
+    ) -> Result<Matrix4, Error> {
         let matrix = call_suite_fn_single!(self, AEGP_GetRenderLayerToWorldXform -> ae_sys::A_Matrix4, render_ctx.as_ptr(), layer_ctx.as_ptr(), &comp_time.into() as *const _)?;
         Ok(matrix.into())
     }
 
     /// Retrieves the bounding rectangle of the layer_contextH (at a given time) within the [`RenderContextHandle`](pr::RenderContextHandle).
-    pub fn render_layer_bounds(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>, comp_time: Time) -> Result<Rect, Error> {
+    pub fn render_layer_bounds(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+        comp_time: Time,
+    ) -> Result<Rect, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetRenderLayerBounds -> ae_sys::A_LegacyRect, render_ctx.as_ptr(), layer_ctx.as_ptr(), &comp_time.into() as *const _)?.into())
     }
 
     /// Returns the opacity of the given layer context at the given time, within the render context.
-    pub fn render_opacity(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>, comp_time: Time) -> Result<f64, Error> {
+    pub fn render_opacity(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+        comp_time: Time,
+    ) -> Result<f64, Error> {
         call_suite_fn_single!(self, AEGP_GetRenderOpacity -> f64, render_ctx.as_ptr(), layer_ctx.as_ptr(), &comp_time.into() as *const _)
     }
 
     /// Returns whether or not a given layer context is active within the render context, at the given time.
-    pub fn is_render_layer_active(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>, comp_time: Time) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsRenderLayerActive -> ae_sys::A_Boolean, render_ctx.as_ptr(), layer_ctx.as_ptr(), &comp_time.into() as *const _)? != 0)
+    pub fn is_render_layer_active(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+        comp_time: Time,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsRenderLayerActive -> ae_sys::A_Boolean, render_ctx.as_ptr(), layer_ctx.as_ptr(), &comp_time.into() as *const _)?
+                != 0,
+        )
     }
 
     /// Sets the progress information for a rendering Artisan.
     ///
     /// * `count` is the number of layers completed
     /// * `num_layers` is the total number of layers the Artisan is rendering
-    pub fn set_artisan_layer_progress(&self, render_ctx: impl AsPtr<PR_RenderContextH>, count: i32, num_layers: i32) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetArtisanLayerProgress, render_ctx.as_ptr(), count, num_layers)
+    pub fn set_artisan_layer_progress(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        count: i32,
+        num_layers: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetArtisanLayerProgress,
+            render_ctx.as_ptr(),
+            count,
+            num_layers
+        )
     }
 
     /// Invokes the entire After Effects render pipeline, including transforms, masking, et cetera,
     /// providing the layer as it appears in its composition, in a composition-sized buffer.
-    pub fn render_layer_plus(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_handle: LayerHandle, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>, render_hints: RenderHints) -> Result<WorldHandle, Error> {
+    pub fn render_layer_plus(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_handle: LayerHandle,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+        render_hints: RenderHints,
+    ) -> Result<WorldHandle, Error> {
         Ok(WorldHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_RenderLayerPlus -> ae_sys::AEGP_WorldH, render_ctx.as_ptr(), layer_handle.as_ptr(), layer_ctx.as_ptr(), render_hints.into())?
+            call_suite_fn_single!(self, AEGP_RenderLayerPlus -> ae_sys::AEGP_WorldH, render_ctx.as_ptr(), layer_handle.as_ptr(), layer_ctx.as_ptr(), render_hints.into())?,
         ))
     }
 
     /// Retrieves the [`RenderLayerContextHandle`] for the specified render and fill contexts.
-    pub fn track_matte_context(&self, render_ctx: impl AsPtr<PR_RenderContextH>, fill_ctx: RenderLayerContextHandle) -> Result<RenderLayerContextHandle, Error> {
+    pub fn track_matte_context(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        fill_ctx: RenderLayerContextHandle,
+    ) -> Result<RenderLayerContextHandle, Error> {
         Ok(RenderLayerContextHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetTrackMatteContext -> ae_sys::AEGP_RenderLayerContextH, render_ctx.as_ptr(), fill_ctx.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetTrackMatteContext -> ae_sys::AEGP_RenderLayerContextH, render_ctx.as_ptr(), fill_ctx.as_ptr())?,
         ))
     }
 
     /// Renders a texture into an [`WorldHandle`], and provides an [`RenderReceiptHandle`] for the operation.
-    pub fn render_texture_with_receipt(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>, render_hints: RenderHints, num_effects: RenderNumEffects, suggested_scale: Option<FloatPoint>, suggested_src_rect: Option<FloatRect>, src_matrix: Option<Matrix3>) -> Result<(RenderReceiptHandle, WorldHandle), Error> {
-        let suggested_scale    = suggested_scale   .map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x);
-        let suggested_src_rect = suggested_src_rect.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x);
-        let src_matrix         = src_matrix        .map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x);
+    pub fn render_texture_with_receipt(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+        render_hints: RenderHints,
+        num_effects: RenderNumEffects,
+        suggested_scale: Option<FloatPoint>,
+        suggested_src_rect: Option<FloatRect>,
+        src_matrix: Option<Matrix3>,
+    ) -> Result<(RenderReceiptHandle, WorldHandle), Error> {
+        let suggested_scale = suggested_scale
+            .map(Into::into)
+            .as_mut()
+            .map_or(std::ptr::null_mut(), |x| x);
+        let suggested_src_rect = suggested_src_rect
+            .map(Into::into)
+            .as_mut()
+            .map_or(std::ptr::null_mut(), |x| x);
+        let src_matrix = src_matrix
+            .map(Into::into)
+            .as_mut()
+            .map_or(std::ptr::null_mut(), |x| x);
         let (receipt, world) = call_suite_fn_double!(self,
             AEGP_RenderTextureWithReceipt -> ae_sys::AEGP_RenderReceiptH, ae_sys::AEGP_WorldH,
             render_ctx.as_ptr(),
@@ -216,17 +360,30 @@ impl CanvasSuite {
         )?;
         Ok((
             RenderReceiptHandle::from_raw(receipt),
-            WorldHandle::from_raw(world)
+            WorldHandle::from_raw(world),
         ))
     }
 
     /// Returns the number of software effects applied in the given [`RenderLayerContextHandle`].
-    pub fn number_of_software_effects(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetNumberOfSoftwareEffects -> i16, render_ctx.as_ptr(), layer_ctx.as_ptr())? as i32)
+    pub fn number_of_software_effects(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetNumberOfSoftwareEffects -> i16, render_ctx.as_ptr(), layer_ctx.as_ptr())?
+                as i32,
+        )
     }
 
     /// An improvement over [`render_layer_plus()`](Self::render_layer_plus), this function also provides an [`RenderReceiptHandle`] for caching purposes.
-    pub fn render_layer_plus_with_receipt(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_handle: LayerHandle, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>, render_hints: RenderHints) -> Result<(RenderReceiptHandle, WorldHandle), Error> {
+    pub fn render_layer_plus_with_receipt(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_handle: LayerHandle,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+        render_hints: RenderHints,
+    ) -> Result<(RenderReceiptHandle, WorldHandle), Error> {
         let (receipt, world) = call_suite_fn_double!(self,
             AEGP_RenderLayerPlusWithReceipt -> ae_sys::AEGP_RenderReceiptH, ae_sys::AEGP_WorldH,
             render_ctx.as_ptr(),
@@ -237,19 +394,29 @@ impl CanvasSuite {
 
         Ok((
             RenderReceiptHandle::from_raw(receipt),
-            WorldHandle::from_raw(world))
-        )
+            WorldHandle::from_raw(world),
+        ))
     }
 
     /// Frees an [`ae_sys::AEGP_RenderReceiptH`]
     ///
     /// This is called automatically on [`RenderReceiptHandle::drop()`]
-    pub fn dispose_render_receipt(&self, render_receipt_handle: ae_sys::AEGP_RenderReceiptH) -> Result<(), Error> {
+    pub fn dispose_render_receipt(
+        &self,
+        render_receipt_handle: ae_sys::AEGP_RenderReceiptH,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_DisposeRenderReceipt, render_receipt_handle)
     }
 
     /// Checks with After Effects' internal caching to determine whether a given [`RenderReceiptHandle`] is still valid.
-    pub fn check_render_receipt(&self, current_render_ctx: impl AsPtr<PR_RenderContextH>, current_layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>, old_render_receipt_handle: RenderReceiptHandle, check_geometrics: bool, num_effects: RenderNumEffects) -> Result<RenderReceiptStatus, Error> {
+    pub fn check_render_receipt(
+        &self,
+        current_render_ctx: impl AsPtr<PR_RenderContextH>,
+        current_layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+        old_render_receipt_handle: RenderReceiptHandle,
+        check_geometrics: bool,
+        num_effects: RenderNumEffects,
+    ) -> Result<RenderReceiptStatus, Error> {
         Ok(call_suite_fn_single!(self,
             AEGP_CheckRenderReceipt -> ae_sys::AEGP_RenderReceiptStatus,
             current_render_ctx.as_ptr(),
@@ -257,28 +424,39 @@ impl CanvasSuite {
             old_render_receipt_handle.as_ptr(),
             check_geometrics as i32 as _,
             num_effects.into()
-        )?.into())
+        )?
+        .into())
     }
 
     /// Generates a [`RenderReceiptHandle`] for a layer as if the first `num_effects` have been rendered.
-    pub fn generate_render_receipt(&self, current_render_ctx: impl AsPtr<PR_RenderContextH>, current_layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>, num_effects: RenderNumEffects) -> Result<RenderReceiptHandle, Error> {
-        Ok(RenderReceiptHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_GenerateRenderReceipt -> ae_sys::AEGP_RenderReceiptH,
-                current_render_ctx.as_ptr(),
-                current_layer_ctx.as_ptr(),
-                num_effects.into()
-            )?
-        ))
+    pub fn generate_render_receipt(
+        &self,
+        current_render_ctx: impl AsPtr<PR_RenderContextH>,
+        current_layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+        num_effects: RenderNumEffects,
+    ) -> Result<RenderReceiptHandle, Error> {
+        Ok(RenderReceiptHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_GenerateRenderReceipt -> ae_sys::AEGP_RenderReceiptH,
+            current_render_ctx.as_ptr(),
+            current_layer_ctx.as_ptr(),
+            num_effects.into()
+        )?))
     }
 
     /// Returns the number of bins After Effects wants the artisan to render.
-    pub fn num_bins_to_render(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<i32, Error> {
+    pub fn num_bins_to_render(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, AEGP_GetNumBinsToRender -> i32, render_ctx.as_ptr())
     }
 
     /// Sets the given render context to be the n-th bin to be rendered by After Effects.
-    pub fn set_nth_bin(&self, render_ctx: impl AsPtr<PR_RenderContextH>, n: i32) -> Result<(), Error> {
+    pub fn set_nth_bin(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        n: i32,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetNthBin, render_ctx.as_ptr(), n)
     }
 
@@ -287,40 +465,57 @@ impl CanvasSuite {
         Ok(call_suite_fn_single!(self,
             AEGP_GetBinType -> ae_sys::AEGP_BinType,
             render_ctx.as_ptr()
-        )?.into())
+        )?
+        .into())
     }
 
     /// Retrieves the transform to correctly orient the layer being rendered with the output world.
     ///
     /// Pass `true` for `only_2dB` to constrain the transform to two dimensions.
-    pub fn render_layer_to_world_xform_2d_3d(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>, comp_time: Time, only_2d: bool) -> Result<Matrix4, Error> {
+    pub fn render_layer_to_world_xform_2d_3d(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+        comp_time: Time,
+        only_2d: bool,
+    ) -> Result<Matrix4, Error> {
         Ok(call_suite_fn_single!(self,
             AEGP_GetRenderLayerToWorldXform2D3D -> ae_sys::A_Matrix4,
             render_ctx.as_ptr(),
             layer_ctx.as_ptr(),
             &comp_time.into() as *const _,
             if only_2d { 1 } else { 0 }
-        )?.into())
+        )?
+        .into())
     }
 
     /// Retrieves the platform-specific window context into which to draw the given [`RenderContextHandle`](pr::RenderContextHandle).
     ///
     /// This function is valid for interactive artisans only.
-    pub fn platform_window_ref(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<ae_sys::AEGP_PlatformWindowRef, Error> {
+    pub fn platform_window_ref(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<ae_sys::AEGP_PlatformWindowRef, Error> {
         call_suite_fn_single!(self, AEGP_GetPlatformWindowRef -> ae_sys::AEGP_PlatformWindowRef, render_ctx.as_ptr())
     }
 
     /// Retrieves the source-to-frame downsample factor for the given [`RenderContextHandle`](pr::RenderContextHandle).
     ///
     /// This function is valid for interactive artisans only.
-    pub fn viewport_scale(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<(f64, f64), Error> {
+    pub fn viewport_scale(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<(f64, f64), Error> {
         call_suite_fn_double!(self, AEGP_GetViewportScale -> f64, f64, render_ctx.as_ptr())
     }
 
     /// Retrieves to origin of the source, within the frame (necessary to translate between the two), for the given [`RenderContextHandle`](pr::RenderContextHandle).
     ///
     /// This function is valid for interactive artisans only.
-    pub fn viewport_origin(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<(i32, i32), Error> {
+    pub fn viewport_origin(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<(i32, i32), Error> {
         call_suite_fn_double!(self, AEGP_GetViewportOrigin -> i32, i32, render_ctx.as_ptr())
     }
 
@@ -334,68 +529,99 @@ impl CanvasSuite {
     /// Retrieves the color used for the fallow regions in the given [`RenderContextHandle`](pr::RenderContextHandle).
     ///
     /// This function is valid for interactive artisans only.
-    pub fn fallow_color(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<ae_sys::PF_Pixel8, Error> {
+    pub fn fallow_color(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<ae_sys::PF_Pixel8, Error> {
         call_suite_fn_single!(self, AEGP_GetFallowColor -> ae_sys::PF_Pixel8, render_ctx.as_ptr())
     }
 
-    pub fn interactive_buffer(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<WorldHandle, Error> {
+    pub fn interactive_buffer(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<WorldHandle, Error> {
         Ok(WorldHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetInteractiveBuffer -> ae_sys::AEGP_WorldH, render_ctx.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetInteractiveBuffer -> ae_sys::AEGP_WorldH, render_ctx.as_ptr())?,
         ))
     }
 
     /// Retrieves whether or not the checkerboard is currently active for the given [`RenderContextHandle`](pr::RenderContextHandle).
     ///
     /// This function is valid for interactive artisans only.
-    pub fn interactive_checkerboard(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetInteractiveCheckerboard -> ae_sys::A_Boolean, render_ctx.as_ptr())? != 0)
+    pub fn interactive_checkerboard(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetInteractiveCheckerboard -> ae_sys::A_Boolean, render_ctx.as_ptr())?
+                != 0,
+        )
     }
 
     /// Retrieves the colors used in the checkerboard.
     ///
     /// This function is valid for interactive artisans only.
-    pub fn interactive_checkerboard_colors(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<(Pixel8, Pixel8), Error> {
+    pub fn interactive_checkerboard_colors(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<(Pixel8, Pixel8), Error> {
         let (px1, px2) = call_suite_fn_double!(self, AEGP_GetInteractiveCheckerboardColors -> ae_sys::PF_Pixel, ae_sys::PF_Pixel, render_ctx.as_ptr())?;
-        Ok((
-            px1.into(),
-            px2.into()
-        ))
+        Ok((px1.into(), px2.into()))
     }
 
     /// Retrieves the width and height of one checkerboard square.
     ///
     /// This function is valid for interactive artisans only.
-    pub fn interactive_checkerboard_size(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<(u32, u32), Error> {
+    pub fn interactive_checkerboard_size(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<(u32, u32), Error> {
         call_suite_fn_double!(self, AEGP_GetInteractiveCheckerboardSize -> u32, u32, render_ctx.as_ptr())
     }
 
     /// Retrieves the cached AEGP_WorldH last used for the [`RenderContextHandle`](pr::RenderContextHandle).
     ///
     /// This function is valid for interactive artisans only.
-    pub fn interactive_cached_buffer(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<WorldHandle, Error> {
+    pub fn interactive_cached_buffer(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<WorldHandle, Error> {
         Ok(WorldHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetInteractiveCachedBuffer -> ae_sys::AEGP_WorldH, render_ctx.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetInteractiveCachedBuffer -> ae_sys::AEGP_WorldH, render_ctx.as_ptr())?,
         ))
     }
 
     /// Determines whether or not the artisan must render the current [`RenderLayerContextHandle`] as a layer.
     ///
     /// This function is valid for interactive artisans only.
-    pub fn artisan_must_render_as_layer(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_ArtisanMustRenderAsLayer -> ae_sys::A_Boolean, render_ctx.as_ptr(), layer_ctx.as_ptr())? != 0)
+    pub fn artisan_must_render_as_layer(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_ArtisanMustRenderAsLayer -> ae_sys::A_Boolean, render_ctx.as_ptr(), layer_ctx.as_ptr())?
+                != 0,
+        )
     }
 
     /// Returns which channels should be displayed by the interactive artisan.
     ///
     /// This function is valid for interactive artisans only.
-    pub fn interactive_display_channel(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<DisplayChannel, Error> {
+    pub fn interactive_display_channel(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<DisplayChannel, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetInteractiveDisplayChannel -> ae_sys::AEGP_DisplayChannelType, render_ctx.as_ptr())?.into())
     }
 
     /// Returns the exposure for the given [`RenderContextHandle`](pr::RenderContextHandle), expressed as a floating point number.
     ///
     /// This function is valid for interactive artisans only.
-    pub fn interactive_exposure(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<f64, Error> {
+    pub fn interactive_exposure(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<f64, Error> {
         call_suite_fn_single!(self, AEGP_GetInteractiveExposure -> f64, render_ctx.as_ptr())
     }
 
@@ -403,17 +629,31 @@ impl CanvasSuite {
     /// Returns the color transform for the given [`RenderContextHandle`](pr::RenderContextHandle).
     ///
     /// This function is valid for interactive artisans only.
-    pub fn color_transform(&self, render_ctx: impl AsPtr<PR_RenderContextH>, xform: *mut std::ffi::c_void) -> Result<(bool, u32), Error> {
+    pub fn color_transform(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        xform: *mut std::ffi::c_void,
+    ) -> Result<(bool, u32), Error> {
         let mut cms_on = 0;
         let mut xform_key = 0;
-        call_suite_fn!(self, AEGP_GetColorTransform, render_ctx.as_ptr(), &mut cms_on, &mut xform_key, xform)?;
+        call_suite_fn!(
+            self,
+            AEGP_GetColorTransform,
+            render_ctx.as_ptr(),
+            &mut cms_on,
+            &mut xform_key,
+            xform
+        )?;
         Ok((cms_on != 0, xform_key))
     }
 
     /// Returns the shutter angle for the given [`RenderContextHandle`](pr::RenderContextHandle).
     ///
     /// This function is valid for interactive artisans only.
-    pub fn comp_shutter_time(&self, render_ctx: impl AsPtr<PR_RenderContextH>) -> Result<(Time, Time), Error> {
+    pub fn comp_shutter_time(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+    ) -> Result<(Time, Time), Error> {
         let (shutter_time, shutter_dur) = call_suite_fn_double!(self,
             AEGP_GetCompShutterTime -> ae_sys::A_Time, ae_sys::A_Time,
             render_ctx.as_ptr()
@@ -424,7 +664,12 @@ impl CanvasSuite {
     /// New in CC. Unlike [`suites::Layer::convert_comp_to_layer_time()`](aegp::suites::Layer::convert_comp_to_layer_time), this handles time remapping with collapsed or nested comps.
     ///
     /// This function is valid for interactive artisans only.
-    pub fn map_comp_to_layer_time(&self, render_ctx: impl AsPtr<PR_RenderContextH>, layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>, comp_time: Time) -> Result<Time, Error> {
+    pub fn map_comp_to_layer_time(
+        &self,
+        render_ctx: impl AsPtr<PR_RenderContextH>,
+        layer_ctx: impl AsPtr<AEGP_RenderLayerContextH>,
+        comp_time: Time,
+    ) -> Result<Time, Error> {
         Ok(call_suite_fn_single!(self, AEGP_MapCompToLayerTime -> ae_sys::A_Time, render_ctx.as_ptr(), layer_ctx.as_ptr(), &comp_time.into() as *const _)?.into())
     }
 }
@@ -469,13 +714,13 @@ define_enum! {
 
 pub enum RenderNumEffects {
     AllEffects,
-    NumEffects(u16)
+    NumEffects(u16),
 }
 impl Into<i16> for RenderNumEffects {
     fn into(self) -> i16 {
         match self {
-            RenderNumEffects::AllEffects    => -1,
-            RenderNumEffects::NumEffects(x) => x as i16
+            RenderNumEffects::AllEffects => -1,
+            RenderNumEffects::NumEffects(x) => x as i16,
         }
     }
 }
@@ -493,6 +738,7 @@ define_enum! {
 pub struct RenderReceiptHandle(after_effects_sys::AEGP_RenderReceiptH);
 impl RenderReceiptHandle {
     pub fn from_raw(raw_handle: after_effects_sys::AEGP_RenderReceiptH) -> Self { Self(raw_handle) }
+
     pub fn as_ptr(&self) -> after_effects_sys::AEGP_RenderReceiptH { self.0 }
 }
 impl Drop for RenderReceiptHandle {

--- a/after-effects/src/aegp/suites/color_settings.rs
+++ b/after-effects/src/aegp/suites/color_settings.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::aegp::*;
+use crate::*;
 use pr::RenderContextHandle;
 
 define_suite!(
@@ -13,83 +13,142 @@ define_suite!(
 impl ColorSettingsSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Retrieves the current opaque `PF_EffectBlendingTables`, for use with `AEGP_TransferRect`.
-    pub fn blending_tables(&self, render_context: RenderContextHandle) -> Result<ae_sys::PF_EffectBlendingTables, Error> {
+    pub fn blending_tables(
+        &self,
+        render_context: RenderContextHandle,
+    ) -> Result<ae_sys::PF_EffectBlendingTables, Error> {
         call_suite_fn_single!(self, AEGP_GetBlendingTables -> ae_sys::PF_EffectBlendingTables, render_context.as_ptr())
     }
 
     /// Returns whether there is a colorspace transform applied to the current item view.
     pub fn does_view_have_color_space_xform(&self, view: ItemViewHandle) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_DoesViewHaveColorSpaceXform -> ae_sys::A_Boolean, view.as_ptr())? != 0)
+        Ok(
+            call_suite_fn_single!(self, AEGP_DoesViewHaveColorSpaceXform -> ae_sys::A_Boolean, view.as_ptr())?
+                != 0,
+        )
     }
 
     /// Changes the view colorspace of the source to be the working colorspace of the destination.
     /// Source and destination can be the same.
-    pub fn xform_working_to_view_color_space(&self, view: ItemViewHandle, src: WorldHandle, dst: &mut WorldHandle) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_XformWorkingToViewColorSpace, view.as_ptr(), src.as_ptr(), dst.as_ptr())
+    pub fn xform_working_to_view_color_space(
+        &self,
+        view: ItemViewHandle,
+        src: WorldHandle,
+        dst: &mut WorldHandle,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_XformWorkingToViewColorSpace,
+            view.as_ptr(),
+            src.as_ptr(),
+            dst.as_ptr()
+        )
     }
 
     /// Retrieves the opaque current working space ICC profile.
     /// The "New" in the name does not indicate that you're making up a new profile; rather, it's part of our function naming standard; anything with "New" in the name allocates something which the caller must dispose.
-    pub fn new_working_space_color_profile(&self, plugin_id: PluginId, comp: CompHandle) -> Result<ColorProfileHandle, Error> {
+    pub fn new_working_space_color_profile(
+        &self,
+        plugin_id: PluginId,
+        comp: CompHandle,
+    ) -> Result<ColorProfileHandle, Error> {
         Ok(ColorProfileHandle::from_raw_owned(
-            call_suite_fn_single!(self, AEGP_GetNewWorkingSpaceColorProfile -> ae_sys::AEGP_ColorProfileP, plugin_id, comp.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetNewWorkingSpaceColorProfile -> ae_sys::AEGP_ColorProfileP, plugin_id, comp.as_ptr())?,
         ))
     }
 
     /// Retrieves a new [`ColorProfileHandle`] from After Effects, representing the specified ICC profile.
-    pub fn new_color_profile_from_icc_profile(&self, plugin_id: PluginId, icc_size: i32, icc_data: *const std::ffi::c_void) -> Result<ColorProfileHandle, Error> {
+    pub fn new_color_profile_from_icc_profile(
+        &self,
+        plugin_id: PluginId,
+        icc_size: i32,
+        icc_data: *const std::ffi::c_void,
+    ) -> Result<ColorProfileHandle, Error> {
         Ok(ColorProfileHandle::from_raw_owned(
-            call_suite_fn_single!(self, AEGP_GetNewColorProfileFromICCProfile -> ae_sys::AEGP_ColorProfileP, plugin_id, icc_size, icc_data)?
+            call_suite_fn_single!(self, AEGP_GetNewColorProfileFromICCProfile -> ae_sys::AEGP_ColorProfileP, plugin_id, icc_size, icc_data)?,
         ))
     }
 
     /// Retrieves a new ICC profile representing the specified color profile.
     ///
     /// Use [`MemHandle::to_bytes()`] to convert into `Vec<u8>`.
-    pub fn new_icc_profile_from_color_profile(&self, plugin_id: PluginId, color_profile: ConstColorProfileHandle) -> Result<MemHandle<'_, u8>, Error> {
+    pub fn new_icc_profile_from_color_profile(
+        &self,
+        plugin_id: PluginId,
+        color_profile: ConstColorProfileHandle,
+    ) -> Result<MemHandle<'_, u8>, Error> {
         let handle = call_suite_fn_single!(self, AEGP_GetNewICCProfileFromColorProfile -> ae_sys::AEGP_MemHandle, plugin_id, color_profile.as_ptr())?;
         Ok(MemHandle::from_raw(handle)?)
     }
 
     /// Returns a textual description of the specified color profile.
-    pub fn new_color_profile_description(&self, plugin_id: PluginId, color_profile: ConstColorProfileHandle) -> Result<String, Error> {
+    pub fn new_color_profile_description(
+        &self,
+        plugin_id: PluginId,
+        color_profile: ConstColorProfileHandle,
+    ) -> Result<String, Error> {
         let mem_handle = call_suite_fn_single!(self, AEGP_GetNewColorProfileDescription -> ae_sys::AEGP_MemHandle, plugin_id, color_profile.as_ptr())?;
         Ok(unsafe {
-            U16CString::from_ptr_str(
-                MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr(),
-            ).to_string_lossy()
+            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
+                .to_string_lossy()
         })
     }
 
     /// Disposes of a color profile, obtained using other functions in this suite.
-    pub fn dispose_color_profile(&self, color_profile: ae_sys::AEGP_ColorProfileP) -> Result<(), Error> {
+    pub fn dispose_color_profile(
+        &self,
+        color_profile: ae_sys::AEGP_ColorProfileP,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_DisposeColorProfile, color_profile)
     }
 
     /// Returns a floating point number approximating the gamma setting used by the specified color profile.
-    pub fn color_profile_approximate_gamma(&self, color_profile: ConstColorProfileHandle) -> Result<f32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetColorProfileApproximateGamma -> ae_sys::A_FpShort, color_profile.as_ptr())?)
+    pub fn color_profile_approximate_gamma(
+        &self,
+        color_profile: ConstColorProfileHandle,
+    ) -> Result<f32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetColorProfileApproximateGamma -> ae_sys::A_FpShort, color_profile.as_ptr())?,
+        )
     }
 
     /// Returns whether the specified color profile is RGB.
-    pub fn is_rgb_color_profile(&self, color_profile: ConstColorProfileHandle) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsRGBColorProfile -> ae_sys::A_Boolean, color_profile.as_ptr())? != 0)
+    pub fn is_rgb_color_profile(
+        &self,
+        color_profile: ConstColorProfileHandle,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsRGBColorProfile -> ae_sys::A_Boolean, color_profile.as_ptr())?
+                != 0,
+        )
     }
 
     /// Sets the working space to the passed color profile.
-    pub fn set_working_color_space(&self, plugin_id: PluginId, comp: CompHandle, color_profile: ConstColorProfileHandle) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetWorkingColorSpace, plugin_id, comp.as_ptr(), color_profile.as_ptr())
+    pub fn set_working_color_space(
+        &self,
+        plugin_id: PluginId,
+        comp: CompHandle,
+        color_profile: ConstColorProfileHandle,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetWorkingColorSpace,
+            plugin_id,
+            comp.as_ptr(),
+            color_profile.as_ptr()
+        )
     }
 
     /// Check if the current project is using the OCIO color engine or not.
     /// Returns true if current project uses OCIO color managed mode.
     pub fn is_ocio_color_management_used(&self, plugin_id: PluginId) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsOCIOColorManagementUsed -> ae_sys::A_Boolean, plugin_id)? != 0)
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsOCIOColorManagementUsed -> ae_sys::A_Boolean, plugin_id)?
+                != 0,
+        )
     }
 
     /// Returns the OCIO configuration file used by the project.
@@ -98,9 +157,8 @@ impl ColorSettingsSuite {
     pub fn ocio_configuration_file(&self, plugin_id: PluginId) -> Result<String, Error> {
         let mem_handle = call_suite_fn_single!(self, AEGP_GetOCIOConfigurationFile -> ae_sys::AEGP_MemHandle, plugin_id)?;
         Ok(unsafe {
-            U16CString::from_ptr_str(
-                MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr(),
-            ).to_string_lossy()
+            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
+                .to_string_lossy()
         })
     }
 
@@ -110,9 +168,8 @@ impl ColorSettingsSuite {
     pub fn ocio_configuration_file_path(&self, plugin_id: PluginId) -> Result<String, Error> {
         let mem_handle = call_suite_fn_single!(self, AEGP_GetOCIOConfigurationFilePath -> ae_sys::AEGP_MemHandle, plugin_id)?;
         Ok(unsafe {
-            U16CString::from_ptr_str(
-                MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr(),
-            ).to_string_lossy()
+            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
+                .to_string_lossy()
         })
     }
 
@@ -122,9 +179,8 @@ impl ColorSettingsSuite {
     pub fn ocio_working_color_space(&self, plugin_id: PluginId) -> Result<String, Error> {
         let mem_handle = call_suite_fn_single!(self, AEGPD_GetOCIOWorkingColorSpace -> ae_sys::AEGP_MemHandle, plugin_id)?;
         Ok(unsafe {
-            U16CString::from_ptr_str(
-                MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr(),
-            ).to_string_lossy()
+            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
+                .to_string_lossy()
         })
     }
 
@@ -133,26 +189,43 @@ impl ColorSettingsSuite {
     /// The returned strings specify the Display and View transforms used at project level.
     pub fn ocio_display_color_space(&self, plugin_id: PluginId) -> Result<(String, String), Error> {
         let (display, view) = call_suite_fn_double!(self, AEGPD_GetOCIODisplayColorSpace -> ae_sys::AEGP_MemHandle, ae_sys::AEGP_MemHandle, plugin_id)?;
-        Ok(unsafe {(
-            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(display)?.lock()?.as_ptr()).to_string_lossy(),
-            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(view)   ?.lock()?.as_ptr()).to_string_lossy()
-        )})
+        Ok(unsafe {
+            (
+                U16CString::from_ptr_str(MemHandle::<u16>::from_raw(display)?.lock()?.as_ptr())
+                    .to_string_lossy(),
+                U16CString::from_ptr_str(MemHandle::<u16>::from_raw(view)?.lock()?.as_ptr())
+                    .to_string_lossy(),
+            )
+        })
     }
+
     pub fn is_color_space_aware_effects_enabled(&self, plugin_id: PluginId) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGPD_IsColorSpaceAwareEffectsEnabled -> ae_sys::A_Boolean, plugin_id)? != 0)
+        Ok(
+            call_suite_fn_single!(self, AEGPD_IsColorSpaceAwareEffectsEnabled -> ae_sys::A_Boolean, plugin_id)?
+                != 0,
+        )
     }
+
     pub fn lut_interpolation_method(&self, plugin_id: PluginId) -> Result<u16, Error> {
-        Ok(call_suite_fn_single!(self, AEGPD_GetLUTInterpolationMethod -> ae_sys::A_u_short, plugin_id)?)
+        Ok(
+            call_suite_fn_single!(self, AEGPD_GetLUTInterpolationMethod -> ae_sys::A_u_short, plugin_id)?,
+        )
     }
+
     pub fn graphics_white_luminance(&self, plugin_id: PluginId) -> Result<u16, Error> {
-        Ok(call_suite_fn_single!(self, AEGPD_GetGraphicsWhiteLuminance -> ae_sys::A_u_short, plugin_id)?)
+        Ok(
+            call_suite_fn_single!(self, AEGPD_GetGraphicsWhiteLuminance -> ae_sys::A_u_short, plugin_id)?,
+        )
     }
+
     pub fn working_color_space_id(&self, plugin_id: PluginId) -> Result<ae_sys::AEGP_GuidP, Error> {
         let val: ae_sys::AEGP_GuidP = unsafe { std::mem::zeroed() };
-        let err = unsafe { ae_get_suite_fn!(self.suite_ptr, AEGPD_GetWorkingColorSpaceId)(plugin_id, val) };
+        let err = unsafe {
+            ae_get_suite_fn!(self.suite_ptr, AEGPD_GetWorkingColorSpaceId)(plugin_id, val)
+        };
         match err {
             0 => Ok(val),
-            _ => Err(Error::from(err))
+            _ => Err(Error::from(err)),
         }
     }
 }

--- a/after-effects/src/aegp/suites/command.rs
+++ b/after-effects/src/aegp/suites/command.rs
@@ -67,9 +67,7 @@ impl CommandSuite {
     ///
     /// Note: On occasion After Effects will send command 0 (zero), so don't use that as part of your command handling logic.
     #[deprecated(since = "0.5.0", note = "renamed to `unique_command`")]
-    pub fn get_unique_command(&self) -> Result<AEGP_Command, Error> {
-        self.unique_command()
-    }
+    pub fn get_unique_command(&self) -> Result<AEGP_Command, Error> { self.unique_command() }
 
     /// Set menu name of a command.
     pub fn set_command_name(&self, command_name: &str, command: AEGP_Command) -> Result<(), Error> {

--- a/after-effects/src/aegp/suites/comp.rs
+++ b/after-effects/src/aegp/suites/comp.rs
@@ -1,6 +1,6 @@
-use crate::*;
 use crate::aegp::*;
-use ae_sys::{ AEGP_CompH, AEGP_ItemH };
+use crate::*;
+use ae_sys::{AEGP_CompH, AEGP_ItemH};
 
 define_suite!(
     /// Provide information about the compositions in a project, and create cameras, lights, and solids.
@@ -13,14 +13,15 @@ define_suite!(
 impl CompSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Retrieves the handle to the composition, given an item handle.
     ///
     /// Returns `None` if `item_handle` is not an `AEGP_CompH`.
-    pub fn comp_from_item(&self, item_handle: impl AsPtr<AEGP_ItemH>) -> Result<Option<CompHandle>, Error> {
+    pub fn comp_from_item(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+    ) -> Result<Option<CompHandle>, Error> {
         let ptr = call_suite_fn_single!(self, AEGP_GetCompFromItem -> ae_sys::AEGP_CompH, item_handle.as_ptr())?;
         Ok(if ptr.is_null() {
             None
@@ -32,65 +33,112 @@ impl CompSuite {
     /// Used to get the item handle, given a composition handle.
     pub fn item_from_comp(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<ItemHandle, Error> {
         Ok(ItemHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetItemFromComp -> ae_sys::AEGP_ItemH, comp_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetItemFromComp -> ae_sys::AEGP_ItemH, comp_handle.as_ptr())?,
         ))
     }
 
     /// Returns current downsample factor. Measured in pixels X by Y.
     ///
     /// Users can choose a custom downsample factor with independent X and Y.
-    pub fn comp_downsample_factor(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<ae_sys::AEGP_DownsampleFactor, Error> {
+    pub fn comp_downsample_factor(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+    ) -> Result<ae_sys::AEGP_DownsampleFactor, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetCompDownsampleFactor -> ae_sys::AEGP_DownsampleFactor, comp_handle.as_ptr())?.into())
     }
 
     /// Sets the composition's downsample factor.
-    pub fn set_comp_downsample_factor(&self, comp_handle: impl AsPtr<AEGP_CompH>, downsample_factor: &ae_sys::AEGP_DownsampleFactor) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetCompDownsampleFactor, comp_handle.as_ptr(), downsample_factor)
+    pub fn set_comp_downsample_factor(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        downsample_factor: &ae_sys::AEGP_DownsampleFactor,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetCompDownsampleFactor,
+            comp_handle.as_ptr(),
+            downsample_factor
+        )
     }
 
     /// Returns the composition background color.
-    pub fn comp_bg_color(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<ae_sys::AEGP_ColorVal, Error> {
+    pub fn comp_bg_color(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+    ) -> Result<ae_sys::AEGP_ColorVal, Error> {
         call_suite_fn_single!(self, AEGP_GetCompBGColor -> ae_sys::AEGP_ColorVal, comp_handle.as_ptr())
     }
 
     /// Sets a composition's background color.
-    pub fn set_comp_bg_color(&self, comp_handle: impl AsPtr<AEGP_CompH>, color: ae_sys::AEGP_ColorVal) -> Result<(), Error> {
+    pub fn set_comp_bg_color(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        color: ae_sys::AEGP_ColorVal,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetCompBGColor, comp_handle.as_ptr(), &color)
     }
 
     /// Returns composition flags, or'd together.
     pub fn comp_flags(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<CompFlags, Error> {
-        CompFlags::from_bits(call_suite_fn_single!(self, AEGP_GetCompFlags -> ae_sys::A_long, comp_handle.as_ptr())?)
-            .ok_or(Error::InvalidParms)
+        CompFlags::from_bits(
+            call_suite_fn_single!(self, AEGP_GetCompFlags -> ae_sys::A_long, comp_handle.as_ptr())?,
+        )
+        .ok_or(Error::InvalidParms)
     }
 
     /// New in CC. Passes back true if the Comp's timeline shows layer names, false if source names.
     ///
     /// This will open the comp as a side effect.
-    pub fn show_layer_name_or_source_name(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetShowLayerNameOrSourceName -> ae_sys::A_Boolean, comp_handle.as_ptr())? != 0)
+    pub fn show_layer_name_or_source_name(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetShowLayerNameOrSourceName -> ae_sys::A_Boolean, comp_handle.as_ptr())?
+                != 0,
+        )
     }
 
     /// New in CC. Pass in true to have the Comp's timeline show layer names, false for source names.
     ///
     /// This will open the comp as a side effect.
-    pub fn set_show_layer_name_or_source_name(&self, comp_handle: impl AsPtr<AEGP_CompH>, show_layer_names: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetShowLayerNameOrSourceName, comp_handle.as_ptr(), if show_layer_names { 1 } else { 0 })
+    pub fn set_show_layer_name_or_source_name(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        show_layer_names: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetShowLayerNameOrSourceName,
+            comp_handle.as_ptr(),
+            if show_layer_names { 1 } else { 0 }
+        )
     }
-
 
     /// New in CC. Passes back true if the Comp's timeline shows blend modes column, false if hidden.
     ///
     /// This will open the comp as a side effect.
     pub fn show_blend_modes(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetShowBlendModes -> ae_sys::A_Boolean, comp_handle.as_ptr())? != 0)
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetShowBlendModes -> ae_sys::A_Boolean, comp_handle.as_ptr())?
+                != 0,
+        )
     }
 
     /// New in CC. Pass in true to have the Comp's timeline show the blend modes column, false to hide it.
     ///
     /// This will open the comp as a side effect.
-    pub fn set_show_blend_modes(&self, comp_handle: impl AsPtr<AEGP_CompH>, show_blend_modes: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetShowBlendModes, comp_handle.as_ptr(), if show_blend_modes { 1 } else { 0 })
+    pub fn set_show_blend_modes(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        show_blend_modes: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetShowBlendModes,
+            comp_handle.as_ptr(),
+            if show_blend_modes { 1 } else { 0 }
+        )
     }
 
     /// Returns the composition's frames per second.
@@ -99,42 +147,67 @@ impl CompSuite {
     }
 
     /// Sets the composition's frames per second.
-    pub fn set_comp_framerate(&self, comp_handle: impl AsPtr<AEGP_CompH>, framerate: f64) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetCompFrameRate, comp_handle.as_ptr(), &framerate)
+    pub fn set_comp_framerate(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        framerate: f64,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetCompFrameRate,
+            comp_handle.as_ptr(),
+            &framerate
+        )
     }
 
     /// The composition shutter angle and phase.
-    pub fn comp_shutter_angle_phase(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<(Ratio, Ratio), Error> {
+    pub fn comp_shutter_angle_phase(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+    ) -> Result<(Ratio, Ratio), Error> {
         let (angle, phase) = call_suite_fn_double!(self, AEGP_GetCompShutterAnglePhase -> ae_sys::A_Ratio, ae_sys::A_Ratio, comp_handle.as_ptr())?;
-        Ok((
-            angle.into(),
-            phase.into()
-        ))
+        Ok((angle.into(), phase.into()))
     }
 
     /// The duration of the shutter frame, in seconds.
-    pub fn comp_shutter_frame_range(&self, comp_handle: impl AsPtr<AEGP_CompH>, comp_time: Time) -> Result<(Time, Time), Error> {
+    pub fn comp_shutter_frame_range(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        comp_time: Time,
+    ) -> Result<(Time, Time), Error> {
         let (start, duration) = call_suite_fn_double!(self, AEGP_GetCompShutterFrameRange -> ae_sys::A_Time, ae_sys::A_Time, comp_handle.as_ptr(), &comp_time.into() as *const _)?;
-        Ok((
-            start.into(),
-            duration.into()
-        ))
+        Ok((start.into(), duration.into()))
     }
 
     /// Retrieves the number of motion blur samples After Effects will perform in the given composition.
-    pub fn comp_suggested_motion_blur_samples(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<i32, Error> {
+    pub fn comp_suggested_motion_blur_samples(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, AEGP_GetCompSuggestedMotionBlurSamples -> i32, comp_handle.as_ptr())
     }
 
     /// Specifies the number of motion blur samples After Effects will perform in the given composition. Undoable.
-    pub fn set_comp_suggested_motion_blur_samples(&self, comp_handle: impl AsPtr<AEGP_CompH>, samples: i32) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetCompSuggestedMotionBlurSamples, comp_handle.as_ptr(), samples)
+    pub fn set_comp_suggested_motion_blur_samples(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        samples: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetCompSuggestedMotionBlurSamples,
+            comp_handle.as_ptr(),
+            samples
+        )
     }
 
     /// New in CC. Retrieves the motion blur adaptive sample limit for the given composition.
     ///
     /// As of CC, a new comp defaults to 128.
-    pub fn comp_motion_blur_adaptive_sample_limit(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<i32, Error> {
+    pub fn comp_motion_blur_adaptive_sample_limit(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, AEGP_GetCompMotionBlurAdaptiveSampleLimit -> i32, comp_handle.as_ptr())
     }
 
@@ -143,8 +216,17 @@ impl CompSuite {
     /// As of CC, both the limit and the suggested values are clamped to \[2,256\] range and the limit value will not be allowed less than the suggested value.
     ///
     /// Undoable.
-    pub fn set_comp_motion_blur_adaptive_sample_limit(&self, comp_handle: impl AsPtr<AEGP_CompH>, limit: i32) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetCompMotionBlurAdaptiveSampleLimit, comp_handle.as_ptr(), limit)
+    pub fn set_comp_motion_blur_adaptive_sample_limit(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        limit: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetCompMotionBlurAdaptiveSampleLimit,
+            comp_handle.as_ptr(),
+            limit
+        )
     }
 
     /// Get the time where the current work area starts.
@@ -153,7 +235,10 @@ impl CompSuite {
     }
 
     /// Get the duration of a composition's current work area, in seconds.
-    pub fn comp_work_area_duration(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<Time, Error> {
+    pub fn comp_work_area_duration(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+    ) -> Result<Time, Error> {
         call_suite_fn_single!(self, AEGP_GetCompWorkAreaDuration -> ae_sys::A_Time, comp_handle.as_ptr()).map(|t| t.into())
     }
 
@@ -161,85 +246,119 @@ impl CompSuite {
     ///
     /// One call to this function is sufficient to set the layer's in point and duration;
     /// it's not necessary to call it twice, once for each timespace.
-    pub fn set_comp_work_area_start_and_duration(&self, comp_handle: impl AsPtr<AEGP_CompH>, start: Time, duration: Time) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetCompWorkAreaStartAndDuration, comp_handle.as_ptr(), &start.into() as *const _ as *const ae_sys::A_Time, &duration.into() as *const _ as *const ae_sys::A_Time)
+    pub fn set_comp_work_area_start_and_duration(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        start: Time,
+        duration: Time,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetCompWorkAreaStartAndDuration,
+            comp_handle.as_ptr(),
+            &start.into() as *const _ as *const ae_sys::A_Time,
+            &duration.into() as *const _ as *const ae_sys::A_Time
+        )
     }
 
     /// Creates a new solid with a specified width, height, color, and duration in the composition. Undo-able.
     ///
     /// If you pass `None` for the duration, After Effects uses its preference for the duration of a new still.
     /// If you pass `None`, or an invalid time scale, duration is set to the length of the composition.
-    pub fn create_solid_in_comp(&self, comp_handle: impl AsPtr<AEGP_CompH>, name: &str, width: i32, height: i32, color: ae_sys::AEGP_ColorVal, duration: Option<Time>) -> Result<LayerHandle, Error> {
+    pub fn create_solid_in_comp(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        name: &str,
+        width: i32,
+        height: i32,
+        color: ae_sys::AEGP_ColorVal,
+        duration: Option<Time>,
+    ) -> Result<LayerHandle, Error> {
         let name = U16CString::from_str(name).map_err(|_| Error::InvalidParms)?;
-        Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_CreateSolidInComp -> ae_sys::AEGP_LayerH,
-                name.as_ptr(),
-                width,
-                height,
-                &color,
-                comp_handle.as_ptr(),
-                duration.map(Into::into).as_ref().map_or(std::ptr::null(), |t| t)
-            )?
-        ))
+        Ok(LayerHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_CreateSolidInComp -> ae_sys::AEGP_LayerH,
+            name.as_ptr(),
+            width,
+            height,
+            &color,
+            comp_handle.as_ptr(),
+            duration.map(Into::into).as_ref().map_or(std::ptr::null(), |t| t)
+        )?))
     }
 
     /// Creates and adds a camera to the specified composition.
     /// Once created, you can manipulate the camera's parameter streams using the [`suites::Stream`](aegp::suites::Stream).
     ///
     /// To specify a two-node camera, use [`suites::Layer::set_layer_flag()`](aegp::suites::Layer::set_layer_flag) to set [`LayerFlags::LOOK_AT_POI`].
-    pub fn create_camera_in_comp(&self, comp_handle: impl AsPtr<AEGP_CompH>, name: &str, center_point: ae_sys::A_FloatPoint) -> Result<LayerHandle, Error> {
+    pub fn create_camera_in_comp(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        name: &str,
+        center_point: ae_sys::A_FloatPoint,
+    ) -> Result<LayerHandle, Error> {
         let name = U16CString::from_str(name).map_err(|_| Error::InvalidParms)?;
-        Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_CreateCameraInComp -> ae_sys::AEGP_LayerH,
-                name.as_ptr(),
-                center_point,
-                comp_handle.as_ptr()
-            )?
-        ))
+        Ok(LayerHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_CreateCameraInComp -> ae_sys::AEGP_LayerH,
+            name.as_ptr(),
+            center_point,
+            comp_handle.as_ptr()
+        )?))
     }
 
     /// Creates and adds a light to the specified composition.
     /// Once created, you can manipulate the light's parameter streams using the AEGP [`suites::Stream`](aegp::suites::Stream).
-    pub fn create_light_in_comp(&self, comp_handle: impl AsPtr<AEGP_CompH>, name: &str, center_point: ae_sys::A_FloatPoint) -> Result<LayerHandle, Error> {
+    pub fn create_light_in_comp(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        name: &str,
+        center_point: ae_sys::A_FloatPoint,
+    ) -> Result<LayerHandle, Error> {
         let name = U16CString::from_str(name).map_err(|_| Error::InvalidParms)?;
-        Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_CreateLightInComp -> ae_sys::AEGP_LayerH,
-                name.as_ptr(),
-                center_point,
-                comp_handle.as_ptr()
-            )?
-        ))
+        Ok(LayerHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_CreateLightInComp -> ae_sys::AEGP_LayerH,
+            name.as_ptr(),
+            center_point,
+            comp_handle.as_ptr()
+        )?))
     }
 
     /// Creates a new composition for the project.
     /// If you don't provide a parent folder, the composition will be at the root level of the project.
     ///
     /// Undo-able.
-    pub fn create_comp(&self, parent_folder: Option<ItemHandle>, name: &str, width: i32, height: i32, pixel_aspect_ratio: Ratio, duration: Time, frame_rate: Ratio) -> Result<CompHandle, Error> {
+    pub fn create_comp(
+        &self,
+        parent_folder: Option<ItemHandle>,
+        name: &str,
+        width: i32,
+        height: i32,
+        pixel_aspect_ratio: Ratio,
+        duration: Time,
+        frame_rate: Ratio,
+    ) -> Result<CompHandle, Error> {
         let name = U16CString::from_str(name).map_err(|_| Error::InvalidParms)?;
-        Ok(CompHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_CreateComp -> ae_sys::AEGP_CompH,
-                parent_folder.map_or(std::ptr::null_mut(), |i| i.as_ptr()),
-                name.as_ptr(),
-                width,
-                height,
-                &pixel_aspect_ratio.into() as *const _,
-                &duration.into() as *const _,
-                &frame_rate.into() as *const _
-            )?
-        ))
+        Ok(CompHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_CreateComp -> ae_sys::AEGP_CompH,
+            parent_folder.map_or(std::ptr::null_mut(), |i| i.as_ptr()),
+            name.as_ptr(),
+            width,
+            height,
+            &pixel_aspect_ratio.into() as *const _,
+            &duration.into() as *const _,
+            &frame_rate.into() as *const _
+        )?))
     }
 
     /// Creates a new [`Collection2Handle`] from the items selected in the given composition.
     ///
     /// The plug-in is responsible for disposing of the [`Collection2Handle`].
-    pub fn new_collection_from_comp_selection(&self, comp_handle: impl AsPtr<AEGP_CompH>, plugin_id: PluginId) -> Result<Collection2Handle, Error> {
+    pub fn new_collection_from_comp_selection(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        plugin_id: PluginId,
+    ) -> Result<Collection2Handle, Error> {
         Ok(Collection2Handle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetNewCollectionFromCompSelection -> ae_sys::AEGP_Collection2H, plugin_id, comp_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetNewCollectionFromCompSelection -> ae_sys::AEGP_Collection2H, plugin_id, comp_handle.as_ptr())?,
         ))
     }
 
@@ -248,77 +367,135 @@ impl CompSuite {
     /// Will return an error if members of the [`Collection2Handle`] are not available.
     ///
     /// Don't assume that a composition hasn't changed between operations; always use a fresh [`Collection2Handle`].
-    pub fn set_selection(&self, comp_handle: impl AsPtr<AEGP_CompH>, collection_handle: Collection2Handle) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetSelection, comp_handle.as_ptr(), collection_handle.as_ptr())
+    pub fn set_selection(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        collection_handle: Collection2Handle,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetSelection,
+            comp_handle.as_ptr(),
+            collection_handle.as_ptr()
+        )
     }
 
-    pub fn comp_display_start_time(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<Time, Error> {
+    pub fn comp_display_start_time(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+    ) -> Result<Time, Error> {
         call_suite_fn_single!(self, AEGP_GetCompDisplayStartTime -> ae_sys::A_Time, comp_handle.as_ptr()).map(|t| t.into())
     }
 
     /// Not undo-able. Sets the displayed start time of a composition (has no effect on the duration of the composition).
-    pub fn set_comp_display_start_time(&self, comp_handle: impl AsPtr<AEGP_CompH>, time: Time) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetCompDisplayStartTime, comp_handle.as_ptr(), &time.into() as *const _ as *const ae_sys::A_Time)
+    pub fn set_comp_display_start_time(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        time: Time,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetCompDisplayStartTime,
+            comp_handle.as_ptr(),
+            &time.into() as *const _ as *const ae_sys::A_Time
+        )
     }
 
     /// Undoable. Sets the duration of the given composition.
-    pub fn set_comp_duration(&self, comp_handle: impl AsPtr<AEGP_CompH>, duration: Time) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetCompDuration, comp_handle.as_ptr(), &duration.into() as *const _ as *const ae_sys::A_Time)
+    pub fn set_comp_duration(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        duration: Time,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetCompDuration,
+            comp_handle.as_ptr(),
+            &duration.into() as *const _ as *const ae_sys::A_Time
+        )
     }
 
     /// Creates a "null object" in the composition (useful for translating projects from 3D applications into After Effects).
     ///
     /// If you pass `None` for the duration, After Effects uses its preference for the duration of a new still.
     /// If you pass 0, or an invalid time scale, duration is set to the length of the composition.
-    pub fn create_null_in_comp(&self, comp_handle: impl AsPtr<AEGP_CompH>, name: &str, duration: Option<Time>) -> Result<LayerHandle, Error> {
+    pub fn create_null_in_comp(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        name: &str,
+        duration: Option<Time>,
+    ) -> Result<LayerHandle, Error> {
         let name = U16CString::from_str(name).map_err(|_| Error::InvalidParms)?;
-        Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_CreateNullInComp -> ae_sys::AEGP_LayerH,
-                name.as_ptr(),
-                comp_handle.as_ptr(),
-                duration.map(Into::into).as_ref().map_or(std::ptr::null(), |t| t)
-            )?
-        ))
+        Ok(LayerHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_CreateNullInComp -> ae_sys::AEGP_LayerH,
+            name.as_ptr(),
+            comp_handle.as_ptr(),
+            duration.map(Into::into).as_ref().map_or(std::ptr::null(), |t| t)
+        )?))
     }
 
     /// Sets the pixel aspect ratio of a composition.
-    pub fn set_comp_pixel_aspect_ratio(&self, comp_handle: impl AsPtr<AEGP_CompH>, pixel_aspect_ratio: Ratio) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetCompPixelAspectRatio, comp_handle.as_ptr(), &pixel_aspect_ratio.into() as *const _)
+    pub fn set_comp_pixel_aspect_ratio(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        pixel_aspect_ratio: Ratio,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetCompPixelAspectRatio,
+            comp_handle.as_ptr(),
+            &pixel_aspect_ratio.into() as *const _
+        )
     }
 
     /// Updated in CS6. Creates a text layer in the composition, and returns its [`LayerHandle`].
-    pub fn create_text_layer_in_comp(&self, comp_handle: impl AsPtr<AEGP_CompH>, select_new_layer: bool) -> Result<LayerHandle, Error> {
-        Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_CreateTextLayerInComp -> ae_sys::AEGP_LayerH,
-                comp_handle.as_ptr(),
-                select_new_layer as _
-            )?
-        ))
+    pub fn create_text_layer_in_comp(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        select_new_layer: bool,
+    ) -> Result<LayerHandle, Error> {
+        Ok(LayerHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_CreateTextLayerInComp -> ae_sys::AEGP_LayerH,
+            comp_handle.as_ptr(),
+            select_new_layer as _
+        )?))
     }
 
     /// Updated in CS6. Creates a new box text layer, and returns its [`LayerHandle`].
-    pub fn create_box_text_layer_in_comp(&self, comp_handle: impl AsPtr<AEGP_CompH>, select_new_layer: bool, box_dimensions: FloatPoint) -> Result<LayerHandle, Error> {
-        Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_CreateBoxTextLayerInComp -> ae_sys::AEGP_LayerH,
-                comp_handle.as_ptr(),
-                select_new_layer as _,
-                box_dimensions.into()
-            )?
-        ))
+    pub fn create_box_text_layer_in_comp(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        select_new_layer: bool,
+        box_dimensions: FloatPoint,
+    ) -> Result<LayerHandle, Error> {
+        Ok(LayerHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_CreateBoxTextLayerInComp -> ae_sys::AEGP_LayerH,
+            comp_handle.as_ptr(),
+            select_new_layer as _,
+            box_dimensions.into()
+        )?))
     }
 
     /// Sets the dimensions of the composition. Undoable.
-    pub fn set_comp_dimensions(&self, comp_handle: impl AsPtr<AEGP_CompH>, width: i32, height: i32) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetCompDimensions, comp_handle.as_ptr(), width, height)
+    pub fn set_comp_dimensions(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        width: i32,
+        height: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetCompDimensions,
+            comp_handle.as_ptr(),
+            width,
+            height
+        )
     }
 
     /// Duplicates the composition. Undoable.
     pub fn duplicate_comp(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<CompHandle, Error> {
         Ok(CompHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_DuplicateComp -> ae_sys::AEGP_CompH, comp_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_DuplicateComp -> ae_sys::AEGP_CompH, comp_handle.as_ptr())?,
         ))
     }
 
@@ -330,39 +507,70 @@ impl CompSuite {
     /// Returns the most-recently-used composition.
     pub fn most_recently_used_comp(&self) -> Result<CompHandle, Error> {
         Ok(CompHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetMostRecentlyUsedComp -> ae_sys::AEGP_CompH)?
+            call_suite_fn_single!(self, AEGP_GetMostRecentlyUsedComp -> ae_sys::AEGP_CompH)?,
         ))
     }
 
     /// Creates and returns a handle to a new vector layer.
-    pub fn create_vector_layer_in_comp(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<LayerHandle, Error> {
+    pub fn create_vector_layer_in_comp(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+    ) -> Result<LayerHandle, Error> {
         Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_CreateVectorLayerInComp -> ae_sys::AEGP_LayerH, comp_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_CreateVectorLayerInComp -> ae_sys::AEGP_LayerH, comp_handle.as_ptr())?,
         ))
     }
 
     /// Returns an [`StreamReferenceHandle`] to the composition's marker stream.
     ///
     /// Must be disposed by caller.
-    pub fn new_comp_marker_stream(&self, comp_handle: impl AsPtr<AEGP_CompH>, plugin_id: PluginId) -> Result<StreamReferenceHandle, Error> {
+    pub fn new_comp_marker_stream(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        plugin_id: PluginId,
+    ) -> Result<StreamReferenceHandle, Error> {
         Ok(StreamReferenceHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetNewCompMarkerStream -> ae_sys::AEGP_StreamRefH, plugin_id, comp_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetNewCompMarkerStream -> ae_sys::AEGP_StreamRefH, plugin_id, comp_handle.as_ptr())?,
         ))
     }
 
     /// Passes back a boolean that indicates whether the specified comp uses drop-frame timecode or not.
-    pub fn comp_display_drop_frame(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetCompDisplayDropFrame -> ae_sys::A_Boolean, comp_handle.as_ptr())? != 0)
+    pub fn comp_display_drop_frame(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetCompDisplayDropFrame -> ae_sys::A_Boolean, comp_handle.as_ptr())?
+                != 0,
+        )
     }
 
     /// Sets the dropness of the timecode in the specified composition.
-    pub fn set_comp_display_drop_frame(&self, comp_handle: impl AsPtr<AEGP_CompH>, drop_frame: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetCompDisplayDropFrame, comp_handle.as_ptr(), if drop_frame { 1 } else { 0 })
+    pub fn set_comp_display_drop_frame(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        drop_frame: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetCompDisplayDropFrame,
+            comp_handle.as_ptr(),
+            if drop_frame { 1 } else { 0 }
+        )
     }
 
     /// Move the selection to a certain layer index. Use along with [`set_selection()`](Self::set_selection).
-    pub fn reorder_comp_selection(&self, comp_handle: impl AsPtr<AEGP_CompH>, layer_index: i32) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_ReorderCompSelection, comp_handle.as_ptr(), layer_index)
+    pub fn reorder_comp_selection(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        layer_index: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_ReorderCompSelection,
+            comp_handle.as_ptr(),
+            layer_index
+        )
     }
 }
 
@@ -570,15 +778,35 @@ impl Composition {
     ///
     /// Returns `Err` if `item_handle` is not an `AEGP_CompH`.
     pub fn from_item(item: impl AsPtr<AEGP_ItemH>) -> Result<Option<Composition>, Error> {
-        Ok(CompSuite::new()?.comp_from_item(item.as_ptr())?.map(Into::into))
+        Ok(CompSuite::new()?
+            .comp_from_item(item.as_ptr())?
+            .map(Into::into))
     }
 
     /// Creates a new composition for the project.
     /// If you don't provide a parent folder, the composition will be at the root level of the project.
     ///
     /// Undo-able.
-    pub fn create(parent_folder: Option<ItemHandle>, name: &str, width: i32, height: i32, pixel_aspect_ratio: Ratio, duration: Time, frame_rate: Ratio) -> Result<Composition, Error> {
-        CompSuite::new()?.create_comp(parent_folder, name, width, height, pixel_aspect_ratio, duration, frame_rate).map(Into::into)
+    pub fn create(
+        parent_folder: Option<ItemHandle>,
+        name: &str,
+        width: i32,
+        height: i32,
+        pixel_aspect_ratio: Ratio,
+        duration: Time,
+        frame_rate: Ratio,
+    ) -> Result<Composition, Error> {
+        CompSuite::new()?
+            .create_comp(
+                parent_folder,
+                name,
+                width,
+                height,
+                pixel_aspect_ratio,
+                duration,
+                frame_rate,
+            )
+            .map(Into::into)
     }
 
     /// Returns the most-recently-used composition.

--- a/after-effects/src/aegp/suites/composite.rs
+++ b/after-effects/src/aegp/suites/composite.rs
@@ -11,13 +11,20 @@ define_suite!(
 impl CompositeSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// For the given `EffectWorld`, sets the alpha to fully transparent except for the specified rectangle.
-    pub fn clear_alpha_except_rect(&self, clipped_dest_rect: Rect, dst_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_ClearAlphaExceptRect, &mut clipped_dest_rect.into() as *mut _, dst_world.as_ptr())
+    pub fn clear_alpha_except_rect(
+        &self,
+        clipped_dest_rect: Rect,
+        dst_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_ClearAlphaExceptRect,
+            &mut clipped_dest_rect.into() as *mut _,
+            dst_world.as_ptr()
+        )
     }
 
     /// Blends two `EffectWorld`s using a transfer mode, with an optional mask.
@@ -46,8 +53,13 @@ impl CompositeSuite {
             src_rect as *const _ as _,
             src_world.as_ptr(),
             comp_mode as *const _ as _,
-            blending_tables.as_ref().map_or(std::ptr::null(), |b| b.as_ptr()) as _,
-            mask_world     .map(Into::into).as_ref().map_or(std::ptr::null(), |m| m),
+            blending_tables
+                .as_ref()
+                .map_or(std::ptr::null(), |b| b.as_ptr()) as _,
+            mask_world
+                .map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null(), |m| m),
             dst_x as i32,
             dst_y as i32,
             dst_world.as_ptr()
@@ -59,39 +71,93 @@ impl CompositeSuite {
     /// NOTE: Unlike most of the other pixel mangling functions provided by After Effects, this one doesn't take `EffectWorld` arguments;
     /// rather, you can simply pass the data pointer from within the `EffectWorld`.
     /// This can be confusing, but as a bonus, the function pads output appropriately so that `num_pix` pixels are always output.
-    pub fn prep_track_matte(&self, num_pix: i32, deep: bool, src_mask: &[ae_sys::PF_Pixel], mask_flags: MaskFlags, dst_mask: &mut [ae_sys::PF_Pixel]) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_PrepTrackMatte, num_pix, deep as _, src_mask.as_ptr(), mask_flags.into(), dst_mask.as_mut_ptr())
+    pub fn prep_track_matte(
+        &self,
+        num_pix: i32,
+        deep: bool,
+        src_mask: &[ae_sys::PF_Pixel],
+        mask_flags: MaskFlags,
+        dst_mask: &mut [ae_sys::PF_Pixel],
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_PrepTrackMatte,
+            num_pix,
+            deep as _,
+            src_mask.as_ptr(),
+            mask_flags.into(),
+            dst_mask.as_mut_ptr()
+        )
     }
 
     /// Copies a rectangle of pixels (pass a `None` rectangle to get all pixels) from one `EffectWorld` to another, at low quality.
-    pub fn copy_bits_lq(&self, src_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>, src_r: Option<Rect>, dst_r: Option<Rect>, dst_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>) -> Result<(), Error> {
-        call_suite_fn!(self,
+    pub fn copy_bits_lq(
+        &self,
+        src_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>,
+        src_r: Option<Rect>,
+        dst_r: Option<Rect>,
+        dst_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
             AEGP_CopyBits_LQ,
             src_world.as_ptr(),
-            src_r.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |r| r),
-            dst_r.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |r| r),
+            src_r
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |r| r),
+            dst_r
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |r| r),
             dst_world.as_ptr()
         )
     }
 
     /// Copies a rectangle of pixels (pass a `None` rectangle to get all pixels) from one `EffectWorld` to another, at high quality, with a straight alpha channel.
-    pub fn copy_bits_hq_straight(&self, src_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>, src_r: Option<Rect>, dst_r: Option<Rect>, dst_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>) -> Result<(), Error> {
-        call_suite_fn!(self,
+    pub fn copy_bits_hq_straight(
+        &self,
+        src_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>,
+        src_r: Option<Rect>,
+        dst_r: Option<Rect>,
+        dst_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
             AEGP_CopyBits_HQ_Straight,
             src_world.as_ptr(),
-            src_r.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |r| r),
-            dst_r.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |r| r),
+            src_r
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |r| r),
+            dst_r
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |r| r),
             dst_world.as_ptr()
         )
     }
 
     /// Copies a rectangle of pixels (pass a `None` rectangle to get all pixels) from one `EffectWorld` to another, at high quality, premultiplying the alpha channel.
-    pub fn copy_bits_hq_premul(&self, src_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>, src_r: Option<Rect>, dst_r: Option<Rect>, dst_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>) -> Result<(), Error> {
-        call_suite_fn!(self,
+    pub fn copy_bits_hq_premul(
+        &self,
+        src_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>,
+        src_r: Option<Rect>,
+        dst_r: Option<Rect>,
+        dst_world: impl AsPtr<*mut ae_sys::PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
             AEGP_CopyBits_HQ_Premul,
             src_world.as_ptr(),
-            src_r.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |r| r),
-            dst_r.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |r| r),
+            src_r
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |r| r),
+            dst_r
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |r| r),
             dst_world.as_ptr()
         )
     }

--- a/after-effects/src/aegp/suites/effect.rs
+++ b/after-effects/src/aegp/suites/effect.rs
@@ -1,6 +1,6 @@
-use crate::*;
 use crate::aegp::*;
-use ae_sys::{ AEGP_EffectRefH, AEGP_LayerH };
+use crate::*;
+use ae_sys::{AEGP_EffectRefH, AEGP_LayerH};
 
 define_suite!(
     /// Access the effects applied to a layer. This suite provides access to all parameter data streams.
@@ -26,24 +26,33 @@ define_suite!(
 impl EffectSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Get the number of effects applied to a layer.
     pub fn layer_num_effects(&self, layer: impl AsPtr<AEGP_LayerH>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetLayerNumEffects -> ae_sys::A_long, layer.as_ptr())? as i32)
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetLayerNumEffects -> ae_sys::A_long, layer.as_ptr())?
+                as i32,
+        )
     }
 
     /// Retrieves (by index) a reference to an effect applied to the layer.
-    pub fn layer_effect_by_index(&self, layer: impl AsPtr<AEGP_LayerH>, plugin_id: PluginId, index: i32) -> Result<EffectRefHandle, Error> {
+    pub fn layer_effect_by_index(
+        &self,
+        layer: impl AsPtr<AEGP_LayerH>,
+        plugin_id: PluginId,
+        index: i32,
+    ) -> Result<EffectRefHandle, Error> {
         Ok(EffectRefHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetLayerEffectByIndex -> ae_sys::AEGP_EffectRefH, plugin_id, layer.as_ptr(), index)?
+            call_suite_fn_single!(self, AEGP_GetLayerEffectByIndex -> ae_sys::AEGP_EffectRefH, plugin_id, layer.as_ptr(), index)?,
         ))
     }
 
     /// Given an [`EffectRefHandle`], retrieves its associated [`InstalledEffectKey`].
-    pub fn installed_key_from_layer_effect(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>) -> Result<InstalledEffectKey, Error> {
+    pub fn installed_key_from_layer_effect(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+    ) -> Result<InstalledEffectKey, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetInstalledKeyFromLayerEffect -> ae_sys::AEGP_InstalledEffectKey, effect_ref.as_ptr())?.into())
     }
 
@@ -53,39 +62,70 @@ impl EffectSuite {
     /// it's provided so AEGPs can access parameter defaults, checkbox names, and pop-up strings.
     ///
     /// Use [`suites::Stream::effect_num_param_streams()`](aegp::suites::Stream::effect_num_param_streams) to get the stream count, useful for determining the maximum `param_index`.
-    pub fn effect_param_union_by_index(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>, plugin_id: PluginId, param_index: i32) -> Result<pf::Param<'_>, Error> {
+    pub fn effect_param_union_by_index(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+        plugin_id: PluginId,
+        param_index: i32,
+    ) -> Result<pf::Param<'_>, Error> {
         let (param_type, u) = call_suite_fn_double!(self, AEGP_GetEffectParamUnionByIndex -> ae_sys::PF_ParamType, ae_sys::PF_ParamDefUnion, plugin_id, effect_ref.as_ptr(), param_index)?;
 
         unsafe {
             match param_type {
-                ae_sys::PF_Param_ANGLE          => Ok(Param::Angle      (AngleDef      ::from_owned(u.ad))),
-                ae_sys::PF_Param_ARBITRARY_DATA => Ok(Param::Arbitrary  (ArbitraryDef  ::from_owned(u.arb_d))),
-                ae_sys::PF_Param_BUTTON         => Ok(Param::Button     (ButtonDef     ::from_owned(u.button_d))),
-                ae_sys::PF_Param_CHECKBOX       => Ok(Param::CheckBox   (CheckBoxDef   ::from_owned(u.bd))),
-                ae_sys::PF_Param_COLOR          => Ok(Param::Color      (ColorDef      ::from_owned(u.cd))),
-                ae_sys::PF_Param_FLOAT_SLIDER   => Ok(Param::FloatSlider(FloatSliderDef::from_owned(u.fs_d))),
-                ae_sys::PF_Param_POPUP          => Ok(Param::Popup      (PopupDef      ::from_owned(u.pd))),
-                ae_sys::PF_Param_SLIDER         => Ok(Param::Slider     (SliderDef     ::from_owned(u.sd))),
-                ae_sys::PF_Param_POINT          => Ok(Param::Point      (PointDef      ::from_owned(u.td))),
-                ae_sys::PF_Param_POINT_3D       => Ok(Param::Point3D    (Point3DDef    ::from_owned(u.point3d_d))),
-                ae_sys::PF_Param_PATH           => Ok(Param::Path       (PathDef       ::from_owned(u.path_d))),
+                ae_sys::PF_Param_ANGLE => Ok(Param::Angle(AngleDef::from_owned(u.ad))),
+                ae_sys::PF_Param_ARBITRARY_DATA => {
+                    Ok(Param::Arbitrary(ArbitraryDef::from_owned(u.arb_d)))
+                }
+                ae_sys::PF_Param_BUTTON => Ok(Param::Button(ButtonDef::from_owned(u.button_d))),
+                ae_sys::PF_Param_CHECKBOX => Ok(Param::CheckBox(CheckBoxDef::from_owned(u.bd))),
+                ae_sys::PF_Param_COLOR => Ok(Param::Color(ColorDef::from_owned(u.cd))),
+                ae_sys::PF_Param_FLOAT_SLIDER => {
+                    Ok(Param::FloatSlider(FloatSliderDef::from_owned(u.fs_d)))
+                }
+                ae_sys::PF_Param_POPUP => Ok(Param::Popup(PopupDef::from_owned(u.pd))),
+                ae_sys::PF_Param_SLIDER => Ok(Param::Slider(SliderDef::from_owned(u.sd))),
+                ae_sys::PF_Param_POINT => Ok(Param::Point(PointDef::from_owned(u.td))),
+                ae_sys::PF_Param_POINT_3D => {
+                    Ok(Param::Point3D(Point3DDef::from_owned(u.point3d_d)))
+                }
+                ae_sys::PF_Param_PATH => Ok(Param::Path(PathDef::from_owned(u.path_d))),
                 _ => Err(Error::InvalidParms),
             }
         }
     }
 
     /// Obtains the flags for the given [`EffectRefHandle`].
-    pub fn effect_flags(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>) -> Result<EffectFlags, Error> {
-        Ok(EffectFlags::from_bits_truncate(call_suite_fn_single!(self, AEGP_GetEffectFlags -> ae_sys::AEGP_EffectFlags, effect_ref.as_ptr())?))
+    pub fn effect_flags(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+    ) -> Result<EffectFlags, Error> {
+        Ok(EffectFlags::from_bits_truncate(
+            call_suite_fn_single!(self, AEGP_GetEffectFlags -> ae_sys::AEGP_EffectFlags, effect_ref.as_ptr())?,
+        ))
     }
 
     /// Sets the flags for the given [`EffectRefHandle`], masked by a different set of effect flags.
-    pub fn set_effect_flags(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>, set_mask: EffectFlags, flags: EffectFlags) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetEffectFlags, effect_ref.as_ptr(), set_mask.bits(), flags.bits())
+    pub fn set_effect_flags(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+        set_mask: EffectFlags,
+        flags: EffectFlags,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetEffectFlags,
+            effect_ref.as_ptr(),
+            set_mask.bits(),
+            flags.bits()
+        )
     }
 
     /// Change the order of applied effects (pass the requested index).
-    pub fn reorder_effect(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>, index: i32) -> Result<(), Error> {
+    pub fn reorder_effect(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+        index: i32,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_ReorderEffect, effect_ref.as_ptr(), index)
     }
 
@@ -94,10 +134,25 @@ impl EffectSuite {
     /// This is how AEGPs communicate with effects.
     ///
     /// Pass [`Command::CompletelyGeneral`](crate::Command::CompletelyGeneral) for `command` to get the old behaviour.
-    pub fn effect_call_generic<T: Sized>(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>, plugin_id: PluginId, time: Time, command: &pf::Command, extra_payload: Option<&T>) -> Result<(), Error> {
+    pub fn effect_call_generic<T: Sized>(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+        plugin_id: PluginId,
+        time: Time,
+        command: &pf::Command,
+        extra_payload: Option<&T>,
+    ) -> Result<(), Error> {
         // T is Sized so it can never be a fat pointer which means we are safe to transmute here.
         // Alternatively we could write extra_payload.map(|p| p as *const _).unwrap_or(core::ptr::null())
-        call_suite_fn!(self, AEGP_EffectCallGeneric, plugin_id, effect_ref.as_ptr(), &time.into() as *const _, command.as_raw(), std::mem::transmute(extra_payload))
+        call_suite_fn!(
+            self,
+            AEGP_EffectCallGeneric,
+            plugin_id,
+            effect_ref.as_ptr(),
+            &time.into() as *const _,
+            command.as_raw(),
+            std::mem::transmute(extra_payload)
+        )
     }
 
     /// Disposes of an [`EffectRefHandle`]. Use this to dispose of any [`EffectRefHandle`] returned by After Effects.
@@ -106,14 +161,22 @@ impl EffectSuite {
     }
 
     /// Apply an effect to a given layer. Returns the newly-created [`EffectRefHandle`].
-    pub fn apply_effect(&self, layer: impl AsPtr<AEGP_LayerH>, plugin_id: PluginId, installed_effect_key: InstalledEffectKey) -> Result<EffectRefHandle, Error> {
+    pub fn apply_effect(
+        &self,
+        layer: impl AsPtr<AEGP_LayerH>,
+        plugin_id: PluginId,
+        installed_effect_key: InstalledEffectKey,
+    ) -> Result<EffectRefHandle, Error> {
         Ok(EffectRefHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_ApplyEffect -> ae_sys::AEGP_EffectRefH, plugin_id, layer.as_ptr(), installed_effect_key.into())?
+            call_suite_fn_single!(self, AEGP_ApplyEffect -> ae_sys::AEGP_EffectRefH, plugin_id, layer.as_ptr(), installed_effect_key.into())?,
         ))
     }
 
     /// Remove an applied effect.
-    pub fn delete_layer_effect(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>) -> Result<(), Error> {
+    pub fn delete_layer_effect(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_DeleteLayerEffect, effect_ref.as_ptr())
     }
 
@@ -125,7 +188,10 @@ impl EffectSuite {
     /// Returns the [`InstalledEffectKey`] of the next installed effect.
     ///
     /// Pass [`InstalledEffectKey::None`] as the first parameter to obtain the first [`InstalledEffectKey`].
-    pub fn next_installed_effect(&self, installed_effect_key: InstalledEffectKey) -> Result<InstalledEffectKey, Error> {
+    pub fn next_installed_effect(
+        &self,
+        installed_effect_key: InstalledEffectKey,
+    ) -> Result<InstalledEffectKey, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetNextInstalledEffect -> ae_sys::AEGP_InstalledEffectKey, installed_effect_key.into())?.into())
     }
 
@@ -134,42 +200,79 @@ impl EffectSuite {
     /// Note: use [`suites::DynamicStream::set_stream_name()`](aegp::suites::DynamicStream::set_stream_name) to change the display name of an effect.
     pub fn effect_name(&self, installed_effect_key: InstalledEffectKey) -> Result<String, Error> {
         let mut name = [0i8; ae_sys::AEGP_MAX_EFFECT_NAME_SIZE as usize + 1];
-        call_suite_fn!(self, AEGP_GetEffectName, installed_effect_key.into(), name.as_mut_ptr() as _)?;
-        Ok(unsafe { std::ffi::CStr::from_ptr(name.as_ptr()) }.to_string_lossy().into_owned())
+        call_suite_fn!(
+            self,
+            AEGP_GetEffectName,
+            installed_effect_key.into(),
+            name.as_mut_ptr() as _
+        )?;
+        Ok(unsafe { std::ffi::CStr::from_ptr(name.as_ptr()) }
+            .to_string_lossy()
+            .into_owned())
     }
 
     /// Get match name of an effect (defined in PiPL). `match_name` up to `48` characters long.
     ///
     /// Match names are in 7-bit ASCII. UI names are in the current application runtime encoding;
     /// for example, ISO 8859-1 for most languages on Windows.
-    pub fn effect_match_name(&self, installed_effect_key: InstalledEffectKey) -> Result<String, Error> {
+    pub fn effect_match_name(
+        &self,
+        installed_effect_key: InstalledEffectKey,
+    ) -> Result<String, Error> {
         let mut name = [0i8; ae_sys::AEGP_MAX_EFFECT_MATCH_NAME_SIZE as usize + 1];
-        call_suite_fn!(self, AEGP_GetEffectMatchName, installed_effect_key.into(), name.as_mut_ptr() as _)?;
+        call_suite_fn!(
+            self,
+            AEGP_GetEffectMatchName,
+            installed_effect_key.into(),
+            name.as_mut_ptr() as _
+        )?;
         // TODO: It's not UTF-8
-        Ok(unsafe { std::ffi::CStr::from_ptr(name.as_ptr()) }.to_string_lossy().into_owned())
+        Ok(unsafe { std::ffi::CStr::from_ptr(name.as_ptr()) }
+            .to_string_lossy()
+            .into_owned())
     }
 
     /// Menu category of effect. `category` can be up to `48` characters long.
-    pub fn effect_category(&self, installed_effect_key: InstalledEffectKey) -> Result<String, Error> {
+    pub fn effect_category(
+        &self,
+        installed_effect_key: InstalledEffectKey,
+    ) -> Result<String, Error> {
         let mut name = [0i8; ae_sys::AEGP_MAX_EFFECT_CATEGORY_NAME_SIZE as usize + 1];
-        call_suite_fn!(self, AEGP_GetEffectCategory, installed_effect_key.into(), name.as_mut_ptr() as _)?;
-        Ok(unsafe { std::ffi::CStr::from_ptr(name.as_ptr()) }.to_string_lossy().into_owned())
+        call_suite_fn!(
+            self,
+            AEGP_GetEffectCategory,
+            installed_effect_key.into(),
+            name.as_mut_ptr() as _
+        )?;
+        Ok(unsafe { std::ffi::CStr::from_ptr(name.as_ptr()) }
+            .to_string_lossy()
+            .into_owned())
     }
 
     /// Duplicates a given [`EffectRefHandle`]. Caller must dispose of duplicate when finished.
-    pub fn duplicate_effect(&self, original_effect_ref: impl AsPtr<AEGP_EffectRefH>) -> Result<EffectRefHandle, Error> {
+    pub fn duplicate_effect(
+        &self,
+        original_effect_ref: impl AsPtr<AEGP_EffectRefH>,
+    ) -> Result<EffectRefHandle, Error> {
         Ok(EffectRefHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_DuplicateEffect -> ae_sys::AEGP_EffectRefH, original_effect_ref.as_ptr())?
+            call_suite_fn_single!(self, AEGP_DuplicateEffect -> ae_sys::AEGP_EffectRefH, original_effect_ref.as_ptr())?,
         ))
     }
 
     /// New in CC 2014. How many masks are on this effect?
     pub fn num_effect_mask(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>) -> Result<usize, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_NumEffectMask -> ae_sys::A_u_long, effect_ref.as_ptr())? as usize)
+        Ok(
+            call_suite_fn_single!(self, AEGP_NumEffectMask -> ae_sys::A_u_long, effect_ref.as_ptr())?
+                as usize,
+        )
     }
 
     /// New in CC 2014. For a given `mask_index`, returns the corresponding `AEGP_MaskIDVal` for use in uniquely identifying the mask.
-    pub fn effect_mask_id(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>, mask_index: usize) -> Result<ae_sys::AEGP_MaskIDVal, Error> {
+    pub fn effect_mask_id(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+        mask_index: usize,
+    ) -> Result<ae_sys::AEGP_MaskIDVal, Error> {
         call_suite_fn_single!(self, AEGP_GetEffectMaskID -> ae_sys::AEGP_MaskIDVal, effect_ref.as_ptr(), mask_index as ae_sys::A_u_long)
     }
 
@@ -180,16 +283,24 @@ impl EffectSuite {
     /// Caller must dispose of [`StreamReferenceHandle`] when finished.
     ///
     /// Undoable.
-    pub fn add_effect_mask(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>, id_val: ae_sys::AEGP_MaskIDVal) -> Result<StreamReferenceHandle, Error> {
+    pub fn add_effect_mask(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+        id_val: ae_sys::AEGP_MaskIDVal,
+    ) -> Result<StreamReferenceHandle, Error> {
         Ok(StreamReferenceHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_AddEffectMask -> ae_sys::AEGP_StreamRefH, effect_ref.as_ptr(), id_val)?
+            call_suite_fn_single!(self, AEGP_AddEffectMask -> ae_sys::AEGP_StreamRefH, effect_ref.as_ptr(), id_val)?,
         ))
     }
 
     /// New in CC 2014. Remove an effect mask.
     ///
     /// Undoable.
-    pub fn remove_effect_mask(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>, id_val: ae_sys::AEGP_MaskIDVal) -> Result<(), Error> {
+    pub fn remove_effect_mask(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+        id_val: ae_sys::AEGP_MaskIDVal,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_RemoveEffectMask, effect_ref.as_ptr(), id_val)
     }
 
@@ -200,14 +311,26 @@ impl EffectSuite {
     /// Caller must dispose of [`StreamReferenceHandle`] when finished.
     ///
     /// Undoable.
-    pub fn set_effect_mask(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>, mask_index: usize, id_val: ae_sys::AEGP_MaskIDVal) -> Result<StreamReferenceHandle, Error> {
+    pub fn set_effect_mask(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+        mask_index: usize,
+        id_val: ae_sys::AEGP_MaskIDVal,
+    ) -> Result<StreamReferenceHandle, Error> {
         Ok(StreamReferenceHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_SetEffectMask -> ae_sys::AEGP_StreamRefH, effect_ref.as_ptr(), mask_index as ae_sys::A_u_long, id_val)?
+            call_suite_fn_single!(self, AEGP_SetEffectMask -> ae_sys::AEGP_StreamRefH, effect_ref.as_ptr(), mask_index as ae_sys::A_u_long, id_val)?,
         ))
     }
-    pub fn is_internal_effect(&self, installed_effect_key: ae_sys::AEGP_InstalledEffectKey) -> Result<bool, Error> {
+
+    pub fn is_internal_effect(
+        &self,
+        installed_effect_key: ae_sys::AEGP_InstalledEffectKey,
+    ) -> Result<bool, Error> {
         let v5 = EffectSuite5::new()?;
-        Ok(call_suite_fn_single!(v5, AEGP_GetIsInternalEffect -> ae_sys::A_Boolean, installed_effect_key)? != 0)
+        Ok(
+            call_suite_fn_single!(v5, AEGP_GetIsInternalEffect -> ae_sys::A_Boolean, installed_effect_key)?
+                != 0,
+        )
     }
 }
 
@@ -219,11 +342,11 @@ define_handle_wrapper!(EffectRefHandle, AEGP_EffectRefH);
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum InstalledEffectKey {
     None,
-    Key(i32)
+    Key(i32),
 }
 impl From<ae_sys::AEGP_InstalledEffectKey> for InstalledEffectKey {
     fn from(key: ae_sys::AEGP_InstalledEffectKey) -> Self {
-        if key == ae_sys::AEGP_InstalledEffectKey_NONE as ae_sys::AEGP_InstalledEffectKey  {
+        if key == ae_sys::AEGP_InstalledEffectKey_NONE as ae_sys::AEGP_InstalledEffectKey {
             InstalledEffectKey::None
         } else {
             InstalledEffectKey::Key(key as _)
@@ -233,7 +356,9 @@ impl From<ae_sys::AEGP_InstalledEffectKey> for InstalledEffectKey {
 impl Into<ae_sys::AEGP_InstalledEffectKey> for InstalledEffectKey {
     fn into(self) -> ae_sys::AEGP_InstalledEffectKey {
         match self {
-            InstalledEffectKey::None     => ae_sys::AEGP_InstalledEffectKey_NONE as ae_sys::AEGP_InstalledEffectKey,
+            InstalledEffectKey::None => {
+                ae_sys::AEGP_InstalledEffectKey_NONE as ae_sys::AEGP_InstalledEffectKey
+            }
             InstalledEffectKey::Key(key) => key as ae_sys::AEGP_InstalledEffectKey,
         }
     }
@@ -326,15 +451,21 @@ define_suite_item_wrapper!(
 
 impl Effect {
     /// Returns a new AEGP effect from the provided `effect_ref` and AEGP plugin ID.
-    pub fn new(effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, plugin_id: PluginId) -> Result<Self, Error> {
+    pub fn new(
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        plugin_id: PluginId,
+    ) -> Result<Self, Error> {
         Ok(Self::from_handle(
             aegp::suites::PFInterface::new()?.new_effect_for_effect(effect_ref, plugin_id)?,
-            true
+            true,
         ))
     }
 
     /// Creates a new [`aegp::LayerRenderOptions`] from this layer.
-    pub fn layer_render_options(&self, plugin_id: PluginId) -> Result<aegp::LayerRenderOptions, Error> {
+    pub fn layer_render_options(
+        &self,
+        plugin_id: PluginId,
+    ) -> Result<aegp::LayerRenderOptions, Error> {
         aegp::LayerRenderOptions::from_upstream_of_effect(self.handle.as_ptr(), plugin_id)
     }
 
@@ -346,7 +477,9 @@ impl Effect {
     /// Returns the [`InstalledEffectKey`] of the next installed effect.
     ///
     /// Pass [`InstalledEffectKey::None`] as the first parameter to obtain the first [`InstalledEffectKey`].
-    pub fn next_installed_effect(installed_effect_key: InstalledEffectKey) -> Result<InstalledEffectKey, Error> {
+    pub fn next_installed_effect(
+        installed_effect_key: InstalledEffectKey,
+    ) -> Result<InstalledEffectKey, Error> {
         EffectSuite::new()?.next_installed_effect(installed_effect_key)
     }
 

--- a/after-effects/src/aegp/suites/footage.rs
+++ b/after-effects/src/aegp/suites/footage.rs
@@ -1,6 +1,6 @@
-use crate::*;
 use crate::aegp::*;
-use ae_sys::{ AEGP_ItemH, AEGP_FootageH };
+use crate::*;
+use ae_sys::{AEGP_FootageH, AEGP_ItemH};
 
 define_suite!(
     /// Provides information about footage, or items in a project or composition. When getting and setting footage's interpretation, it is possible to specify incompatible options.
@@ -19,35 +19,38 @@ define_suite!(
 impl FootageSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Returns an error if item isn't a footage item.
     /// Used to convert an item handle to a footage handle.
-    pub fn main_footage_from_item(&self, item_handle: impl AsPtr<AEGP_ItemH>) -> Result<FootageHandle, Error> {
+    pub fn main_footage_from_item(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+    ) -> Result<FootageHandle, Error> {
         Ok(FootageHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetMainFootageFromItem -> ae_sys::AEGP_FootageH, item_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetMainFootageFromItem -> ae_sys::AEGP_FootageH, item_handle.as_ptr())?,
         ))
     }
 
     /// Returns an error if item has no proxy. Returns the proxy footage handle.
     /// Note: a composition can have a proxy.
-    pub fn proxy_footage_from_item(&self, item_handle: impl AsPtr<AEGP_ItemH>) -> Result<FootageHandle, Error> {
+    pub fn proxy_footage_from_item(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+    ) -> Result<FootageHandle, Error> {
         Ok(FootageHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetProxyFootageFromItem -> ae_sys::AEGP_FootageH, item_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetProxyFootageFromItem -> ae_sys::AEGP_FootageH, item_handle.as_ptr())?,
         ))
     }
 
     /// Returns the number of data (RGBA or audio) files, and the number of files per frame (may be greater than one if the footage has auxiliary channels).
-    pub fn footage_num_files(&self, footage_handle: impl AsPtr<AEGP_FootageH>) -> Result<(usize, usize), Error> {
+    pub fn footage_num_files(
+        &self,
+        footage_handle: impl AsPtr<AEGP_FootageH>,
+    ) -> Result<(usize, usize), Error> {
         let (num_main_files, files_per_frame) = call_suite_fn_double!(self, AEGP_GetFootageNumFiles -> ae_sys::A_long, ae_sys::A_long, footage_handle.as_ptr())?;
-        Ok((
-            num_main_files  as usize,
-            files_per_frame as usize
-        ))
+        Ok((num_main_files as usize, files_per_frame as usize))
     }
-
 
     /// Get fully realized path to footage source file.
     ///
@@ -55,60 +58,94 @@ impl FootageSuite {
     /// `frame_num` ranges from `0 to num_main_files`, as obtained using [`footage_num_files()`](Self::footage_num_files).
     ///
     /// [`ae_sys::AEGP_FOOTAGE_MAIN_FILE_INDEX`](after_effects_sys::AEGP_FOOTAGE_MAIN_FILE_INDEX) is the main file.
-    pub fn footage_path(&self, footage_handle: impl AsPtr<AEGP_FootageH>, frame_num: usize, file_index: usize) -> Result<String, Error> {
+    pub fn footage_path(
+        &self,
+        footage_handle: impl AsPtr<AEGP_FootageH>,
+        frame_num: usize,
+        file_index: usize,
+    ) -> Result<String, Error> {
         let mem_handle = call_suite_fn_single!(self, AEGP_GetFootagePath -> ae_sys::AEGP_MemHandle, footage_handle.as_ptr(), frame_num as i32, file_index as i32)?;
 
         // Create a mem handle each and lock it.
         // When the lock goes out of scope it unlocks and when the handle goes out of scope it gives the memory back to Ae.
         Ok(unsafe {
-            U16CString::from_ptr_str(
-                MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr(),
-            ).to_string_lossy()
+            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
+                .to_string_lossy()
         })
     }
 
     /// Retrieves the footage signature of specified footage.
-    pub fn footage_signature(&self, footage_handle: impl AsPtr<AEGP_FootageH>) -> Result<FootageSignature, Error> {
+    pub fn footage_signature(
+        &self,
+        footage_handle: impl AsPtr<AEGP_FootageH>,
+    ) -> Result<FootageSignature, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetFootageSignature -> ae_sys::AEGP_FootageSignature, footage_handle.as_ptr())?.into())
     }
 
     /// Creates a new footage item. The file path is a NULL-terminated UTF-16 string with platform separators.
     /// Note that footage filenames with colons are not allowed, since colons are used as path separators in the HFS+ file system.
     /// Note the optional params. If `allow_interpretation_dialog` is `false`, After Effects will guess the alpha interpretation.
-    pub fn new_footage(&self, plugin_id: PluginId, path: &str, layer_info: Option<ae_sys::AEGP_FootageLayerKey>, sequence_options: Option<ae_sys::AEGP_FileSequenceImportOptions>,interp_style: InterpretationStyle) -> Result<FootageHandle, Error> {
+    pub fn new_footage(
+        &self,
+        plugin_id: PluginId,
+        path: &str,
+        layer_info: Option<ae_sys::AEGP_FootageLayerKey>,
+        sequence_options: Option<ae_sys::AEGP_FileSequenceImportOptions>,
+        interp_style: InterpretationStyle,
+    ) -> Result<FootageHandle, Error> {
         let path = widestring::U16CString::from_str(path).map_err(|_| Error::InvalidParms)?;
 
-        Ok(FootageHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_NewFootage -> ae_sys::AEGP_FootageH,
-                plugin_id,
-                path.as_ptr(),
-                layer_info.as_ref().map_or(std::ptr::null(), |li| li),
-                sequence_options.as_ref().map_or(std::ptr::null(), |so| so),
-                interp_style.into(),
-                std::ptr::null_mut()
-            )?
-        ))
+        Ok(FootageHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_NewFootage -> ae_sys::AEGP_FootageH,
+            plugin_id,
+            path.as_ptr(),
+            layer_info.as_ref().map_or(std::ptr::null(), |li| li),
+            sequence_options.as_ref().map_or(std::ptr::null(), |so| so),
+            interp_style.into(),
+            std::ptr::null_mut()
+        )?))
     }
 
     /// Adds a footage item to a project. Footage will be adopted by the project, and may be added only once.
     /// This is Undo-able; do not dispose of the returned added item if it's undone.
-    pub fn add_footage_to_project(&self, footage_handle: impl AsPtr<AEGP_FootageH>, folder_handle: &ItemHandle) -> Result<ItemHandle, Error> {
+    pub fn add_footage_to_project(
+        &self,
+        footage_handle: impl AsPtr<AEGP_FootageH>,
+        folder_handle: &ItemHandle,
+    ) -> Result<ItemHandle, Error> {
         Ok(ItemHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_AddFootageToProject -> ae_sys::AEGP_ItemH, footage_handle.as_ptr(), folder_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_AddFootageToProject -> ae_sys::AEGP_ItemH, footage_handle.as_ptr(), folder_handle.as_ptr())?,
         ))
     }
 
     /// Sets footage as the proxy for an item. Will be adopted by the project.
     /// This is Undo-able; do not dispose of the returned added item if it's undone.
-    pub fn set_item_proxy_footage(&self, item_handle: impl AsPtr<AEGP_ItemH>, footage_handle: impl AsPtr<AEGP_FootageH>) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetItemProxyFootage, footage_handle.as_ptr(), item_handle.as_ptr())
+    pub fn set_item_proxy_footage(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        footage_handle: impl AsPtr<AEGP_FootageH>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetItemProxyFootage,
+            footage_handle.as_ptr(),
+            item_handle.as_ptr()
+        )
     }
 
     /// Replaces footage for an item. The item will replace the main footage for this item.
     /// This is Undo-able; do not dispose of the returned added item if it's undone.
-    pub fn replace_item_main_footage(&self, item_handle: impl AsPtr<AEGP_ItemH>, footage_handle: impl AsPtr<AEGP_FootageH>) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_ReplaceItemMainFootage, footage_handle.as_ptr(), item_handle.as_ptr())
+    pub fn replace_item_main_footage(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        footage_handle: impl AsPtr<AEGP_FootageH>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_ReplaceItemMainFootage,
+            footage_handle.as_ptr(),
+            item_handle.as_ptr()
+        )
     }
 
     /// Deletes a footage item. Do not dispose of footage you did not create, or that has been added to the project.
@@ -119,18 +156,36 @@ impl FootageSuite {
     /// Populates an [`AEGP_FootageInterp`](after_effects_sys::AEGP_FootageInterp) describing the settings of the [`FootageHandle`].
     /// There is no way to create a valid [`AEGP_FootageInterp`](after_effects_sys::AEGP_FootageInterp) other than by using this function.
     /// If `proxy` is `true`, the proxy footage's settings are retrieved.
-    pub fn footage_interpretation(&self, item_handle: impl AsPtr<AEGP_ItemH>, proxy: bool) -> Result<ae_sys::AEGP_FootageInterp, Error> {
+    pub fn footage_interpretation(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        proxy: bool,
+    ) -> Result<ae_sys::AEGP_FootageInterp, Error> {
         call_suite_fn_single!(self, AEGP_GetFootageInterpretation -> ae_sys::AEGP_FootageInterp, item_handle.as_ptr(), proxy.into())
     }
 
     /// Apply the settings in the [`AEGP_FootageInterp`](after_effects_sys::AEGP_FootageInterp) to the `item_handle`. Undo-able.
     /// If `proxy` is `true`, the proxy footage's settings are modified.
-    pub fn set_footage_interpretation(&self, item_handle: impl AsPtr<AEGP_ItemH>, proxy: bool, interp: &ae_sys::AEGP_FootageInterp) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetFootageInterpretation, item_handle.as_ptr(), proxy.into(), interp)
+    pub fn set_footage_interpretation(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        proxy: bool,
+        interp: &ae_sys::AEGP_FootageInterp,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetFootageInterpretation,
+            item_handle.as_ptr(),
+            proxy.into(),
+            interp
+        )
     }
 
     /// Returns an [`AEGP_FootageLayerKey`](after_effects_sys::AEGP_FootageLayerKey) describing the footage.
-    pub fn footage_layer_key(&self, footage_handle: impl AsPtr<AEGP_FootageH>) -> Result<ae_sys::AEGP_FootageLayerKey, Error> {
+    pub fn footage_layer_key(
+        &self,
+        footage_handle: impl AsPtr<AEGP_FootageH>,
+    ) -> Result<ae_sys::AEGP_FootageLayerKey, Error> {
         call_suite_fn_single!(self, AEGP_GetFootageLayerKey -> ae_sys::AEGP_FootageLayerKey, footage_handle.as_ptr())
     }
 
@@ -151,59 +206,106 @@ impl FootageSuite {
     /// Starting in CC, [`FileType::None`](crate::aeio::FileType::None) is now a warning condition.
     /// If you pass [`FileType::Any`](crate::aeio::FileType::Any), then path MUST exist.
     /// If the path may not exist, pass [`FileType::Dir`](crate::aeio::FileType::Dir) for folder, or [`FileType::Generic`](crate::aeio::FileType::Generic) for a file.
-    pub fn new_placeholder_footage_with_path(&self, plugin_id: PluginId, path: &str, path_platform: Platform, file_type: crate::aeio::FileType, width: i32, height: i32, duration: Option<Time>) -> Result<FootageHandle, Error> {
+    pub fn new_placeholder_footage_with_path(
+        &self,
+        plugin_id: PluginId,
+        path: &str,
+        path_platform: Platform,
+        file_type: crate::aeio::FileType,
+        width: i32,
+        height: i32,
+        duration: Option<Time>,
+    ) -> Result<FootageHandle, Error> {
         let path = widestring::U16CString::from_str(path).map_err(|_| Error::InvalidParms)?;
 
-        Ok(FootageHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_NewPlaceholderFootageWithPath -> ae_sys::AEGP_FootageH,
-                plugin_id,
-                path.as_ptr(),
-                path_platform.into(),
-                file_type as _,
-                width,
-                height,
-                duration.map(Into::into).as_ref().map_or(std::ptr::null(), |d| d)
-            )?
-        ))
+        Ok(FootageHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_NewPlaceholderFootageWithPath -> ae_sys::AEGP_FootageH,
+            plugin_id,
+            path.as_ptr(),
+            path_platform.into(),
+            file_type as _,
+            width,
+            height,
+            duration.map(Into::into).as_ref().map_or(std::ptr::null(), |d| d)
+        )?))
     }
 
     /// This is the way to add a solid.
     /// Until the footage is added to the project, the caller owns the [`FootageHandle`]
     /// (and must dispose of it if, and only if, it isn't added to the project).
-    pub fn new_solid_footage(&self, name: &str, width: i32, height: i32, color: &ae_sys::AEGP_ColorVal) -> Result<FootageHandle, Error> {
+    pub fn new_solid_footage(
+        &self,
+        name: &str,
+        width: i32,
+        height: i32,
+        color: &ae_sys::AEGP_ColorVal,
+    ) -> Result<FootageHandle, Error> {
         let name = std::ffi::CString::new(name).map_err(|_| Error::InvalidParms)?;
 
         Ok(FootageHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_NewSolidFootage -> ae_sys::AEGP_FootageH, name.as_ptr(), width, height, color as *const _)?
+            call_suite_fn_single!(self, AEGP_NewSolidFootage -> ae_sys::AEGP_FootageH, name.as_ptr(), width, height, color as *const _)?,
         ))
     }
 
     /// Returns the color of a given solid. Returns an error if the [`ItemHandle`] is not a solid.
     /// If `proxy` is `true`, the proxy solid's color is retrieved.
-    pub fn solid_footage_color(&self, item_handle: impl AsPtr<AEGP_ItemH>, proxy: bool) -> Result<ae_sys::AEGP_ColorVal, Error> {
+    pub fn solid_footage_color(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        proxy: bool,
+    ) -> Result<ae_sys::AEGP_ColorVal, Error> {
         call_suite_fn_single!(self, AEGP_GetSolidFootageColor -> ae_sys::AEGP_ColorVal, item_handle.as_ptr(), proxy.into())
     }
 
     /// Sets the color of a solid. Undo-able.
     /// If `proxy` is `true`, the proxy solid's color is set.
-    pub fn set_solid_footage_color(&self, item_handle: impl AsPtr<AEGP_ItemH>, proxy: bool, color: &ae_sys::AEGP_ColorVal) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetSolidFootageColor, item_handle.as_ptr(), proxy.into(), color)
+    pub fn set_solid_footage_color(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        proxy: bool,
+        color: &ae_sys::AEGP_ColorVal,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetSolidFootageColor,
+            item_handle.as_ptr(),
+            proxy.into(),
+            color
+        )
     }
 
     /// Sets the dimensions of a solid. Undo-able.
     /// If `proxy` is `true`, the proxy solid's dimensions are modified. Returns an error if the item isn't a solid.
-    pub fn set_solid_footage_dimensions(&self, item_handle: impl AsPtr<AEGP_ItemH>, proxy: bool, width: i32, height: i32) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetSolidFootageDimensions, item_handle.as_ptr(), proxy.into(), width, height)
+    pub fn set_solid_footage_dimensions(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        proxy: bool,
+        width: i32,
+        height: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetSolidFootageDimensions,
+            item_handle.as_ptr(),
+            proxy.into(),
+            width,
+            height
+        )
     }
 
     /// Retrieves information about the audio data in the footage item (by populating the `AEGP_SoundDataFormat` you passed in).
-    pub fn footage_sound_data_format(&self, footage_handle: impl AsPtr<AEGP_FootageH>) -> Result<ae_sys::AEGP_SoundDataFormat, Error> {
+    pub fn footage_sound_data_format(
+        &self,
+        footage_handle: impl AsPtr<AEGP_FootageH>,
+    ) -> Result<ae_sys::AEGP_SoundDataFormat, Error> {
         call_suite_fn_single!(self, AEGP_GetFootageSoundDataFormat -> ae_sys::AEGP_SoundDataFormat, footage_handle.as_ptr())
     }
 
     /// Populates and returns a `AEGP_FileSequenceImportOptions` describing the given `AEGP_FootageH`.
-    pub fn footage_sequence_import_options(&self, footage_handle: impl AsPtr<AEGP_FootageH>) -> Result<ae_sys::AEGP_FileSequenceImportOptions, Error> {
+    pub fn footage_sequence_import_options(
+        &self,
+        footage_handle: impl AsPtr<AEGP_FootageH>,
+    ) -> Result<ae_sys::AEGP_FileSequenceImportOptions, Error> {
         call_suite_fn_single!(self, AEGP_GetFootageSequenceImportOptions -> ae_sys::AEGP_FileSequenceImportOptions, footage_handle.as_ptr())
     }
 }
@@ -283,11 +385,23 @@ impl Footage {
     /// Creates a new footage item. The file path is a string with platform separators.
     /// Note that footage filenames with colons are not allowed, since colons are used as path separators in the HFS+ file system.
     /// Note the optional params. If `allow_interpretation_dialog` is `false`, After Effects will guess the alpha interpretation.
-    pub fn create(plugin_id: PluginId, path: &str, layer_info: Option<ae_sys::AEGP_FootageLayerKey>, sequence_options: Option<ae_sys::AEGP_FileSequenceImportOptions>, interp_style: InterpretationStyle) -> Result<Footage, Error> {
+    pub fn create(
+        plugin_id: PluginId,
+        path: &str,
+        layer_info: Option<ae_sys::AEGP_FootageLayerKey>,
+        sequence_options: Option<ae_sys::AEGP_FileSequenceImportOptions>,
+        interp_style: InterpretationStyle,
+    ) -> Result<Footage, Error> {
         let footage_suite = FootageSuite::new()?;
         Ok(Footage::from_handle(
-            footage_suite.new_footage(plugin_id, path, layer_info, sequence_options, interp_style)?,
-            false
+            footage_suite.new_footage(
+                plugin_id,
+                path,
+                layer_info,
+                sequence_options,
+                interp_style,
+            )?,
+            false,
         ))
     }
 
@@ -298,22 +412,43 @@ impl Footage {
     /// Starting in CC, [`FileType::None`](crate::aeio::FileType::None) is now a warning condition.
     /// If you pass [`FileType::Any`](crate::aeio::FileType::Any), then path MUST exist.
     /// If the path may not exist, pass [`FileType::Dir`](crate::aeio::FileType::Dir) for folder, or [`FileType::Generic`](crate::aeio::FileType::Generic) for a file.
-    pub fn new_placeholder_with_path(plugin_id: PluginId, path: &str, path_platform: Platform, file_type: crate::aeio::FileType, width: i32, height: i32, duration: Option<Time>) -> Result<Footage, Error> {
+    pub fn new_placeholder_with_path(
+        plugin_id: PluginId,
+        path: &str,
+        path_platform: Platform,
+        file_type: crate::aeio::FileType,
+        width: i32,
+        height: i32,
+        duration: Option<Time>,
+    ) -> Result<Footage, Error> {
         let footage_suite = FootageSuite::new()?;
         Ok(Footage::from_handle(
-            footage_suite.new_placeholder_footage_with_path(plugin_id, path, path_platform, file_type, width, height, duration)?,
-            false
+            footage_suite.new_placeholder_footage_with_path(
+                plugin_id,
+                path,
+                path_platform,
+                file_type,
+                width,
+                height,
+                duration,
+            )?,
+            false,
         ))
     }
 
     /// This is the way to add a solid.
     /// Until the footage is added to the project, the caller owns the [`FootageHandle`]
     /// (and must dispose of it if, and only if, it isn't added to the project).
-    pub fn new_solid(name: &str, width: i32, height: i32, color: &ae_sys::AEGP_ColorVal) -> Result<Footage, Error> {
+    pub fn new_solid(
+        name: &str,
+        width: i32,
+        height: i32,
+        color: &ae_sys::AEGP_ColorVal,
+    ) -> Result<Footage, Error> {
         let footage_suite = FootageSuite::new()?;
         Ok(Footage::from_handle(
             footage_suite.new_solid_footage(name, width, height, color)?,
-            false
+            false,
         ))
     }
 }

--- a/after-effects/src/aegp/suites/io_in.rs
+++ b/after-effects/src/aegp/suites/io_in.rs
@@ -1,6 +1,6 @@
 use crate::*;
-use widestring::U16CString;
 use ae_sys::AEIO_InSpecH;
+use widestring::U16CString;
 
 define_suite!(
     /// These functions manage an input specification, After Effects' internal representation of data gathered from any source.
@@ -15,14 +15,16 @@ define_suite!(
 impl IOInSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Retrieves the options data (created by your AEIO) for the given [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn in_spec_options_handle(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<aeio::Handle, Error> {
+    pub fn in_spec_options_handle(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<aeio::Handle, Error> {
         Ok(aeio::Handle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetInSpecOptionsHandle -> *mut std::ffi::c_void, in_spec_handle.as_ptr())? as _
+            call_suite_fn_single!(self, AEGP_GetInSpecOptionsHandle -> *mut std::ffi::c_void, in_spec_handle.as_ptr())?
+                as _,
         ))
     }
 
@@ -31,30 +33,56 @@ impl IOInSuite {
     /// Must be allocated using the [`suites::Memory`](aegp::suites::Memory).
     ///
     /// Returns the old options handle.
-    pub fn set_in_spec_options_handle(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, options: &aeio::Handle) -> Result<aeio::Handle, Error> {
+    pub fn set_in_spec_options_handle(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        options: &aeio::Handle,
+    ) -> Result<aeio::Handle, Error> {
         Ok(aeio::Handle::from_raw(
-            call_suite_fn_single!(self, AEGP_SetInSpecOptionsHandle -> *mut std::ffi::c_void, in_spec_handle.as_ptr(), options.as_ptr() as *mut _)? as _
+            call_suite_fn_single!(self, AEGP_SetInSpecOptionsHandle -> *mut std::ffi::c_void, in_spec_handle.as_ptr(), options.as_ptr() as *mut _)?
+                as _,
         ))
     }
 
     /// Retrieves the file path for the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn in_spec_file_path(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<String, Error> {
+    pub fn in_spec_file_path(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<String, Error> {
         let mem_handle = call_suite_fn_single!(self, AEGP_GetInSpecFilePath -> ae_sys::AEGP_MemHandle, in_spec_handle.as_ptr())?;
         Ok(unsafe {
             U16CString::from_ptr_str(
-                aegp::MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr(),
-            ).to_string_lossy()
+                aegp::MemHandle::<u16>::from_raw(mem_handle)?
+                    .lock()?
+                    .as_ptr(),
+            )
+            .to_string_lossy()
         })
     }
 
     /// Retrieves the frame rate of the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn in_spec_native_fps(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetInSpecNativeFPS -> ae_sys::A_Fixed, in_spec_handle.as_ptr())? as i32)
+    pub fn in_spec_native_fps(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetInSpecNativeFPS -> ae_sys::A_Fixed, in_spec_handle.as_ptr())?
+                as i32,
+        )
     }
 
     /// Sets the frame rate of the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn set_in_spec_native_fps(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, native_fps: i32) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecNativeFPS, in_spec_handle.as_ptr(), native_fps as _)
+    pub fn set_in_spec_native_fps(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        native_fps: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecNativeFPS,
+            in_spec_handle.as_ptr(),
+            native_fps as _
+        )
     }
 
     /// Retrieves the bit depth of the image data in the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
@@ -63,7 +91,11 @@ impl IOInSuite {
     }
 
     /// Indicates to After Effects the bit depth of the image data in the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn set_in_spec_depth(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, depth: i16) -> Result<(), Error> {
+    pub fn set_in_spec_depth(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        depth: i16,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetInSpecDepth, in_spec_handle.as_ptr(), depth)
     }
 
@@ -73,32 +105,63 @@ impl IOInSuite {
     }
 
     /// Indicates to After Effects the size (in bytes) of the data referenced by the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn set_in_spec_size(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, size: u64) -> Result<(), Error> {
+    pub fn set_in_spec_size(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        size: u64,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetInSpecSize, in_spec_handle.as_ptr(), size)
     }
 
     /// Retrieves field information for the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn in_spec_interlace_label(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<ae_sys::FIEL_Label, Error> {
+    pub fn in_spec_interlace_label(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<ae_sys::FIEL_Label, Error> {
         call_suite_fn_single!(self, AEGP_GetInSpecInterlaceLabel -> ae_sys::FIEL_Label, in_spec_handle.as_ptr())
     }
 
     /// Specifies field information for the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn set_in_spec_interlace_label(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, interlace_label: &ae_sys::FIEL_Label) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecInterlaceLabel, in_spec_handle.as_ptr(), interlace_label)
+    pub fn set_in_spec_interlace_label(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        interlace_label: &ae_sys::FIEL_Label,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecInterlaceLabel,
+            in_spec_handle.as_ptr(),
+            interlace_label
+        )
     }
 
     /// Retrieves alpha channel interpretation information for the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn in_spec_alpha_label(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<ae_sys::AEIO_AlphaLabel, Error> {
+    pub fn in_spec_alpha_label(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<ae_sys::AEIO_AlphaLabel, Error> {
         call_suite_fn_single!(self, AEGP_GetInSpecAlphaLabel -> ae_sys::AEIO_AlphaLabel, in_spec_handle.as_ptr())
     }
 
     /// Sets alpha channel interpretation information for the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn set_in_spec_alpha_label(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, alpha_label: &ae_sys::AEIO_AlphaLabel) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecAlphaLabel, in_spec_handle.as_ptr(), alpha_label)
+    pub fn set_in_spec_alpha_label(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        alpha_label: &ae_sys::AEIO_AlphaLabel,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecAlphaLabel,
+            in_spec_handle.as_ptr(),
+            alpha_label
+        )
     }
 
     /// Retrieves the duration of the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn in_spec_duration(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<Time, Error> {
+    pub fn in_spec_duration(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<Time, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetInSpecDuration -> ae_sys::A_Time, in_spec_handle.as_ptr())?.into())
     }
 
@@ -108,31 +171,62 @@ impl IOInSuite {
     /// If you don't set the `A_Time.scale` to something other than zero, your file(s) will not import.
     ///
     /// This will be fixed in future versions.
-    pub fn set_in_spec_duration(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, duration: Time) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecDuration, in_spec_handle.as_ptr(), &duration.into() as *const _)
+    pub fn set_in_spec_duration(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        duration: Time,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecDuration,
+            in_spec_handle.as_ptr(),
+            &duration.into() as *const _
+        )
     }
 
     /// Retrieves the width and height of the image data in the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn in_spec_dimensions(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<(i32, i32), Error> {
+    pub fn in_spec_dimensions(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<(i32, i32), Error> {
         let (width, height) = call_suite_fn_double!(self, AEGP_GetInSpecDimensions -> ae_sys::A_long, ae_sys::A_long, in_spec_handle.as_ptr())?;
-        Ok((
-            width as i32,
-            height as i32
-        ))
+        Ok((width as i32, height as i32))
     }
 
     /// Indicates to After Effects the width and height of the image data in the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn set_in_spec_dimensions(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, width: i32, height: i32) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecDimensions, in_spec_handle.as_ptr(), width, height)
+    pub fn set_in_spec_dimensions(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        width: i32,
+        height: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecDimensions,
+            in_spec_handle.as_ptr(),
+            width,
+            height
+        )
     }
 
     /// Retrieves the width, height, bounding rect, and scaling factor applied to an [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn in_spec_rational_dimensions(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<(ae_sys::AEIO_RationalScale, i32, i32, Rect), Error> {
+    pub fn in_spec_rational_dimensions(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<(ae_sys::AEIO_RationalScale, i32, i32, Rect), Error> {
         let mut rs: ae_sys::AEIO_RationalScale = unsafe { std::mem::zeroed() };
         let mut width = 0;
         let mut height = 0;
         let mut rect: ae_sys::A_Rect = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, AEGP_InSpecGetRationalDimensions, in_spec_handle.as_ptr(), &mut rs, &mut width, &mut height, &mut rect)?;
+        call_suite_fn!(
+            self,
+            AEGP_InSpecGetRationalDimensions,
+            in_spec_handle.as_ptr(),
+            &mut rs,
+            &mut width,
+            &mut height,
+            &mut rect
+        )?;
         Ok((rs, width, height, rect.into()))
     }
 
@@ -142,55 +236,118 @@ impl IOInSuite {
     }
 
     /// Sets the horizontal scaling factor of an [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn set_in_spec_hsf(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, hsf: Ratio) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecHSF, in_spec_handle.as_ptr(), &hsf.into() as *const _)
+    pub fn set_in_spec_hsf(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        hsf: Ratio,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecHSF,
+            in_spec_handle.as_ptr(),
+            &hsf.into() as *const _
+        )
     }
 
     /// Obtains the sampling rate (in samples per second) for the audio data referenced by the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn in_spec_sound_rate(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<f64, Error> {
+    pub fn in_spec_sound_rate(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<f64, Error> {
         call_suite_fn_single!(self, AEGP_GetInSpecSoundRate -> f64, in_spec_handle.as_ptr())
     }
 
     /// Sets the sampling rate (in samples per second) for the audio data referenced by the [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn set_in_spec_sound_rate(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, rate: f64) -> Result<(), Error> {
+    pub fn set_in_spec_sound_rate(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        rate: f64,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetInSpecSoundRate, in_spec_handle.as_ptr(), rate)
     }
 
     /// Obtains the encoding method (signed PCM, unsigned PCM, or floating point) from an [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn in_spec_sound_encoding(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<aeio::SoundEncoding, Error> {
+    pub fn in_spec_sound_encoding(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<aeio::SoundEncoding, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetInSpecSoundEncoding -> ae_sys::AEIO_SndEncoding, in_spec_handle.as_ptr())?.into())
     }
 
     /// Sets the encoding method of an [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn set_in_spec_sound_encoding(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, encoding: aeio::SoundEncoding) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecSoundEncoding, in_spec_handle.as_ptr(), encoding.into())
+    pub fn set_in_spec_sound_encoding(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        encoding: aeio::SoundEncoding,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecSoundEncoding,
+            in_spec_handle.as_ptr(),
+            encoding.into()
+        )
     }
 
     /// Retrieves the bytes-per-sample (1,2, or 4) from an [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn in_spec_sound_sample_size(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<aeio::SoundSampleSize, Error> {
+    pub fn in_spec_sound_sample_size(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<aeio::SoundSampleSize, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetInSpecSoundSampleSize -> ae_sys::AEIO_SndSampleSize, in_spec_handle.as_ptr())?.into())
     }
 
     /// Set the bytes per sample of an [`aeio::InSpecHandle`](crate::aeio::InSpecHandle).
-    pub fn set_in_spec_sound_sample_size(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, bytes_per_sample: aeio::SoundSampleSize) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecSoundSampleSize, in_spec_handle.as_ptr(), bytes_per_sample.into())
+    pub fn set_in_spec_sound_sample_size(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        bytes_per_sample: aeio::SoundSampleSize,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecSoundSampleSize,
+            in_spec_handle.as_ptr(),
+            bytes_per_sample.into()
+        )
     }
 
     /// Determines whether the audio in the [`aeio::SoundChannels`] is mono or stereo.
-    pub fn in_spec_sound_channels(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<aeio::SoundChannels, Error> {
+    pub fn in_spec_sound_channels(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<aeio::SoundChannels, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetInSpecSoundChannels -> ae_sys::AEIO_SndChannels, in_spec_handle.as_ptr())?.into())
     }
 
     /// Sets the audio in an [`aeio::SoundChannels`] to mono or stereo.
-    pub fn set_in_spec_sound_channels(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, num_channels: aeio::SoundChannels) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecSoundChannels, in_spec_handle.as_ptr(), num_channels.into())
+    pub fn set_in_spec_sound_channels(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        num_channels: aeio::SoundChannels,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecSoundChannels,
+            in_spec_handle.as_ptr(),
+            num_channels.into()
+        )
     }
 
     /// If your file format has auxiliary files which you want to prevent users from opening directly,
     /// pass it's extension, file type and creator to this function to keep it from appearing in input dialogs.
-    pub fn add_aux_ext_map(&self, extension: &str, file_type: aeio::FileType, creator: i32) -> Result<(), Error> {
+    pub fn add_aux_ext_map(
+        &self,
+        extension: &str,
+        file_type: aeio::FileType,
+        creator: i32,
+    ) -> Result<(), Error> {
         let extension = std::ffi::CString::new(extension).map_err(|_| Error::InvalidParms)?;
-        call_suite_fn!(self, AEGP_AddAuxExtMap, extension.as_ptr(), file_type as _, creator)
+        call_suite_fn!(
+            self,
+            AEGP_AddAuxExtMap,
+            extension.as_ptr(),
+            file_type as _,
+            creator
+        )
     }
 
     /// In case of RGB data, if there is an embedded icc profile, build an `AEGP_ColorProfile` out of
@@ -204,53 +361,139 @@ impl IOInSuite {
     /// If you are unpacking non-RGB data into specific RGB color space, you must pass the profile describing this space to [`set_in_spec_assigned_color_profile()`](Self::set_in_spec_assigned_color_profile) below.
     /// Otherwise, your RGB data will be incorrectly interpreted as being in working space.
     /// Either color profile or profile description should be NULL in this function. You cannot use both.
-    pub fn set_in_spec_embedded_color_profile(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, color_profile: Option<ae_sys::AEGP_ConstColorProfileP>, profile_desc: Option<&str>) -> Result<(), Error> {
+    pub fn set_in_spec_embedded_color_profile(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        color_profile: Option<ae_sys::AEGP_ConstColorProfileP>,
+        profile_desc: Option<&str>,
+    ) -> Result<(), Error> {
         let profile_desc = if let Some(profile_desc) = profile_desc {
             Some(widestring::U16CString::from_str(profile_desc).map_err(|_| Error::InvalidParms)?)
         } else {
             None
         };
 
-        call_suite_fn!(self, AEGP_SetInSpecEmbeddedColorProfile, in_spec_handle.as_ptr(), color_profile.unwrap_or(core::ptr::null_mut()), profile_desc.as_ref().map_or(std::ptr::null(), |pd| pd.as_ptr()))
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecEmbeddedColorProfile,
+            in_spec_handle.as_ptr(),
+            color_profile.unwrap_or(core::ptr::null_mut()),
+            profile_desc
+                .as_ref()
+                .map_or(std::ptr::null(), |pd| pd.as_ptr())
+        )
     }
 
     /// Assign a valid RGB color profile to the footage.
-    pub fn set_in_spec_assigned_color_profile(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, color_profile: ae_sys::AEGP_ConstColorProfileP) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecAssignedColorProfile, in_spec_handle.as_ptr(), color_profile)
+    pub fn set_in_spec_assigned_color_profile(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        color_profile: ae_sys::AEGP_ConstColorProfileP,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecAssignedColorProfile,
+            in_spec_handle.as_ptr(),
+            color_profile
+        )
     }
 
     /// New in CC. Retrieves the native start time of the footage.
-    pub fn in_spec_native_start_time(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<Time, Error> {
+    pub fn in_spec_native_start_time(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<Time, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetInSpecNativeStartTime -> ae_sys::A_Time, in_spec_handle.as_ptr())?.into())
     }
 
     /// New in CC. Assign a native start time to the footage.
-    pub fn set_in_spec_native_start_time(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, start_time: Time) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecNativeStartTime, in_spec_handle.as_ptr(), &start_time.into() as *const _)
+    pub fn set_in_spec_native_start_time(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        start_time: Time,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecNativeStartTime,
+            in_spec_handle.as_ptr(),
+            &start_time.into() as *const _
+        )
     }
 
     /// New in CC. Clear the native start time of the footage.
     /// Setting the native start time to 0 using [`set_in_spec_native_start_time()`](Self::set_in_spec_native_start_time) doesn't do this.
     /// It still means there is a special native start time provided.
-    pub fn clear_in_spec_native_start_time(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_ClearInSpecNativeStartTime, in_spec_handle.as_ptr())
+    pub fn clear_in_spec_native_start_time(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_ClearInSpecNativeStartTime,
+            in_spec_handle.as_ptr()
+        )
     }
 
     /// New in CC. Retrieve the drop-frame setting of the footage.
-    pub fn in_spec_native_display_drop_frame(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetInSpecNativeDisplayDropFrame -> ae_sys::A_Boolean, in_spec_handle.as_ptr())? != 0)
+    pub fn in_spec_native_display_drop_frame(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetInSpecNativeDisplayDropFrame -> ae_sys::A_Boolean, in_spec_handle.as_ptr())?
+                != 0,
+        )
     }
 
     /// New in CC. Assign the drop-frame setting of the footage.
-    pub fn set_in_spec_native_display_drop_frame(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, drop_frame: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecNativeDisplayDropFrame, in_spec_handle.as_ptr(), drop_frame as _)
+    pub fn set_in_spec_native_display_drop_frame(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        drop_frame: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecNativeDisplayDropFrame,
+            in_spec_handle.as_ptr(),
+            drop_frame as _
+        )
     }
+
     // v6
-    pub fn set_in_spec_still_sequence_native_fps(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, native_still_seq_fps: i32) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecStillSequenceNativeFPS, in_spec_handle.as_ptr(), native_still_seq_fps as _)
+    pub fn set_in_spec_still_sequence_native_fps(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        native_still_seq_fps: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecStillSequenceNativeFPS,
+            in_spec_handle.as_ptr(),
+            native_still_seq_fps as _
+        )
     }
-    pub fn set_in_spec_color_space_from_cicp(&self, in_spec_handle: impl AsPtr<AEIO_InSpecH>, color_primaries_code: i32, transfer_characteristics_code: i32, matrix_coefficients_code: i32, full_range_video_flag: i32, bit_depth_l: i32, is_rgb: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetInSpecColorSpaceFromCICP, in_spec_handle.as_ptr(), color_primaries_code as _, transfer_characteristics_code as _, matrix_coefficients_code as _, full_range_video_flag as _, bit_depth_l as _, is_rgb as _)
+
+    pub fn set_in_spec_color_space_from_cicp(
+        &self,
+        in_spec_handle: impl AsPtr<AEIO_InSpecH>,
+        color_primaries_code: i32,
+        transfer_characteristics_code: i32,
+        matrix_coefficients_code: i32,
+        full_range_video_flag: i32,
+        bit_depth_l: i32,
+        is_rgb: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetInSpecColorSpaceFromCICP,
+            in_spec_handle.as_ptr(),
+            color_primaries_code as _,
+            transfer_characteristics_code as _,
+            matrix_coefficients_code as _,
+            full_range_video_flag as _,
+            bit_depth_l as _,
+            is_rgb as _
+        )
     }
 }
 
@@ -396,7 +639,11 @@ define_suite_item_wrapper!(
 impl InputSpecification {
     /// If your file format has auxiliary files which you want to prevent users from opening directly,
     /// pass it's extension, file type and creator to this function to keep it from appearing in input dialogs.
-    pub fn add_aux_ext_map(extension: &str, file_type: aeio::FileType, creator: i32) -> Result<(), Error> {
+    pub fn add_aux_ext_map(
+        extension: &str,
+        file_type: aeio::FileType,
+        creator: i32,
+    ) -> Result<(), Error> {
         IOInSuite::new()?.add_aux_ext_map(extension, file_type, creator)
     }
 }

--- a/after-effects/src/aegp/suites/item.rs
+++ b/after-effects/src/aegp/suites/item.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::aegp::*;
+use crate::*;
 use ae_sys::AEGP_ItemH;
 
 define_suite!(
@@ -17,19 +17,21 @@ define_suite!(
 impl ItemSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Retrieves the first item in a given project.
     pub fn first_proj_item(&self, project_handle: &ProjectHandle) -> Result<ItemHandle, Error> {
         Ok(ItemHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetFirstProjItem -> ae_sys::AEGP_ItemH, project_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetFirstProjItem -> ae_sys::AEGP_ItemH, project_handle.as_ptr())?,
         ))
     }
 
     /// Retrieves the next project item; Result will be `None` after the last item.
-    pub fn next_proj_item(&self, project_handle: &ProjectHandle, item_handle: impl AsPtr<AEGP_ItemH>) -> Result<Option<ItemHandle>, Error> {
+    pub fn next_proj_item(
+        &self,
+        project_handle: &ProjectHandle,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+    ) -> Result<Option<ItemHandle>, Error> {
         let next_item = call_suite_fn_single!(self, AEGP_GetNextProjItem -> ae_sys::AEGP_ItemH, project_handle.as_ptr(), item_handle.as_ptr())?;
         if next_item.is_null() {
             Ok(None)
@@ -53,15 +55,29 @@ impl ItemSuite {
 
     /// Returns true if the Project window is active and the item is selected.
     pub fn is_item_selected(&self, item_handle: impl AsPtr<AEGP_ItemH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsItemSelected -> ae_sys::A_Boolean, item_handle.as_ptr())? != 0)
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsItemSelected -> ae_sys::A_Boolean, item_handle.as_ptr())?
+                != 0,
+        )
     }
 
     /// Toggles the selection state of the item, and (depending on `deselect_others`) can deselect other items.
     /// This call selects items in the Project panel.
     ///
     /// To make selections in the Composition panel, use [`suites::Comp:set_selection()`](aegp::suites::Comp::set_selection).
-    pub fn select_item(&self, item_handle: impl AsPtr<AEGP_ItemH>, select: bool, deselect_others: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SelectItem, item_handle.as_ptr(), select.into(), deselect_others.into())
+    pub fn select_item(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        select: bool,
+        deselect_others: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SelectItem,
+            item_handle.as_ptr(),
+            select.into(),
+            deselect_others.into()
+        )
     }
 
     /// Gets type of an item. Note: solids don't appear in the project, but can be the source to a layer.
@@ -72,24 +88,38 @@ impl ItemSuite {
     /// Get name of type. (name length up to `32`).
     pub fn type_name(&self, item_type: ItemType) -> Result<String, Error> {
         let mut buffer = [0i8; ae_sys::AEGP_MAX_TYPE_NAME_SIZE as _];
-        call_suite_fn!(self, AEGP_GetTypeName, item_type.into(), buffer.as_mut_ptr() as *mut _)?;
-        Ok(unsafe { std::ffi::CStr::from_ptr(buffer.as_ptr()) }.to_string_lossy().into_owned())
+        call_suite_fn!(
+            self,
+            AEGP_GetTypeName,
+            item_type.into(),
+            buffer.as_mut_ptr() as *mut _
+        )?;
+        Ok(unsafe { std::ffi::CStr::from_ptr(buffer.as_ptr()) }
+            .to_string_lossy()
+            .into_owned())
     }
 
     /// Get item name.
-    pub fn item_name(&self, item_handle: impl AsPtr<AEGP_ItemH>, plugin_id: PluginId) -> Result<String, Error> {
+    pub fn item_name(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        plugin_id: PluginId,
+    ) -> Result<String, Error> {
         let mem_handle = call_suite_fn_single!(self, AEGP_GetItemName -> ae_sys::AEGP_MemHandle, plugin_id, item_handle.as_ptr())?;
         // Create a mem handle each and lock it.
         // When the lock goes out of scope it unlocks and when the handle goes out of scope it gives the memory back to Ae.
         Ok(unsafe {
-            U16CString::from_ptr_str(
-                MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr(),
-            ).to_string_lossy()
+            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
+                .to_string_lossy()
         })
     }
 
     /// Specifies the name of the [`ItemHandle`].
-    pub fn set_item_name(&self, item_handle: impl AsPtr<AEGP_ItemH>, name: &str) -> Result<(), Error> {
+    pub fn set_item_name(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        name: &str,
+    ) -> Result<(), Error> {
         let name = U16CString::from_str(name).map_err(|_| Error::InvalidParms)?;
         call_suite_fn!(self, AEGP_SetItemName, item_handle.as_ptr(), name.as_ptr())
     }
@@ -104,17 +134,30 @@ impl ItemSuite {
     /// Unlike the [`ItemFlags::HAS_AUDIO`] flag, this bit flag will set only if the comp has at least one layer where audio is actually on.
     pub fn item_flags(&self, item_handle: impl AsPtr<AEGP_ItemH>) -> Result<ItemFlags, Error> {
         Ok(ItemFlags::from_bits_truncate(
-            call_suite_fn_single!(self, AEGP_GetItemFlags -> ae_sys::A_long, item_handle.as_ptr())? as _
+            call_suite_fn_single!(self, AEGP_GetItemFlags -> ae_sys::A_long, item_handle.as_ptr())?
+                as _,
         ))
     }
 
     /// Toggle item's proxy usage. Undoable.
-    pub fn set_item_use_proxy(&self, item_handle: impl AsPtr<AEGP_ItemH>, use_proxy: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetItemUseProxy, item_handle.as_ptr(), use_proxy.into())
+    pub fn set_item_use_proxy(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        use_proxy: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetItemUseProxy,
+            item_handle.as_ptr(),
+            use_proxy.into()
+        )
     }
 
     /// Get folder containing item.
-    pub fn item_parent_folder(&self, item_handle: impl AsPtr<AEGP_ItemH>) -> Result<Option<ItemHandle>, Error> {
+    pub fn item_parent_folder(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+    ) -> Result<Option<ItemHandle>, Error> {
         let parent_folder = call_suite_fn_single!(self, AEGP_GetItemParentFolder -> ae_sys::AEGP_ItemH, item_handle.as_ptr())?;
         if parent_folder.is_null() {
             Ok(None)
@@ -124,8 +167,17 @@ impl ItemSuite {
     }
 
     /// Sets an item's parent folder. Undoable.
-    pub fn set_item_parent_folder(&self, item_handle: impl AsPtr<AEGP_ItemH>, parent_folder: &ItemHandle) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetItemParentFolder, item_handle.as_ptr(), parent_folder.as_ptr())
+    pub fn set_item_parent_folder(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        parent_folder: &ItemHandle,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetItemParentFolder,
+            item_handle.as_ptr(),
+            parent_folder.as_ptr()
+        )
     }
 
     /// Get duration of item, in seconds.
@@ -139,16 +191,19 @@ impl ItemSuite {
     }
 
     /// Get width and height of item.
-    pub fn item_dimensions(&self, item_handle: impl AsPtr<AEGP_ItemH>) -> Result<(u32, u32), Error> {
+    pub fn item_dimensions(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+    ) -> Result<(u32, u32), Error> {
         let (width, height) = call_suite_fn_double!(self, AEGP_GetItemDimensions -> ae_sys::A_long, ae_sys:: A_long, item_handle.as_ptr())?;
-        Ok((
-            width as _,
-            height as _
-        ))
+        Ok((width as _, height as _))
     }
 
     /// Get the width of a pixel, assuming its height is 1.0, as numerator over denominator.
-    pub fn item_pixel_aspect_ratio(&self, item_handle: impl AsPtr<AEGP_ItemH>) -> Result<Ratio, Error> {
+    pub fn item_pixel_aspect_ratio(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+    ) -> Result<Ratio, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetItemPixelAspectRatio -> ae_sys::A_Ratio, item_handle.as_ptr())?.into())
     }
 
@@ -161,36 +216,55 @@ impl ItemSuite {
     /// Creates a new folder in the project. The newly created folder is allocated and owned by After Effects.
     ///
     /// Passing `None` for `parent_folder` creates the folder at the project's root.
-    pub fn create_new_folder(&self, name: &str, parent_folder: Option<ItemHandle>) -> Result<ItemHandle, Error> {
+    pub fn create_new_folder(
+        &self,
+        name: &str,
+        parent_folder: Option<ItemHandle>,
+    ) -> Result<ItemHandle, Error> {
         let name = U16CString::from_str(name).map_err(|_| Error::InvalidParms)?;
-        Ok(ItemHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_CreateNewFolder -> ae_sys::AEGP_ItemH,
-                name.as_ptr(),
-                parent_folder.as_ref().map_or(std::ptr::null_mut(), |f| f.as_ptr())
-            )?
-        ))
+        Ok(ItemHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_CreateNewFolder -> ae_sys::AEGP_ItemH,
+            name.as_ptr(),
+            parent_folder.as_ref().map_or(std::ptr::null_mut(), |f| f.as_ptr())
+        )?))
     }
 
     /// Sets the current time within a given [`ItemHandle`].
-    pub fn set_item_current_time(&self, item_handle: impl AsPtr<AEGP_ItemH>, new_time: Time) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetItemCurrentTime, item_handle.as_ptr(), &new_time.into())
+    pub fn set_item_current_time(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        new_time: Time,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetItemCurrentTime,
+            item_handle.as_ptr(),
+            &new_time.into()
+        )
     }
 
     /// Retrieves the [`ItemHandle`]'s comment.
     pub fn item_comment(&self, item_handle: impl AsPtr<AEGP_ItemH>) -> Result<String, Error> {
         let mem_handle = call_suite_fn_single!(self, AEGP_GetItemComment -> ae_sys::AEGP_MemHandle, item_handle.as_ptr())?;
         Ok(unsafe {
-            U16CString::from_ptr_str(
-                MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr(),
-            ).to_string_lossy()
+            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
+                .to_string_lossy()
         })
     }
 
     /// Sets the [`ItemHandle`]'s comment.
-    pub fn set_item_comment(&self, item_handle: impl AsPtr<AEGP_ItemH>, comment: &str) -> Result<(), Error> {
+    pub fn set_item_comment(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        comment: &str,
+    ) -> Result<(), Error> {
         let comment = U16CString::from_str(comment).map_err(|_| Error::InvalidParms)?;
-        call_suite_fn!(self, AEGP_SetItemComment, item_handle.as_ptr(), comment.as_ptr())
+        call_suite_fn!(
+            self,
+            AEGP_SetItemComment,
+            item_handle.as_ptr(),
+            comment.as_ptr()
+        )
     }
 
     /// Retrieves an item's label.
@@ -199,14 +273,21 @@ impl ItemSuite {
     }
 
     /// Sets an item's label.
-    pub fn set_item_label(&self, item_handle: impl AsPtr<AEGP_ItemH>, label: LabelId) -> Result<(), Error> {
+    pub fn set_item_label(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+        label: LabelId,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetItemLabel, item_handle.as_ptr(), label.into())
     }
 
     /// Gets an item's most recently used view.
     ///
     /// The view can be used with two calls in the [`suites::ColorSettings`](aegp::suites::ColorSettings), to perform a color transform on a pixel buffer from working to view color space.
-    pub fn item_mru_view(&self, item_handle: impl AsPtr<AEGP_ItemH>) -> Result<ae_sys::AEGP_ItemViewP, Error> {
+    pub fn item_mru_view(
+        &self,
+        item_handle: impl AsPtr<AEGP_ItemH>,
+    ) -> Result<ae_sys::AEGP_ItemViewP, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetItemMRUView -> ae_sys::AEGP_ItemViewP, item_handle.as_ptr())?.into())
     }
 }
@@ -388,24 +469,30 @@ define_suite_item_wrapper!(
 impl Item {
     /// Get name of type. (name length up to `32`).
     pub fn type_name(&self) -> Result<String, Error> {
-        let Ok(ref suite) = *self.suite else { return Err(Error::MissingSuite); };
+        let Ok(ref suite) = *self.suite else {
+            return Err(Error::MissingSuite);
+        };
         suite.type_name(self.item_type()?)
     }
 
     /// Creates a new folder in the project, inside the current item.
     /// The newly created folder is allocated and owned by After Effects.
     pub fn create_folder_inside(&self, name: &str) -> Result<Item, Error> {
-        let Ok(ref suite) = *self.suite else { return Err(Error::MissingSuite); };
+        let Ok(ref suite) = *self.suite else {
+            return Err(Error::MissingSuite);
+        };
         Ok(Item::from_handle(
             suite.create_new_folder(name, Some(self.handle))?,
-            false
+            false,
         ))
     }
 
     /// Returns the composition for this item. Returns an error if the item isn't a composition.
     pub fn composition(&self) -> Result<Composition, Error> {
         if self.item_type()? == ItemType::Comp {
-            let Ok(ref comp) = *self.comp else { return Err(Error::MissingSuite); };
+            let Ok(ref comp) = *self.comp else {
+                return Err(Error::MissingSuite);
+            };
             Ok(comp.comp_from_item(self.as_ptr())?.unwrap().into())
         } else {
             Err(Error::Parameter)

--- a/after-effects/src/aegp/suites/keyframe.rs
+++ b/after-effects/src/aegp/suites/keyframe.rs
@@ -1,6 +1,6 @@
-use crate::*;
 use crate::aegp::*;
-use ae_sys::{ A_long, A_short, A_Time, AEGP_StreamValue2, AEGP_KeyframeEase, AEGP_StreamRefH };
+use crate::*;
+use ae_sys::{A_Time, A_long, A_short, AEGP_KeyframeEase, AEGP_StreamRefH, AEGP_StreamValue2};
 
 define_suite!(
     /// Keyframes make After Effects what it is. AEGPs (and...ssshh, don't tell anyone...effects) can use this suite to add, manipulate and remove keyframes from any keyframe-able stream.
@@ -24,9 +24,7 @@ define_suite!(
 impl KeyframeSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Retrieves the number of keyframes on the given stream.
     ///
@@ -38,7 +36,12 @@ impl KeyframeSuite {
     }
 
     /// Retrieves the time of the specified keyframe.
-    pub fn keyframe_time(&self, stream: impl AsPtr<AEGP_StreamRefH>, key_index: i32, time_mode: TimeMode) -> Result<Time, Error> {
+    pub fn keyframe_time(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        key_index: i32,
+        time_mode: TimeMode,
+    ) -> Result<Time, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetKeyframeTime -> A_Time, stream.as_ptr(), key_index, time_mode.into())?.into())
     }
 
@@ -49,17 +52,34 @@ impl KeyframeSuite {
     /// All indexes greater than the new index are now invalid (but you knew that).
     ///
     /// If there is already a keyframe at that time, the values will be updated.
-    pub fn insert_keyframe(&self, stream: impl AsPtr<AEGP_StreamRefH>, time_mode: TimeMode, time: Time) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_InsertKeyframe -> A_long, stream.as_ptr(), time_mode.into(), &time.into() as *const _)? as i32)
+    pub fn insert_keyframe(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        time_mode: TimeMode,
+        time: Time,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_InsertKeyframe -> A_long, stream.as_ptr(), time_mode.into(), &time.into() as *const _)?
+                as i32,
+        )
     }
 
     /// Deletes the specified keyframe.
-    pub fn delete_keyframe(&self, stream: impl AsPtr<AEGP_StreamRefH>, key_index: i32) -> Result<(), Error> {
+    pub fn delete_keyframe(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        key_index: i32,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_DeleteKeyframe, stream.as_ptr(), key_index)
     }
 
     /// Creates and populates an [`StreamValue`] for the stream's value at the time of the keyframe.
-    pub fn new_keyframe_value(&self, stream: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId, key_index: i32) -> Result<StreamValue, Error> {
+    pub fn new_keyframe_value(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+        key_index: i32,
+    ) -> Result<StreamValue, Error> {
         let stream_suite = aegp::suites::Stream::new()?;
         let type_ = stream_suite.stream_type(stream.as_ptr())?;
 
@@ -71,33 +91,60 @@ impl KeyframeSuite {
     }
 
     /// Sets the stream's value at the time of the keyframe.
-    pub fn set_keyframe_value(&self, stream: impl AsPtr<AEGP_StreamRefH>, key_index: i32, value: StreamValue) -> Result<(), Error> {
+    pub fn set_keyframe_value(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        key_index: i32,
+        value: StreamValue,
+    ) -> Result<(), Error> {
         let sys_stream_value2 = AEGP_StreamValue2 {
             streamH: stream.as_ptr(),
-            val: value.to_sys()
+            val: value.to_sys(),
         };
-        call_suite_fn!(self, AEGP_SetKeyframeValue, stream.as_ptr(), key_index, &sys_stream_value2)
+        call_suite_fn!(
+            self,
+            AEGP_SetKeyframeValue,
+            stream.as_ptr(),
+            key_index,
+            &sys_stream_value2
+        )
     }
 
     /// Retrieves the dimensionality of the stream's value.
-    pub fn stream_value_dimensionality(&self, stream: impl AsPtr<AEGP_StreamRefH>) -> Result<i16, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetStreamValueDimensionality -> A_short, stream.as_ptr())? as i16)
+    pub fn stream_value_dimensionality(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<i16, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetStreamValueDimensionality -> A_short, stream.as_ptr())?
+                as i16,
+        )
     }
 
     /// Retrieves the temporal dimensionality of the stream.
-    pub fn stream_temporal_dimensionality(&self, stream: impl AsPtr<AEGP_StreamRefH>) -> Result<i16, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetStreamTemporalDimensionality -> A_short, stream.as_ptr())? as i16)
+    pub fn stream_temporal_dimensionality(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<i16, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetStreamTemporalDimensionality -> A_short, stream.as_ptr())?
+                as i16,
+        )
     }
 
     /// Returns the [`StreamValue`]s representing the stream's tangential values at the time of the keyframe.
     ///
     /// Returns a tuple containing the in and out tangents.
-    pub fn new_keyframe_spatial_tangents(&self, stream: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId, key_index: i32) -> Result<(StreamValue, StreamValue), Error> {
+    pub fn new_keyframe_spatial_tangents(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+        key_index: i32,
+    ) -> Result<(StreamValue, StreamValue), Error> {
         let stream_suite = aegp::suites::Stream::new()?;
         let type_ = stream_suite.stream_type(stream.as_ptr())?;
 
-        let (mut sys_in_tan, mut sys_out_tan) =
-            call_suite_fn_double!(self, AEGP_GetNewKeyframeSpatialTangents -> AEGP_StreamValue2, AEGP_StreamValue2, plugin_id, stream.as_ptr(), key_index)?;
+        let (mut sys_in_tan, mut sys_out_tan) = call_suite_fn_double!(self, AEGP_GetNewKeyframeSpatialTangents -> AEGP_StreamValue2, AEGP_StreamValue2, plugin_id, stream.as_ptr(), key_index)?;
 
         let in_tan = StreamValue::from_sys(type_, sys_in_tan.val);
         let out_tan = StreamValue::from_sys(type_, sys_out_tan.val);
@@ -109,75 +156,162 @@ impl KeyframeSuite {
     }
 
     /// Specifies the tangential [`StreamValue`]s to be used for the stream's value at the time of the keyframe.
-    pub fn set_keyframe_spatial_tangents(&self, stream: impl AsPtr<AEGP_StreamRefH>, key_index: i32, in_tan: StreamValue, out_tan: StreamValue) -> Result<(), Error> {
+    pub fn set_keyframe_spatial_tangents(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        key_index: i32,
+        in_tan: StreamValue,
+        out_tan: StreamValue,
+    ) -> Result<(), Error> {
         let sys_in_tan = AEGP_StreamValue2 {
             streamH: stream.as_ptr(),
-            val: in_tan.to_sys()
+            val: in_tan.to_sys(),
         };
         let sys_out_tan = AEGP_StreamValue2 {
             streamH: stream.as_ptr(),
-            val: out_tan.to_sys()
+            val: out_tan.to_sys(),
         };
-        call_suite_fn!(self, AEGP_SetKeyframeSpatialTangents, stream.as_ptr(), key_index, &sys_in_tan, &sys_out_tan)
+        call_suite_fn!(
+            self,
+            AEGP_SetKeyframeSpatialTangents,
+            stream.as_ptr(),
+            key_index,
+            &sys_in_tan,
+            &sys_out_tan
+        )
     }
 
     /// Retrieves the [`AEGP_KeyframeEase`](after_effects_sys::AEGP_KeyframeEase)s associated with the specified dimension of the stream's value at the time of the keyframe.
-    pub fn keyframe_temporal_ease(&self, stream: impl AsPtr<AEGP_StreamRefH>, key_index: i32, dimension: i32) -> Result<(AEGP_KeyframeEase, AEGP_KeyframeEase), Error> {
+    pub fn keyframe_temporal_ease(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        key_index: i32,
+        dimension: i32,
+    ) -> Result<(AEGP_KeyframeEase, AEGP_KeyframeEase), Error> {
         call_suite_fn_double!(self, AEGP_GetKeyframeTemporalEase -> ae_sys::AEGP_KeyframeEase, ae_sys::AEGP_KeyframeEase, stream.as_ptr(), key_index, dimension)
     }
 
     /// Specifies the [`AEGP_KeyframeEase`](after_effects_sys::AEGP_KeyframeEase)s to be used for the stream's value at the time of the keyframe.
-    pub fn set_keyframe_temporal_ease(&self, stream: impl AsPtr<AEGP_StreamRefH>, key_index: i32, dimension: i32, in_ease: &AEGP_KeyframeEase, out_ease: &AEGP_KeyframeEase) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetKeyframeTemporalEase, stream.as_ptr(), key_index, dimension, in_ease, out_ease)
+    pub fn set_keyframe_temporal_ease(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        key_index: i32,
+        dimension: i32,
+        in_ease: &AEGP_KeyframeEase,
+        out_ease: &AEGP_KeyframeEase,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetKeyframeTemporalEase,
+            stream.as_ptr(),
+            key_index,
+            dimension,
+            in_ease,
+            out_ease
+        )
     }
 
     /// Retrieves the flags currently set for the keyframe.
-    pub fn keyframe_flags(&self, stream: impl AsPtr<AEGP_StreamRefH>, key_index: i32) -> Result<KeyframeFlags, Error> {
+    pub fn keyframe_flags(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        key_index: i32,
+    ) -> Result<KeyframeFlags, Error> {
         Ok(KeyframeFlags::from_bits_truncate(
-            call_suite_fn_single!(self, AEGP_GetKeyframeFlags -> ae_sys::AEGP_KeyframeFlags, stream.as_ptr(), key_index)?
+            call_suite_fn_single!(self, AEGP_GetKeyframeFlags -> ae_sys::AEGP_KeyframeFlags, stream.as_ptr(), key_index)?,
         ))
     }
 
     /// Sets the specified flag for the keyframe. Flags must be set individually.
-    pub fn set_keyframe_flag(&self, stream: impl AsPtr<AEGP_StreamRefH>, key_index: i32, flag: KeyframeFlags, value: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetKeyframeFlag, stream.as_ptr(), key_index, flag.bits(), value.into())
+    pub fn set_keyframe_flag(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        key_index: i32,
+        flag: KeyframeFlags,
+        value: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetKeyframeFlag,
+            stream.as_ptr(),
+            key_index,
+            flag.bits(),
+            value.into()
+        )
     }
 
     /// Retrieves the in and out [`KeyframeInterpolation`]s for the specified keyframe.
-    pub fn keyframe_interpolation(&self, stream: impl AsPtr<AEGP_StreamRefH>, key_index: i32) -> Result<(KeyframeInterpolation, KeyframeInterpolation), Error> {
-        let (in_interp, out_interp) =
-            call_suite_fn_double!(self,
-                AEGP_GetKeyframeInterpolation -> ae_sys::AEGP_KeyframeInterpolationType, ae_sys::AEGP_KeyframeInterpolationType,
-                stream.as_ptr(),
-                key_index
-            )?;
+    pub fn keyframe_interpolation(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        key_index: i32,
+    ) -> Result<(KeyframeInterpolation, KeyframeInterpolation), Error> {
+        let (in_interp, out_interp) = call_suite_fn_double!(self,
+            AEGP_GetKeyframeInterpolation -> ae_sys::AEGP_KeyframeInterpolationType, ae_sys::AEGP_KeyframeInterpolationType,
+            stream.as_ptr(),
+            key_index
+        )?;
         Ok((in_interp.into(), out_interp.into()))
     }
 
     /// Specifies the in and out [`KeyframeInterpolation`]s to be used for the given keyframe.
-    pub fn set_keyframe_interpolation(&self, stream: impl AsPtr<AEGP_StreamRefH>, key_index: i32, in_interp: KeyframeInterpolation, out_interp: KeyframeInterpolation) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetKeyframeInterpolation, stream.as_ptr(), key_index, in_interp.into(), out_interp.into())
+    pub fn set_keyframe_interpolation(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        key_index: i32,
+        in_interp: KeyframeInterpolation,
+        out_interp: KeyframeInterpolation,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetKeyframeInterpolation,
+            stream.as_ptr(),
+            key_index,
+            in_interp.into(),
+            out_interp.into()
+        )
     }
 
     /// Informs After Effects that you're going to be adding several keyframes to the specified stream.
     ///
     /// Returns an [`AddKeyframesInfoHandle`], which you can use to add keyframes.
-    pub fn start_add_keyframes(&self, stream: impl AsPtr<AEGP_StreamRefH>) -> Result<AddKeyframesInfoHandle, Error> {
+    pub fn start_add_keyframes(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<AddKeyframesInfoHandle, Error> {
         Ok(AddKeyframesInfoHandle {
             suite: self.clone(),
             handle: call_suite_fn_single!(self, AEGP_StartAddKeyframes -> ae_sys::AEGP_AddKeyframesInfoH, stream.as_ptr())?,
-            add: true
+            add: true,
         })
     }
 
     /// Retrieves the label color index for the specified keyframe.
-    pub fn keyframe_label_color_index(&self, stream: impl AsPtr<AEGP_StreamRefH>, key_index: i32) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetKeyframeLabelColorIndex -> A_long, stream.as_ptr(), key_index)? as i32)
+    pub fn keyframe_label_color_index(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        key_index: i32,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetKeyframeLabelColorIndex -> A_long, stream.as_ptr(), key_index)?
+                as i32,
+        )
     }
 
     /// Specifies the label color index to be used for the specified keyframe.
-    pub fn set_keyframe_label_color_index(&self, stream: impl AsPtr<AEGP_StreamRefH>, key_index: i32, key_label: i32) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetKeyframeLabelColorIndex, stream.as_ptr(), key_index, key_label)
+    pub fn set_keyframe_label_color_index(
+        &self,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        key_index: i32,
+        key_label: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetKeyframeLabelColorIndex,
+            stream.as_ptr(),
+            key_index,
+            key_label
+        )
     }
 }
 
@@ -228,22 +362,34 @@ impl AddKeyframesInfoHandle {
     ///
     /// Note: this doesn't actually do anything to the stream's value.
     pub fn add_keyframes(&mut self, time_mode: TimeMode, time: Time) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self.suite, AEGP_AddKeyframes -> A_long, self.handle, time_mode.into(), &time.into() as *const _)? as i32)
+        Ok(
+            call_suite_fn_single!(self.suite, AEGP_AddKeyframes -> A_long, self.handle, time_mode.into(), &time.into() as *const _)?
+                as i32,
+        )
     }
 
     /// Sets the value of the specified keyframe.
-    pub fn set_add_keyframe(&mut self, key_index: i32, stream: impl AsPtr<AEGP_StreamRefH>, value: StreamValue) -> Result<(), Error> {
+    pub fn set_add_keyframe(
+        &mut self,
+        key_index: i32,
+        stream: impl AsPtr<AEGP_StreamRefH>,
+        value: StreamValue,
+    ) -> Result<(), Error> {
         let sys_stream_value2 = AEGP_StreamValue2 {
             streamH: stream.as_ptr(),
-            val: value.to_sys()
+            val: value.to_sys(),
         };
-        call_suite_fn!(self.suite, AEGP_SetAddKeyframe, self.handle, key_index, &sys_stream_value2)
+        call_suite_fn!(
+            self.suite,
+            AEGP_SetAddKeyframe,
+            self.handle,
+            key_index,
+            &sys_stream_value2
+        )
     }
 
     /// Sets the `add` flag, used in a call to `AEGP_EndAddKeyframes`. Defaults to true
-    pub fn set_add(&mut self, add: bool) {
-        self.add = add;
-    }
+    pub fn set_add(&mut self, add: bool) { self.add = add; }
 }
 impl Drop for AddKeyframesInfoHandle {
     fn drop(&mut self) {

--- a/after-effects/src/aegp/suites/layer.rs
+++ b/after-effects/src/aegp/suites/layer.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::aegp::*;
+use crate::*;
 use ae_sys::{AEGP_CompH, AEGP_LayerH};
 
 define_suite!(
@@ -37,19 +37,24 @@ define_suite!(
 impl LayerSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Obtains the number of layers in a composition.
     pub fn comp_num_layers(&self, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<usize, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetCompNumLayers -> i32, comp_handle.as_ptr())? as usize)
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetCompNumLayers -> i32, comp_handle.as_ptr())?
+                as usize,
+        )
     }
 
     /// Get a [`LayerHandle`] from a composition. Zero is the foremost layer.
-    pub fn comp_layer_by_index(&self, comp_handle: impl AsPtr<AEGP_CompH>, layer_index: usize) -> Result<LayerHandle, Error> {
+    pub fn comp_layer_by_index(
+        &self,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+        layer_index: usize,
+    ) -> Result<LayerHandle, Error> {
         Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetCompLayerByIndex -> ae_sys::AEGP_LayerH, comp_handle.as_ptr(), layer_index as _)?
+            call_suite_fn_single!(self, AEGP_GetCompLayerByIndex -> ae_sys::AEGP_LayerH, comp_handle.as_ptr(), layer_index as _)?,
         ))
     }
 
@@ -71,95 +76,170 @@ impl LayerSuite {
     }
 
     /// Get the [`ItemHandle`] of the layer's source item.
-    pub fn layer_source_item(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<ItemHandle, Error> {
+    pub fn layer_source_item(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<ItemHandle, Error> {
         Ok(ItemHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetLayerSourceItem -> ae_sys::AEGP_ItemH, layer_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetLayerSourceItem -> ae_sys::AEGP_ItemH, layer_handle.as_ptr())?,
         ))
     }
 
     /// Retrieves the ID of the given [`LayerHandle`].
     ///
     /// This is useful when hunting for a specific layer's ID in an [`StreamValue`].
-    pub fn layer_source_item_id(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<i32, Error> {
+    pub fn layer_source_item_id(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<i32, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetLayerSourceItemID -> i32, layer_handle.as_ptr())?)
     }
 
     /// Get the AEGP_CompH of the composition containing the layer.
-    pub fn layer_parent_comp(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<CompHandle, Error> {
+    pub fn layer_parent_comp(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<CompHandle, Error> {
         Ok(CompHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetLayerParentComp -> ae_sys::AEGP_CompH, layer_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetLayerParentComp -> ae_sys::AEGP_CompH, layer_handle.as_ptr())?,
         ))
     }
 
     /// Get the name of a layer.
-    pub fn layer_name(&self, layer_handle: impl AsPtr<AEGP_LayerH>, plugin_id: PluginId) -> Result<(String, String), Error> {
+    pub fn layer_name(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        plugin_id: PluginId,
+    ) -> Result<(String, String), Error> {
         let (layer_name, source_name) = call_suite_fn_double!(self, AEGP_GetLayerName ->ae_sys::AEGP_MemHandle, ae_sys::AEGP_MemHandle, plugin_id, layer_handle.as_ptr())?;
         unsafe {
             Ok((
                 // Create a mem handle each and lock it.
                 // When the lock goes out of scope it unlocks and when the handle goes out of scope it gives the memory back to Ae.
-                U16CString::from_ptr_str(MemHandle::<u16>::from_raw(layer_name)?.lock()?.as_ptr()).to_string_lossy(),
-                U16CString::from_ptr_str(MemHandle::<u16>::from_raw(source_name)?.lock()?.as_ptr()).to_string_lossy()
+                U16CString::from_ptr_str(MemHandle::<u16>::from_raw(layer_name)?.lock()?.as_ptr())
+                    .to_string_lossy(),
+                U16CString::from_ptr_str(MemHandle::<u16>::from_raw(source_name)?.lock()?.as_ptr())
+                    .to_string_lossy(),
             ))
         }
     }
 
     /// Get the quality of a layer.
-    pub fn layer_quality(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<LayerQuality, Error> {
+    pub fn layer_quality(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<LayerQuality, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetLayerQuality -> ae_sys::AEGP_LayerQuality, layer_handle.as_ptr())?.into())
     }
 
     /// Sets the quality of a layer. Undoable.
-    pub fn set_layer_quality(&self, layer_handle: impl AsPtr<AEGP_LayerH>, quality: LayerQuality) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetLayerQuality, layer_handle.as_ptr(), quality.into())
+    pub fn set_layer_quality(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        quality: LayerQuality,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetLayerQuality,
+            layer_handle.as_ptr(),
+            quality.into()
+        )
     }
 
     /// Get flags for a layer.
     pub fn layer_flags(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<LayerFlags, Error> {
         Ok(LayerFlags::from_bits_truncate(
-            call_suite_fn_single!(self, AEGP_GetLayerFlags -> ae_sys::AEGP_LayerFlags, layer_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetLayerFlags -> ae_sys::AEGP_LayerFlags, layer_handle.as_ptr())?,
         ))
     }
 
     /// Sets one layer flag at a time. Undoable.
-    pub fn set_layer_flag(&self, layer_handle: impl AsPtr<AEGP_LayerH>, single_flag: LayerFlags, value: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetLayerFlag, layer_handle.as_ptr(), single_flag.bits(), value as _)
+    pub fn set_layer_flag(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        single_flag: LayerFlags,
+        value: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetLayerFlag,
+            layer_handle.as_ptr(),
+            single_flag.bits(),
+            value as _
+        )
     }
 
     /// Determines whether the layer's video is visible.
     ///
     /// This is necessary to account for 'solo' status of other layers in the composition; non-solo'd layers are still on.
-    pub fn is_layer_video_really_on(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsLayerVideoReallyOn -> ae_sys::A_Boolean, layer_handle.as_ptr())? != 0)
+    pub fn is_layer_video_really_on(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsLayerVideoReallyOn -> ae_sys::A_Boolean, layer_handle.as_ptr())?
+                != 0,
+        )
     }
 
     /// Accounts for solo status of other layers in the composition.
-    pub fn is_layer_audio_really_on(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsLayerAudioReallyOn -> ae_sys::A_Boolean, layer_handle.as_ptr())? != 0)
+    pub fn is_layer_audio_really_on(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsLayerAudioReallyOn -> ae_sys::A_Boolean, layer_handle.as_ptr())?
+                != 0,
+        )
     }
 
     /// Get current time, in layer or composition timespace. This value is not updated during rendering.
     ///
     /// NOTE: If a layer starts at other than time 0 or is time-stretched other than 100%, layer time and composition time are distinct.
-    pub fn layer_current_time(&self, layer_handle: impl AsPtr<AEGP_LayerH>, time_mode: TimeMode) -> Result<Time, Error> {
+    pub fn layer_current_time(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        time_mode: TimeMode,
+    ) -> Result<Time, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetLayerCurrentTime -> ae_sys::A_Time, layer_handle.as_ptr(), time_mode.into())?.into())
     }
 
     /// Get time of first visible frame in composition or layer time.
     ///
     /// In layer time, the `in_point` is always 0.
-    pub fn layer_in_point(&self, layer_handle: impl AsPtr<AEGP_LayerH>, time_mode: TimeMode) -> Result<Time, Error> {
+    pub fn layer_in_point(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        time_mode: TimeMode,
+    ) -> Result<Time, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetLayerInPoint -> ae_sys::A_Time, layer_handle.as_ptr(), time_mode.into())?.into())
     }
 
     /// Get duration of layer, in composition or layer time, in seconds.
-    pub fn layer_duration(&self, layer_handle: impl AsPtr<AEGP_LayerH>, time_mode: TimeMode) -> Result<Time, Error> {
+    pub fn layer_duration(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        time_mode: TimeMode,
+    ) -> Result<Time, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetLayerDuration -> ae_sys::A_Time, layer_handle.as_ptr(), time_mode.into())?.into())
     }
 
     /// Set duration and in point of layer in composition or layer time. Undo-able.
-    pub fn set_layer_in_point_and_duration(&self, layer_handle: impl AsPtr<AEGP_LayerH>, in_point: Time, duration: Time, time_mode: TimeMode) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetLayerInPointAndDuration, layer_handle.as_ptr(), time_mode.into(), &in_point.into() as *const _, &duration.into() as *const _)
+    pub fn set_layer_in_point_and_duration(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        in_point: Time,
+        duration: Time,
+        time_mode: TimeMode,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetLayerInPointAndDuration,
+            layer_handle.as_ptr(),
+            time_mode.into(),
+            &in_point.into() as *const _,
+            &duration.into() as *const _
+        )
     }
 
     /// Get the offset from the start of the composition to layer time 0, in composition time.
@@ -168,8 +248,17 @@ impl LayerSuite {
     }
 
     /// Set the offset from the start of the composition to the first frame of the layer, in composition time. Undoable.
-    pub fn set_layer_offset(&self, layer_handle: impl AsPtr<AEGP_LayerH>, offset: Time) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetLayerOffset, layer_handle.as_ptr(), &offset.into() as *const _)
+    pub fn set_layer_offset(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        offset: Time,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetLayerOffset,
+            layer_handle.as_ptr(),
+            &offset.into() as *const _
+        )
     }
 
     /// Get stretch factor of a layer.
@@ -178,12 +267,24 @@ impl LayerSuite {
     }
 
     /// Set stretch factor of a layer.
-    pub fn set_layer_stretch(&self, layer_handle: impl AsPtr<AEGP_LayerH>, stretch: Ratio) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetLayerStretch, layer_handle.as_ptr(), &stretch.into() as *const _)
+    pub fn set_layer_stretch(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        stretch: Ratio,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetLayerStretch,
+            layer_handle.as_ptr(),
+            &stretch.into() as *const _
+        )
     }
 
     /// Get transfer mode of a layer.
-    pub fn layer_transfer_mode(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<ae_sys::AEGP_LayerTransferMode, Error> {
+    pub fn layer_transfer_mode(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<ae_sys::AEGP_LayerTransferMode, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetLayerTransferMode -> ae_sys::AEGP_LayerTransferMode, layer_handle.as_ptr())?.into())
     }
 
@@ -191,8 +292,17 @@ impl LayerSuite {
     ///
     /// As of 23.0, when you make a layer a track matte, the layer being matted will be disabled,
     /// as when you do this via the interface.
-    pub fn set_layer_transfer_mode(&self, layer_handle: impl AsPtr<AEGP_LayerH>, transfer_mode: &ae_sys::AEGP_LayerTransferMode) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetLayerTransferMode, layer_handle.as_ptr(), transfer_mode)
+    pub fn set_layer_transfer_mode(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        transfer_mode: &ae_sys::AEGP_LayerTransferMode,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetLayerTransferMode,
+            layer_handle.as_ptr(),
+            transfer_mode
+        )
     }
 
     /// Tests whether it's currently valid to add a given item to a composition.
@@ -200,101 +310,187 @@ impl LayerSuite {
     /// A composition cannot be added to itself, or to any compositions which it contains; other conditions can preclude successful adding too.
     ///
     /// Adding a layer without first using this function will produce undefined results.
-    pub fn is_add_layer_valid(&self, item_handle: &ItemHandle, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsAddLayerValid -> ae_sys::A_Boolean, item_handle.as_ptr(), comp_handle.as_ptr())? != 0)
+    pub fn is_add_layer_valid(
+        &self,
+        item_handle: &ItemHandle,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsAddLayerValid -> ae_sys::A_Boolean, item_handle.as_ptr(), comp_handle.as_ptr())?
+                != 0,
+        )
     }
 
     /// Add an item to the composition, above all other layers. Undo-able.
     ///
     /// Use [`Self::is_add_layer_valid()`] first, to confirm that it's possible.
-    pub fn add_layer(&self, item_handle: &ItemHandle, comp_handle: impl AsPtr<AEGP_CompH>) -> Result<LayerHandle, Error> {
+    pub fn add_layer(
+        &self,
+        item_handle: &ItemHandle,
+        comp_handle: impl AsPtr<AEGP_CompH>,
+    ) -> Result<LayerHandle, Error> {
         Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_AddLayer -> ae_sys::AEGP_LayerH, item_handle.as_ptr(), comp_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_AddLayer -> ae_sys::AEGP_LayerH, item_handle.as_ptr(), comp_handle.as_ptr())?,
         ))
     }
 
     /// Change the order of layers. Undoable.
     ///
     /// To add a layer to the end of the composition, to use `layer_index = -1`
-    pub fn reorder_layer(&self, layer_handle: impl AsPtr<AEGP_LayerH>, layer_index: i32) -> Result<(), Error> {
+    pub fn reorder_layer(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        layer_index: i32,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_ReorderLayer, layer_handle.as_ptr(), layer_index)
     }
 
     /// Given a layer's handle and a time, returns the bounds of area visible with masks applied.
-    pub fn layer_masked_bounds(&self, layer_handle: impl AsPtr<AEGP_LayerH>, time_mode: TimeMode, time: Time) -> Result<FloatRect, Error> {
+    pub fn layer_masked_bounds(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        time_mode: TimeMode,
+        time: Time,
+    ) -> Result<FloatRect, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetLayerMaskedBounds -> ae_sys::A_FloatRect, layer_handle.as_ptr(), time_mode.into(), &time.into() as *const _)?.into())
     }
 
     /// Returns a layer's object type.
-    pub fn layer_object_type(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<ObjectType, Error> {
+    pub fn layer_object_type(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<ObjectType, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetLayerObjectType -> ae_sys::AEGP_ObjectType, layer_handle.as_ptr())?.into())
     }
 
     /// Is the footage item a 3D layer. All AV layers are either 2D or 3D.
     pub fn is_layer_3d(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsLayer3D -> ae_sys::A_Boolean, layer_handle.as_ptr())? != 0)
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsLayer3D -> ae_sys::A_Boolean, layer_handle.as_ptr())?
+                != 0,
+        )
     }
 
     /// Is the footage item a 2D layer. All AV layers are either 2D or 3D.
     pub fn is_layer_2d(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsLayer2D -> ae_sys::A_Boolean, layer_handle.as_ptr())? != 0)
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsLayer2D -> ae_sys::A_Boolean, layer_handle.as_ptr())?
+                != 0,
+        )
     }
 
     /// Given composition time and a layer, see if the layer will render.
     ///
     /// Time mode is either [`TimeMode::LayerTime`] or [`TimeMode::CompTime`].
-    pub fn is_video_active(&self, layer_handle: impl AsPtr<AEGP_LayerH>, time_mode: TimeMode, time: Time) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsVideoActive -> ae_sys::A_Boolean, layer_handle.as_ptr(), time_mode.into(), &time.into() as *const _)? != 0)
+    pub fn is_video_active(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        time_mode: TimeMode,
+        time: Time,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsVideoActive -> ae_sys::A_Boolean, layer_handle.as_ptr(), time_mode.into(), &time.into() as *const _)?
+                != 0,
+        )
     }
 
     /// Is the layer used as a track matte?
-    pub fn is_layer_used_as_track_matte(&self, layer_handle: impl AsPtr<AEGP_LayerH>, fill_must_be_active: bool) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsLayerUsedAsTrackMatte -> ae_sys::A_Boolean, layer_handle.as_ptr(), fill_must_be_active as _)? != 0)
+    pub fn is_layer_used_as_track_matte(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        fill_must_be_active: bool,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsLayerUsedAsTrackMatte -> ae_sys::A_Boolean, layer_handle.as_ptr(), fill_must_be_active as _)?
+                != 0,
+        )
     }
 
     /// Does this layer have a Track Matte?
-    pub fn does_layer_have_track_matte(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_DoesLayerHaveTrackMatte -> ae_sys::A_Boolean, layer_handle.as_ptr())? != 0)
+    pub fn does_layer_have_track_matte(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_DoesLayerHaveTrackMatte -> ae_sys::A_Boolean, layer_handle.as_ptr())?
+                != 0,
+        )
     }
 
     /// Given a time in composition space, returns the time relative to the layer source footage.
-    pub fn convert_comp_to_layer_time(&self, layer_handle: impl AsPtr<AEGP_LayerH>, comp_time: Time) -> Result<Time, Error> {
+    pub fn convert_comp_to_layer_time(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        comp_time: Time,
+    ) -> Result<Time, Error> {
         Ok(call_suite_fn_single!(self, AEGP_ConvertCompToLayerTime -> ae_sys::A_Time, layer_handle.as_ptr(), &comp_time.into() as *const _)?.into())
     }
 
     /// Given a time in layer space, find the corresponding time in composition space.
-    pub fn convert_layer_to_comp_time(&self, layer_handle: impl AsPtr<AEGP_LayerH>, layer_time: Time) -> Result<Time, Error> {
+    pub fn convert_layer_to_comp_time(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        layer_time: Time,
+    ) -> Result<Time, Error> {
         Ok(call_suite_fn_single!(self, AEGP_ConvertLayerToCompTime -> ae_sys::A_Time, layer_handle.as_ptr(), &layer_time.into() as *const _)?.into())
     }
 
     /// Used by the dancing dissolve transfer function.
-    pub fn layer_dancing_rand_value(&self, layer_handle: impl AsPtr<AEGP_LayerH>, time: Time) -> Result<i32, Error> {
+    pub fn layer_dancing_rand_value(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        time: Time,
+    ) -> Result<i32, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetLayerDancingRandValue -> ae_sys::A_long, layer_handle.as_ptr(), &time.into() as *const _)?.into())
     }
 
     /// Supplies the layer's unique ID. This ID never changes during the lifetime of the project.
     pub fn layer_id(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<LayerId, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetLayerID -> ae_sys::AEGP_LayerIDVal, layer_handle.as_ptr())? as LayerId)
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetLayerID -> ae_sys::AEGP_LayerIDVal, layer_handle.as_ptr())?
+                as LayerId,
+        )
     }
 
     /// Given a layer handle and time, returns the layer-to-world transformation matrix.
-    pub fn layer_to_world_xform(&self, layer_handle: impl AsPtr<AEGP_LayerH>, time: Time) -> Result<Matrix4, Error> {
+    pub fn layer_to_world_xform(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        time: Time,
+    ) -> Result<Matrix4, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetLayerToWorldXform -> ae_sys::A_Matrix4, layer_handle.as_ptr(), &time.into() as *const _)?.into())
     }
 
     /// Given a layer handle, the current (composition) time, and the requested view time, returns the translation between the user's view and the layer, corrected for the composition's current aspect ratio.
-    pub fn layer_to_world_xform_from_view(&self, layer_handle: impl AsPtr<AEGP_LayerH>, comp_time: Time, view_time: Time) -> Result<Matrix4, Error> {
+    pub fn layer_to_world_xform_from_view(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        comp_time: Time,
+        view_time: Time,
+    ) -> Result<Matrix4, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetLayerToWorldXformFromView -> ae_sys::A_Matrix4, layer_handle.as_ptr(), &comp_time.into() as *const _, &view_time.into() as *const _)?.into())
     }
 
     /// Sets the name of a layer. Undo-able.
-    pub fn set_layer_name(&self, layer_handle: impl AsPtr<AEGP_LayerH>, new_name: &str) -> Result<(), Error> {
+    pub fn set_layer_name(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        new_name: &str,
+    ) -> Result<(), Error> {
         let new_name = U16CString::from_str(new_name).map_err(|_| Error::InvalidParms)?;
-        call_suite_fn!(self, AEGP_SetLayerName, layer_handle.as_ptr(), new_name.as_ptr())
+        call_suite_fn!(
+            self,
+            AEGP_SetLayerName,
+            layer_handle.as_ptr(),
+            new_name.as_ptr()
+        )
     }
 
     /// Retrieves the handle to a layer's parent (none if not parented).
-    pub fn layer_parent(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<Option<LayerHandle>, Error> {
+    pub fn layer_parent(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<Option<LayerHandle>, Error> {
         let parent_handle = call_suite_fn_single!(self, AEGP_GetLayerParent -> ae_sys::AEGP_LayerH, layer_handle.as_ptr())?;
         if parent_handle.is_null() {
             Ok(None)
@@ -304,8 +500,17 @@ impl LayerSuite {
     }
 
     /// Sets a layer's parent layer.
-    pub fn set_layer_parent(&self, layer_handle: impl AsPtr<AEGP_LayerH>, parent_handle: LayerHandle) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetLayerParent, layer_handle.as_ptr(), parent_handle.as_ptr())
+    pub fn set_layer_parent(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        parent_handle: LayerHandle,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetLayerParent,
+            layer_handle.as_ptr(),
+            parent_handle.as_ptr()
+        )
     }
 
     /// Deletes a layer. Can you believe it took us three suite versions to add a delete function? Neither can we.
@@ -314,16 +519,23 @@ impl LayerSuite {
     }
 
     /// Duplicates the layer. Undoable.
-    pub fn duplicate_layer(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<LayerHandle, Error> {
+    pub fn duplicate_layer(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<LayerHandle, Error> {
         Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_DuplicateLayer -> ae_sys::AEGP_LayerH, layer_handle.as_ptr())?
+            call_suite_fn_single!(self, AEGP_DuplicateLayer -> ae_sys::AEGP_LayerH, layer_handle.as_ptr())?,
         ))
     }
 
     /// Retrieves the [`LayerHandle`] associated with a given [`LayerId`] (which is what you get when accessing an effect's layer parameter stream).
-    pub fn layer_from_layer_id(&self, parent: &CompHandle, layer_id: LayerId) -> Result<LayerHandle, Error> {
+    pub fn layer_from_layer_id(
+        &self,
+        parent: &CompHandle,
+        layer_id: LayerId,
+    ) -> Result<LayerHandle, Error> {
         Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetLayerFromLayerID -> ae_sys::AEGP_LayerH, parent.as_ptr(), layer_id as _)?
+            call_suite_fn_single!(self, AEGP_GetLayerFromLayerID -> ae_sys::AEGP_LayerH, parent.as_ptr(), layer_id as _)?,
         ))
     }
 
@@ -333,8 +545,17 @@ impl LayerSuite {
     }
 
     /// Sets a layer's [`LabelId`]. Undoable.
-    pub fn set_layer_label(&self, layer_handle: impl AsPtr<AEGP_LayerH>, label_id: LabelId) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetLayerLabel, layer_handle.as_ptr(), label_id.into())
+    pub fn set_layer_label(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        label_id: LabelId,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetLayerLabel,
+            layer_handle.as_ptr(),
+            label_id.into()
+        )
     }
 
     /// New in CC. Get the sampling quality of a layer.
@@ -343,7 +564,10 @@ impl LayerSuite {
     ///
     /// - [`LayerSamplingQuality::Bilinear`]
     /// - [`LayerSamplingQuality::Bicubic`]
-    pub fn layer_sampling_quality(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<LayerSamplingQuality, Error> {
+    pub fn layer_sampling_quality(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<LayerSamplingQuality, Error> {
         let v8 = LayerSuite8::new()?;
         Ok(call_suite_fn_single!(v8, AEGP_GetLayerSamplingQuality -> ae_sys::AEGP_LayerSamplingQuality, layer_handle.as_ptr())?.into())
     }
@@ -354,13 +578,25 @@ impl LayerSuite {
     ///
     /// If you want to force it on you must also set the layer quality to [`LayerQuality::Best`] with [`Self::set_layer_quality`].
     /// Otherwise it will only be using the specified layer sampling quality whenever the layer quality is set to [`LayerQuality::Best`].
-    pub fn set_layer_sampling_quality(&self, layer_handle: impl AsPtr<AEGP_LayerH>, quality: LayerSamplingQuality) -> Result<(), Error> {
+    pub fn set_layer_sampling_quality(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        quality: LayerSamplingQuality,
+    ) -> Result<(), Error> {
         let v8 = LayerSuite8::new()?;
-        call_suite_fn!(v8, AEGP_SetLayerSamplingQuality, layer_handle.as_ptr(), quality.into())
+        call_suite_fn!(
+            v8,
+            AEGP_SetLayerSamplingQuality,
+            layer_handle.as_ptr(),
+            quality.into()
+        )
     }
 
     /// New in 23.0. Returns the track matte layer of [`LayerHandle`]. Returns `None` if there is no track matte layer.
-    pub fn track_matte_layer(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<Option<LayerHandle>, Error> {
+    pub fn track_matte_layer(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<Option<LayerHandle>, Error> {
         let v9 = LayerSuite9::new()?;
         let track_matte_handle = call_suite_fn_single!(v9, AEGP_GetTrackMatteLayer -> ae_sys::AEGP_LayerH, layer_handle.as_ptr())?;
         if track_matte_handle.is_null() {
@@ -373,9 +609,20 @@ impl LayerSuite {
     /// New in 23.0. Sets the track matte layer and track matte type of [`LayerHandle`].
     ///
     /// Setting the track matte type as [`TrackMatte::NoTrackMatte`] removes track matte.
-    pub fn set_track_matte(&self, layer_handle: impl AsPtr<AEGP_LayerH>, track_matte_layer: Option<LayerHandle>, track_matte_type: TrackMatte) -> Result<(), Error> {
+    pub fn set_track_matte(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        track_matte_layer: Option<LayerHandle>,
+        track_matte_type: TrackMatte,
+    ) -> Result<(), Error> {
         let v9 = LayerSuite9::new()?;
-        call_suite_fn!(v9, AEGP_SetTrackMatte, layer_handle.as_ptr(), track_matte_layer.map_or(std::ptr::null_mut(), |h| h.as_ptr()), track_matte_type.into())
+        call_suite_fn!(
+            v9,
+            AEGP_SetTrackMatte,
+            layer_handle.as_ptr(),
+            track_matte_layer.map_or(std::ptr::null_mut(), |h| h.as_ptr()),
+            track_matte_type.into()
+        )
     }
 
     /// New in 23.0. Removes the track matte layer of [`LayerHandle`].
@@ -701,18 +948,26 @@ impl Layer {
     ///
     /// If a composition or timeline window is active, the active layer is the selected layer (if only one is selected; otherwise `None` is returned).
     pub fn active() -> Result<Option<Layer>, Error> {
-        LayerSuite::new()?.active_layer().map(|h| h.map(|x| Layer::from_handle(x, false)))
+        LayerSuite::new()?
+            .active_layer()
+            .map(|h| h.map(|x| Layer::from_handle(x, false)))
     }
 
     /// Creates a new mask on the referenced layer, with zero nodes. Returns new mask and its index.
     pub fn create_new_mask(&self) -> Result<(Mask, i32), Error> {
-        let Ok(ref suite) = *self.mask else { return Err(Error::MissingSuite); };
-        suite.create_new_mask(self.handle.as_ptr()).map(|(mask, idx)| (mask.into(), idx))
+        let Ok(ref suite) = *self.mask else {
+            return Err(Error::MissingSuite);
+        };
+        suite
+            .create_new_mask(self.handle.as_ptr())
+            .map(|(mask, idx)| (mask.into(), idx))
     }
 
     /// Creates a new [`aegp::LayerRenderOptions`] from this layer.
-    pub fn layer_render_options(&self, plugin_id: PluginId) -> Result<aegp::LayerRenderOptions, Error> {
+    pub fn layer_render_options(
+        &self,
+        plugin_id: PluginId,
+    ) -> Result<aegp::LayerRenderOptions, Error> {
         aegp::LayerRenderOptions::from_layer(self.handle.as_ptr(), plugin_id)
     }
-
 }

--- a/after-effects/src/aegp/suites/layer_render_options.rs
+++ b/after-effects/src/aegp/suites/layer_render_options.rs
@@ -1,5 +1,7 @@
 use crate::*;
-use ae_sys::{ AEGP_LayerH, AEGP_EffectRefH, AEGP_LayerRenderOptionsH, A_Time, AEGP_WorldType, AEGP_MatteMode };
+use ae_sys::{
+    A_Time, AEGP_EffectRefH, AEGP_LayerH, AEGP_LayerRenderOptionsH, AEGP_MatteMode, AEGP_WorldType,
+};
 
 define_suite!(
     /// New in 13.0
@@ -12,18 +14,20 @@ define_suite!(
 impl LayerRenderOptionsSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Returns the [`LayerRenderOptionsHandle`] associated with a given `AEGP_LayerH`.
     /// Render time is set to the layer's current time, time step is set to layer's frame duration,
     /// ROI to the layer's nominal bounds, and EffectsToRender to "all".
     ///
     /// The returned object will be disposed on drop
-    pub fn new_from_layer(&self, layer: impl AsPtr<AEGP_LayerH>, plugin_id: aegp::PluginId) -> Result<LayerRenderOptionsHandle, Error> {
+    pub fn new_from_layer(
+        &self,
+        layer: impl AsPtr<AEGP_LayerH>,
+        plugin_id: aegp::PluginId,
+    ) -> Result<LayerRenderOptionsHandle, Error> {
         Ok(LayerRenderOptionsHandle::from_raw_owned(
-            call_suite_fn_single!(self, AEGP_NewFromLayer -> AEGP_LayerRenderOptionsH, plugin_id, layer.as_ptr())?
+            call_suite_fn_single!(self, AEGP_NewFromLayer -> AEGP_LayerRenderOptionsH, plugin_id, layer.as_ptr())?,
         ))
     }
 
@@ -32,16 +36,24 @@ impl LayerRenderOptionsSuite {
     /// ROI to the layer's nominal bounds, and EffectsToRender to the index of `effect_ref`.
     ///
     /// The returned object will be disposed on drop
-    pub fn new_from_upstream_of_effect(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>, plugin_id: aegp::PluginId) -> Result<LayerRenderOptionsHandle, Error> {
+    pub fn new_from_upstream_of_effect(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+        plugin_id: aegp::PluginId,
+    ) -> Result<LayerRenderOptionsHandle, Error> {
         Ok(LayerRenderOptionsHandle::from_raw_owned(
-            call_suite_fn_single!(self, AEGP_NewFromUpstreamOfEffect -> AEGP_LayerRenderOptionsH, plugin_id, effect_ref.as_ptr())?
+            call_suite_fn_single!(self, AEGP_NewFromUpstreamOfEffect -> AEGP_LayerRenderOptionsH, plugin_id, effect_ref.as_ptr())?,
         ))
     }
 
     /// Duplicates the given [`LayerRenderOptionsHandle`].
-    pub fn duplicate(&self, options: impl AsPtr<AEGP_LayerRenderOptionsH>, plugin_id: aegp::PluginId) -> Result<LayerRenderOptionsHandle, Error> {
+    pub fn duplicate(
+        &self,
+        options: impl AsPtr<AEGP_LayerRenderOptionsH>,
+        plugin_id: aegp::PluginId,
+    ) -> Result<LayerRenderOptionsHandle, Error> {
         Ok(LayerRenderOptionsHandle::from_raw_owned(
-            call_suite_fn_single!(self, AEGP_Duplicate -> AEGP_LayerRenderOptionsH, plugin_id, options.as_ptr())?
+            call_suite_fn_single!(self, AEGP_Duplicate -> AEGP_LayerRenderOptionsH, plugin_id, options.as_ptr())?,
         ))
     }
 
@@ -51,7 +63,11 @@ impl LayerRenderOptionsSuite {
     }
 
     /// Sets the render time of the given [`LayerRenderOptionsHandle`].
-    pub fn set_time(&self, options: impl AsPtr<AEGP_LayerRenderOptionsH>, time: Time) -> Result<(), Error> {
+    pub fn set_time(
+        &self,
+        options: impl AsPtr<AEGP_LayerRenderOptionsH>,
+        time: Time,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetTime, options.as_ptr(), time.into())
     }
 
@@ -61,7 +77,11 @@ impl LayerRenderOptionsSuite {
     }
 
     /// Specifies the time step (duration of a frame) for the referenced [`LayerRenderOptionsHandle`].
-    pub fn set_time_step(&self, options: impl AsPtr<AEGP_LayerRenderOptionsH>, time_step: Time) -> Result<(), Error> {
+    pub fn set_time_step(
+        &self,
+        options: impl AsPtr<AEGP_LayerRenderOptionsH>,
+        time_step: Time,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetTimeStep, options.as_ptr(), time_step.into())
     }
 
@@ -71,22 +91,40 @@ impl LayerRenderOptionsSuite {
     }
 
     /// Specifies the AEGP_WorldType of the output of a given [`LayerRenderOptionsHandle`].
-    pub fn set_world_type(&self, options: impl AsPtr<AEGP_LayerRenderOptionsH>, typ: aegp::WorldType) -> Result<(), Error> {
+    pub fn set_world_type(
+        &self,
+        options: impl AsPtr<AEGP_LayerRenderOptionsH>,
+        typ: aegp::WorldType,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetWorldType, options.as_ptr(), typ.into())
     }
 
     /// Retrieves the AEGP_WorldType of the given [`LayerRenderOptionsHandle`].
-    pub fn world_type(&self, options: impl AsPtr<AEGP_LayerRenderOptionsH>) -> Result<aegp::WorldType, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetWorldType -> AEGP_WorldType, options.as_ptr())?.into())
+    pub fn world_type(
+        &self,
+        options: impl AsPtr<AEGP_LayerRenderOptionsH>,
+    ) -> Result<aegp::WorldType, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetWorldType -> AEGP_WorldType, options.as_ptr())?
+                .into(),
+        )
     }
 
     /// Specifies the downsample factor (with independent horizontal and vertical settings) for the given [`LayerRenderOptionsHandle`].
-    pub fn set_downsample_factor(&self, options: impl AsPtr<AEGP_LayerRenderOptionsH>, x: i16, y: i16) -> Result<(), Error> {
+    pub fn set_downsample_factor(
+        &self,
+        options: impl AsPtr<AEGP_LayerRenderOptionsH>,
+        x: i16,
+        y: i16,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetDownsampleFactor, options.as_ptr(), x, y)
     }
 
     /// Retrieves the downsample factor for the given [`LayerRenderOptionsHandle`].
-    pub fn downsample_factor(&self, options: impl AsPtr<AEGP_LayerRenderOptionsH>) -> Result<(i16, i16), Error> {
+    pub fn downsample_factor(
+        &self,
+        options: impl AsPtr<AEGP_LayerRenderOptionsH>,
+    ) -> Result<(i16, i16), Error> {
         call_suite_fn_double!(self, AEGP_GetDownsampleFactor -> i16, i16, options.as_ptr())
     }
 
@@ -95,13 +133,23 @@ impl LayerRenderOptionsSuite {
     /// - [`MatteMode::Straight`]
     /// - [`MatteMode::PremulBlack`]
     /// - [`MatteMode::PremulBgColor`]
-    pub fn set_matte_mode(&self, options: impl AsPtr<AEGP_LayerRenderOptionsH>, mode: MatteMode) -> Result<(), Error> {
+    pub fn set_matte_mode(
+        &self,
+        options: impl AsPtr<AEGP_LayerRenderOptionsH>,
+        mode: MatteMode,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetMatteMode, options.as_ptr(), mode.into())
     }
 
     /// Retrieves the matte mode for the given [`LayerRenderOptionsHandle`].
-    pub fn matte_mode(&self, options: impl AsPtr<AEGP_LayerRenderOptionsH>) -> Result<MatteMode, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetMatteMode -> AEGP_MatteMode, options.as_ptr())?.into())
+    pub fn matte_mode(
+        &self,
+        options: impl AsPtr<AEGP_LayerRenderOptionsH>,
+    ) -> Result<MatteMode, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetMatteMode -> AEGP_MatteMode, options.as_ptr())?
+                .into(),
+        )
     }
 }
 
@@ -112,7 +160,10 @@ define_owned_handle_wrapper!(LayerRenderOptionsHandle, AEGP_LayerRenderOptionsH)
 impl Drop for LayerRenderOptionsHandle {
     fn drop(&mut self) {
         if self.is_owned() {
-            LayerRenderOptionsSuite::new().unwrap().dispose(self.as_ptr()).unwrap();
+            LayerRenderOptionsSuite::new()
+                .unwrap()
+                .dispose(self.as_ptr())
+                .unwrap();
         }
     }
 }
@@ -178,10 +229,15 @@ impl LayerRenderOptions {
     /// ROI to the layer's nominal bounds, and EffectsToRender to "all".
     ///
     /// The returned object will be disposed on drop
-    pub fn from_layer(layer: impl AsPtr<AEGP_LayerH>, plugin_id: aegp::PluginId) -> Result<Self, Error> {
+    pub fn from_layer(
+        layer: impl AsPtr<AEGP_LayerH>,
+        plugin_id: aegp::PluginId,
+    ) -> Result<Self, Error> {
         Ok(Self::from_handle(
-            LayerRenderOptionsSuite::new().unwrap().new_from_layer(layer, plugin_id)?,
-            false
+            LayerRenderOptionsSuite::new()
+                .unwrap()
+                .new_from_layer(layer, plugin_id)?,
+            false,
         ))
     }
 
@@ -190,10 +246,15 @@ impl LayerRenderOptions {
     /// ROI to the layer's nominal bounds, and EffectsToRender to the index of `effect_ref`.
     ///
     /// The returned object will be disposed on drop
-    pub fn from_upstream_of_effect(effect_ref: impl AsPtr<AEGP_EffectRefH>, plugin_id: aegp::PluginId) -> Result<Self, Error> {
+    pub fn from_upstream_of_effect(
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+        plugin_id: aegp::PluginId,
+    ) -> Result<Self, Error> {
         Ok(Self::from_handle(
-            LayerRenderOptionsSuite::new().unwrap().new_from_upstream_of_effect(effect_ref, plugin_id)?,
-            false
+            LayerRenderOptionsSuite::new()
+                .unwrap()
+                .new_from_upstream_of_effect(effect_ref, plugin_id)?,
+            false,
         ))
     }
 }

--- a/after-effects/src/aegp/suites/light.rs
+++ b/after-effects/src/aegp/suites/light.rs
@@ -1,6 +1,6 @@
+use crate::aegp::LayerHandle;
 use crate::*;
 use ae_sys::AEGP_LayerH;
-use crate::aegp::LayerHandle;
 
 define_suite!(
     /// Get and set the type of lights in a composition.
@@ -29,13 +29,10 @@ define_suite!(
     kAEGPLightSuiteVersion3
 );
 
-
 impl LightSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Retrieves the [`LightType`] of the specified camera layer
     pub fn light_type(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<LightType, Error> {
@@ -43,19 +40,41 @@ impl LightSuite {
     }
 
     /// Sets the [`LightType`] for the specified camera layer.
-    pub fn set_light_type(&self, layer_handle: impl AsPtr<AEGP_LayerH>, light_type: LightType) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetLightType, layer_handle.as_ptr(), light_type.into())
+    pub fn set_light_type(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        light_type: LightType,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetLightType,
+            layer_handle.as_ptr(),
+            light_type.into()
+        )
     }
 
-    pub fn light_source(&self, layer_handle: impl AsPtr<AEGP_LayerH>) -> Result<LayerHandle, Error> {
+    pub fn light_source(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<LayerHandle, Error> {
         let v3 = LightSuite3::new()?;
         Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(v3, AEGP_GetLightSource -> ae_sys::AEGP_LayerH, layer_handle.as_ptr())?
+            call_suite_fn_single!(v3, AEGP_GetLightSource -> ae_sys::AEGP_LayerH, layer_handle.as_ptr())?,
         ))
     }
-    pub fn set_light_source(&self, layer_handle: impl AsPtr<AEGP_LayerH>, light_source: impl AsPtr<AEGP_LayerH>) -> Result<(), Error> {
+
+    pub fn set_light_source(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        light_source: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<(), Error> {
         let v3 = LightSuite3::new()?;
-        call_suite_fn!(v3, AEGP_SetLightSource, layer_handle.as_ptr(), light_source.as_ptr())
+        call_suite_fn!(
+            v3,
+            AEGP_SetLightSource,
+            layer_handle.as_ptr(),
+            light_source.as_ptr()
+        )
     }
 }
 

--- a/after-effects/src/aegp/suites/mask.rs
+++ b/after-effects/src/aegp/suites/mask.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use ae_sys::{ A_long, AEGP_LayerH, AEGP_MaskRefH, AEGP_MaskOutlineValH };
+use ae_sys::{A_long, AEGP_LayerH, AEGP_MaskOutlineValH, AEGP_MaskRefH};
 
 define_suite!(
     /// Access, manipulate, and delete a layer's masks.
@@ -12,9 +12,7 @@ define_suite!(
 impl MaskSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Counts the masks applied to a layer.
     pub fn layer_num_masks(&self, layer: impl AsPtr<AEGP_LayerH>) -> Result<i32, Error> {
@@ -22,9 +20,13 @@ impl MaskSuite {
     }
 
     /// Given a layer handle and mask index, returns a pointer to the mask handle.
-    pub fn layer_mask_by_index(&self, layer: impl AsPtr<AEGP_LayerH>, mask_index: i32) -> Result<MaskRefHandle, Error> {
+    pub fn layer_mask_by_index(
+        &self,
+        layer: impl AsPtr<AEGP_LayerH>,
+        mask_index: i32,
+    ) -> Result<MaskRefHandle, Error> {
         Ok(MaskRefHandle::from_raw_owned(
-            call_suite_fn_single!(self, AEGP_GetLayerMaskByIndex -> ae_sys::AEGP_MaskRefH, layer.as_ptr(), mask_index as _)?
+            call_suite_fn_single!(self, AEGP_GetLayerMaskByIndex -> ae_sys::AEGP_MaskRefH, layer.as_ptr(), mask_index as _)?,
         ))
     }
 
@@ -35,11 +37,18 @@ impl MaskSuite {
 
     /// Given a mask handle, determines if the mask is inverted or not.
     pub fn mask_invert(&self, mask: impl AsPtr<AEGP_MaskRefH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetMaskInvert -> ae_sys::A_Boolean, mask.as_ptr())? != 0)
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetMaskInvert -> ae_sys::A_Boolean, mask.as_ptr())?
+                != 0,
+        )
     }
 
     /// Sets the inversion state of a mask.
-    pub fn set_mask_invert(&self, mask: impl AsPtr<AEGP_MaskRefH>, invert: bool) -> Result<(), Error> {
+    pub fn set_mask_invert(
+        &self,
+        mask: impl AsPtr<AEGP_MaskRefH>,
+        invert: bool,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetMaskInvert, mask.as_ptr(), invert as _)
     }
 
@@ -48,75 +57,138 @@ impl MaskSuite {
     /// * [`MaskMode::None`] does nothing.
     /// * [`MaskMode::Add`] is the default behavior.
     pub fn mask_mode(&self, mask: impl AsPtr<AEGP_MaskRefH>) -> Result<MaskMode, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetMaskMode -> ae_sys::PF_MaskMode, mask.as_ptr())?.into())
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetMaskMode -> ae_sys::PF_MaskMode, mask.as_ptr())?
+                .into(),
+        )
     }
 
     /// Sets the mode of the given mask.
-    pub fn set_mask_mode(&self, mask: impl AsPtr<AEGP_MaskRefH>, mode: MaskMode) -> Result<(), Error> {
+    pub fn set_mask_mode(
+        &self,
+        mask: impl AsPtr<AEGP_MaskRefH>,
+        mode: MaskMode,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetMaskMode, mask.as_ptr(), mode.into())
     }
 
     /// Retrieves the motion blur setting for the given mask.
-    pub fn mask_motion_blur_state(&self, mask: impl AsPtr<AEGP_MaskRefH>) -> Result<MaskMBlur, Error> {
+    pub fn mask_motion_blur_state(
+        &self,
+        mask: impl AsPtr<AEGP_MaskRefH>,
+    ) -> Result<MaskMBlur, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetMaskMotionBlurState -> ae_sys::AEGP_MaskMBlur, mask.as_ptr())?.into())
     }
 
     /// New in CS6. Sets the motion blur setting for the given mask.
-    pub fn set_mask_motion_blur_state(&self, mask: impl AsPtr<AEGP_MaskRefH>, blur_state: MaskMBlur) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetMaskMotionBlurState, mask.as_ptr(), blur_state.into())
+    pub fn set_mask_motion_blur_state(
+        &self,
+        mask: impl AsPtr<AEGP_MaskRefH>,
+        blur_state: MaskMBlur,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetMaskMotionBlurState,
+            mask.as_ptr(),
+            blur_state.into()
+        )
     }
 
     /// New in CS6. Gets the type of feather falloff for the given mask, either
     /// [`MaskFeatherFalloff::Smooth`] or [`MaskFeatherFalloff::Linear`].
-    pub fn mask_feather_falloff(&self, mask: impl AsPtr<AEGP_MaskRefH>) -> Result<MaskFeatherFalloff, Error> {
+    pub fn mask_feather_falloff(
+        &self,
+        mask: impl AsPtr<AEGP_MaskRefH>,
+    ) -> Result<MaskFeatherFalloff, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetMaskFeatherFalloff -> ae_sys::AEGP_MaskFeatherFalloff, mask.as_ptr())?.into())
     }
 
     /// Sets the type of feather falloff for the given mask.
-    pub fn set_mask_feather_falloff(&self, mask: impl AsPtr<AEGP_MaskRefH>, falloff: MaskFeatherFalloff) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetMaskFeatherFalloff, mask.as_ptr(), falloff.into())
+    pub fn set_mask_feather_falloff(
+        &self,
+        mask: impl AsPtr<AEGP_MaskRefH>,
+        falloff: MaskFeatherFalloff,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetMaskFeatherFalloff,
+            mask.as_ptr(),
+            falloff.into()
+        )
     }
 
     /// Retrieves the color of the specified mask.
     pub fn mask_color(&self, mask: impl AsPtr<AEGP_MaskRefH>) -> Result<pf::PixelF64, Error> {
-        let color_val = call_suite_fn_single!(self, AEGP_GetMaskColor -> ae_sys::AEGP_ColorVal, mask.as_ptr())?;
+        let color_val =
+            call_suite_fn_single!(self, AEGP_GetMaskColor -> ae_sys::AEGP_ColorVal, mask.as_ptr())?;
         Ok(unsafe { std::mem::transmute(color_val) })
     }
 
     /// Sets the color of the specified mask.
-    pub fn set_mask_color(&self, mask: impl AsPtr<AEGP_MaskRefH>, color: pf::PixelF64) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetMaskColor, mask.as_ptr(), std::mem::transmute(&color))
+    pub fn set_mask_color(
+        &self,
+        mask: impl AsPtr<AEGP_MaskRefH>,
+        color: pf::PixelF64,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetMaskColor,
+            mask.as_ptr(),
+            std::mem::transmute(&color)
+        )
     }
 
     /// Retrieves the lock state of the specified mask.
     pub fn mask_lock_state(&self, mask: impl AsPtr<AEGP_MaskRefH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetMaskLockState -> ae_sys::A_Boolean, mask.as_ptr())? != 0)
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetMaskLockState -> ae_sys::A_Boolean, mask.as_ptr())?
+                != 0,
+        )
     }
 
     /// Sets the lock state of the specified mask.
-    pub fn set_mask_lock_state(&self, mask: impl AsPtr<AEGP_MaskRefH>, lock: bool) -> Result<(), Error> {
+    pub fn set_mask_lock_state(
+        &self,
+        mask: impl AsPtr<AEGP_MaskRefH>,
+        lock: bool,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetMaskLockState, mask.as_ptr(), lock as _)
     }
 
     /// Returns whether or not the given mask is used as a rotobezier.
     pub fn mask_is_roto_bezier(&self, mask: impl AsPtr<AEGP_MaskRefH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetMaskIsRotoBezier -> ae_sys::A_Boolean, mask.as_ptr())? != 0)
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetMaskIsRotoBezier -> ae_sys::A_Boolean, mask.as_ptr())?
+                != 0,
+        )
     }
 
     /// Sets whether a given mask is to be used as a rotobezier.
-    pub fn set_mask_is_roto_bezier(&self, mask: impl AsPtr<AEGP_MaskRefH>, is_roto_bezier: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetMaskIsRotoBezier, mask.as_ptr(), is_roto_bezier as _)
+    pub fn set_mask_is_roto_bezier(
+        &self,
+        mask: impl AsPtr<AEGP_MaskRefH>,
+        is_roto_bezier: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetMaskIsRotoBezier,
+            mask.as_ptr(),
+            is_roto_bezier as _
+        )
     }
 
     /// Duplicates a given mask.
     pub fn duplicate_mask(&self, mask: impl AsPtr<AEGP_MaskRefH>) -> Result<MaskRefHandle, Error> {
         Ok(MaskRefHandle::from_raw_owned(
-            call_suite_fn_single!(self, AEGP_DuplicateMask -> ae_sys::AEGP_MaskRefH, mask.as_ptr())?
+            call_suite_fn_single!(self, AEGP_DuplicateMask -> ae_sys::AEGP_MaskRefH, mask.as_ptr())?,
         ))
     }
 
     /// Creates a new mask on the referenced layer, with zero nodes. Returns new mask and its index.
-    pub fn create_new_mask(&self, layer: impl AsPtr<AEGP_LayerH>) -> Result<(MaskRefHandle, i32), Error> {
+    pub fn create_new_mask(
+        &self,
+        layer: impl AsPtr<AEGP_LayerH>,
+    ) -> Result<(MaskRefHandle, i32), Error> {
         let (mask, index) = call_suite_fn_double!(self, AEGP_CreateNewMask -> ae_sys::AEGP_MaskRefH, A_long, layer.as_ptr())?;
         Ok((MaskRefHandle::from_raw_owned(mask), index))
     }
@@ -128,7 +200,10 @@ impl MaskSuite {
 
     /// Retrieves the ``AEGP_MaskIDVal`` for the given [`MaskRefHandle`], for use in uniquely identifying the mask.
     pub fn mask_id(&self, mask: impl AsPtr<AEGP_MaskRefH>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetMaskID -> ae_sys::AEGP_MaskIDVal, mask.as_ptr())? as i32)
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetMaskID -> ae_sys::AEGP_MaskIDVal, mask.as_ptr())?
+                as i32,
+        )
     }
 }
 
@@ -170,68 +245,152 @@ define_suite!(
 impl MaskOutlineSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Given an mask outline pointer (obtainable through the [`suites::Stream`](aegp::suites::Stream), determines if the mask path is open or closed.
-    pub fn is_mask_outline_open(&self, mask_outline: impl AsPtr<AEGP_MaskOutlineValH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsMaskOutlineOpen -> ae_sys::A_Boolean, mask_outline.as_ptr())? != 0)
+    pub fn is_mask_outline_open(
+        &self,
+        mask_outline: impl AsPtr<AEGP_MaskOutlineValH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsMaskOutlineOpen -> ae_sys::A_Boolean, mask_outline.as_ptr())?
+                != 0,
+        )
     }
 
     /// Sets the open state of the given mask outline.
-    pub fn set_mask_outline_open(&self, mask_outline: impl AsPtr<AEGP_MaskOutlineValH>, open: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetMaskOutlineOpen, mask_outline.as_ptr(), open as _)
+    pub fn set_mask_outline_open(
+        &self,
+        mask_outline: impl AsPtr<AEGP_MaskOutlineValH>,
+        open: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetMaskOutlineOpen,
+            mask_outline.as_ptr(),
+            open as _
+        )
     }
 
     /// Given a mask outline pointer, returns the number of segments in the path.
-    pub fn mask_outline_num_segments(&self, mask_outline: impl AsPtr<AEGP_MaskOutlineValH>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetMaskOutlineNumSegments -> A_long, mask_outline.as_ptr())? as i32)
+    pub fn mask_outline_num_segments(
+        &self,
+        mask_outline: impl AsPtr<AEGP_MaskOutlineValH>,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetMaskOutlineNumSegments -> A_long, mask_outline.as_ptr())?
+                as i32,
+        )
     }
 
     /// Given a mask outline pointer and a point between 0 and the total number of segments.
-    pub fn mask_outline_vertex_info(&self, mask_outline: impl AsPtr<AEGP_MaskOutlineValH>, point: i32) -> Result<ae_sys::AEGP_MaskVertex, Error> {
+    pub fn mask_outline_vertex_info(
+        &self,
+        mask_outline: impl AsPtr<AEGP_MaskOutlineValH>,
+        point: i32,
+    ) -> Result<ae_sys::AEGP_MaskVertex, Error> {
         call_suite_fn_single!(self, AEGP_GetMaskOutlineVertexInfo -> ae_sys::AEGP_MaskVertex, mask_outline.as_ptr(), point as _)
     }
 
     /// Sets the vertex information for a given index.
-    pub fn set_mask_outline_vertex_info(&self, mask_outline: impl AsPtr<AEGP_MaskOutlineValH>, point: i32, vertex: &ae_sys::AEGP_MaskVertex) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetMaskOutlineVertexInfo, mask_outline.as_ptr(), point as _, vertex)
+    pub fn set_mask_outline_vertex_info(
+        &self,
+        mask_outline: impl AsPtr<AEGP_MaskOutlineValH>,
+        point: i32,
+        vertex: &ae_sys::AEGP_MaskVertex,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetMaskOutlineVertexInfo,
+            mask_outline.as_ptr(),
+            point as _,
+            vertex
+        )
     }
 
     /// Creates a vertex at index position.
-    pub fn create_vertex(&self, mask_outline: impl AsPtr<AEGP_MaskOutlineValH>, position: i32) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_CreateVertex, mask_outline.as_ptr(), position as _)
+    pub fn create_vertex(
+        &self,
+        mask_outline: impl AsPtr<AEGP_MaskOutlineValH>,
+        position: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_CreateVertex,
+            mask_outline.as_ptr(),
+            position as _
+        )
     }
 
     /// Removes a vertex from a mask.
-    pub fn delete_vertex(&self, mask_outline: impl AsPtr<AEGP_MaskOutlineValH>, index: i32) -> Result<(), Error> {
+    pub fn delete_vertex(
+        &self,
+        mask_outline: impl AsPtr<AEGP_MaskOutlineValH>,
+        index: i32,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_DeleteVertex, mask_outline.as_ptr(), index as _)
     }
 
     /// Given a mask outline pointer, returns the number of feathers in the path.
-    pub fn mask_outline_num_feathers(&self, mask_outline: impl AsPtr<AEGP_MaskOutlineValH>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetMaskOutlineNumFeathers -> A_long, mask_outline.as_ptr())? as i32)
+    pub fn mask_outline_num_feathers(
+        &self,
+        mask_outline: impl AsPtr<AEGP_MaskOutlineValH>,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetMaskOutlineNumFeathers -> A_long, mask_outline.as_ptr())?
+                as i32,
+        )
     }
 
     /// Given a mask outline pointer and a feather index, returns the feather information.
-    pub fn mask_outline_feather_info(&self, mask_outline: impl AsPtr<AEGP_MaskOutlineValH>, feather_index: i32) -> Result<ae_sys::AEGP_MaskFeather, Error> {
+    pub fn mask_outline_feather_info(
+        &self,
+        mask_outline: impl AsPtr<AEGP_MaskOutlineValH>,
+        feather_index: i32,
+    ) -> Result<ae_sys::AEGP_MaskFeather, Error> {
         call_suite_fn_single!(self, AEGP_GetMaskOutlineFeatherInfo -> ae_sys::AEGP_MaskFeather, mask_outline.as_ptr(), feather_index as _)
     }
 
     /// Sets the feather information for a given index. Feather must already exist; use [`create_mask_outline_feather()`](Self::create_mask_outline_feather) first, if needed.
-    pub fn set_mask_outline_feather_info(&self, mask_outline: impl AsPtr<AEGP_MaskOutlineValH>, feather_index: i32, feather: &ae_sys::AEGP_MaskFeather) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetMaskOutlineFeatherInfo, mask_outline.as_ptr(), feather_index as _, feather)
+    pub fn set_mask_outline_feather_info(
+        &self,
+        mask_outline: impl AsPtr<AEGP_MaskOutlineValH>,
+        feather_index: i32,
+        feather: &ae_sys::AEGP_MaskFeather,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetMaskOutlineFeatherInfo,
+            mask_outline.as_ptr(),
+            feather_index as _,
+            feather
+        )
     }
 
     /// Creates a feather at the given index. Returns the index of new feather.
-    pub fn create_mask_outline_feather(&self, mask_outline: impl AsPtr<AEGP_MaskOutlineValH>, feather: Option<ae_sys::AEGP_MaskFeather>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_CreateMaskOutlineFeather -> ae_sys::AEGP_FeatherIndex, mask_outline.as_ptr(), feather.as_ref().map_or(std::ptr::null_mut(), |t| t))? as i32)
+    pub fn create_mask_outline_feather(
+        &self,
+        mask_outline: impl AsPtr<AEGP_MaskOutlineValH>,
+        feather: Option<ae_sys::AEGP_MaskFeather>,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_CreateMaskOutlineFeather -> ae_sys::AEGP_FeatherIndex, mask_outline.as_ptr(), feather.as_ref().map_or(std::ptr::null_mut(), |t| t))?
+                as i32,
+        )
     }
 
     /// Deletes a feather from the mask.
-    pub fn delete_mask_outline_feather(&self, mask_outline: impl AsPtr<AEGP_MaskOutlineValH>, index: i32) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_DeleteMaskOutlineFeather, mask_outline.as_ptr(), index as _)
+    pub fn delete_mask_outline_feather(
+        &self,
+        mask_outline: impl AsPtr<AEGP_MaskOutlineValH>,
+        index: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_DeleteMaskOutlineFeather,
+            mask_outline.as_ptr(),
+            index as _
+        )
     }
 }
 

--- a/after-effects/src/aegp/suites/memory.rs
+++ b/after-effects/src/aegp/suites/memory.rs
@@ -1,6 +1,6 @@
-use crate::*;
 use crate::aegp::*;
-use ae_sys::{ AEGP_MemHandle, AEGP_MemSize };
+use crate::*;
+use ae_sys::{AEGP_MemHandle, AEGP_MemSize};
 
 define_suite!(
     /// Use the AEGP Memory Suite to manage memory used by the AEGP.
@@ -17,9 +17,7 @@ define_suite!(
 impl MemorySuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Create a new memory handle.
     /// This memory is guaranteed to be 16-byte aligned.
@@ -27,7 +25,12 @@ impl MemorySuite {
     ///
     /// Use `name` to identify the memory you are asking for.
     /// After Effects uses the string to display any related error messages.
-    pub fn new_mem_handle(&self, plugin_id: PluginId, name: &str, size: usize) -> Result<AEGP_MemHandle, Error> {
+    pub fn new_mem_handle(
+        &self,
+        plugin_id: PluginId,
+        name: &str,
+        size: usize,
+    ) -> Result<AEGP_MemHandle, Error> {
         let name = CString::new(name).unwrap();
         call_suite_fn_single!(self, AEGP_NewMemHandle -> AEGP_MemHandle, plugin_id, name.as_ptr(), size as u32, 0)
     }
@@ -39,7 +42,10 @@ impl MemorySuite {
 
     /// Locks the handle into memory (cannot be moved by OS).
     /// Use this function prior to using memory allocated by [`new_mem_handle()`](Self::new_mem_handle). Can be nested.
-    pub fn lock_mem_handle(&self, mem_handle: AEGP_MemHandle) -> Result<*mut std::ffi::c_void, Error> {
+    pub fn lock_mem_handle(
+        &self,
+        mem_handle: AEGP_MemHandle,
+    ) -> Result<*mut std::ffi::c_void, Error> {
         call_suite_fn_single!(self, AEGP_LockMemHandle -> *mut std::ffi::c_void, mem_handle)
     }
 
@@ -50,13 +56,27 @@ impl MemorySuite {
 
     /// Returns the allocated size of the handle.
     pub fn mem_handle_size(&self, mem_handle: AEGP_MemHandle) -> Result<usize, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetMemHandleSize -> AEGP_MemSize, mem_handle)? as usize)
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetMemHandleSize -> AEGP_MemSize, mem_handle)?
+                as usize,
+        )
     }
 
     /// Changes the allocated size of the handle.
-    pub fn resize_mem_handle(&self, what: &str, new_size: usize, mem_handle: AEGP_MemHandle) -> Result<(), Error> {
+    pub fn resize_mem_handle(
+        &self,
+        what: &str,
+        new_size: usize,
+        mem_handle: AEGP_MemHandle,
+    ) -> Result<(), Error> {
         let what = CString::new(what).unwrap();
-        call_suite_fn!(self, AEGP_ResizeMemHandle, what.as_ptr(), new_size as AEGP_MemSize, mem_handle)
+        call_suite_fn!(
+            self,
+            AEGP_ResizeMemHandle,
+            what.as_ptr(),
+            new_size as AEGP_MemSize,
+            mem_handle
+        )
     }
 
     /// If After Effects runs into problems with the memory handling, the error should be reported to the user.
@@ -74,10 +94,7 @@ impl MemorySuite {
     /// so for example memory allocated using [`suites::Handle`](crate::suites::Handle) will not be reported here.
     pub fn mem_stats(&self, plugin_id: PluginId) -> Result<(i32, i32), Error> {
         let (count, size) = call_suite_fn_double!(self, AEGP_GetMemStats -> ae_sys::A_long, ae_sys::A_long, plugin_id)?;
-        Ok((
-            count as _,
-            size as _
-        ))
+        Ok((count as _, size as _))
     }
 }
 
@@ -106,9 +123,7 @@ impl<'a, T: 'a> MemHandle<'a, T> {
         Ok(handle)
     }
 
-    pub fn len(&self) -> Result<usize, Error> {
-        self.suite.mem_handle_size(self.handle)
-    }
+    pub fn len(&self) -> Result<usize, Error> { self.suite.mem_handle_size(self.handle) }
 
     #[inline]
     pub fn lock(&self) -> Result<MemHandleLock<'_, T>, Error> {
@@ -121,9 +136,7 @@ impl<'a, T: 'a> MemHandle<'a, T> {
 
     /// Only call this if you know what you're doing.
     #[inline]
-    pub(crate) fn unlock(&self) -> Result<(), Error> {
-        self.suite.unlock_mem_handle(self.handle)
-    }
+    pub(crate) fn unlock(&self) -> Result<(), Error> { self.suite.unlock_mem_handle(self.handle) }
 
     pub fn from_raw(handle: ae_sys::AEGP_MemHandle) -> Result<MemHandle<'a, T>, Error> {
         Ok(Self {
@@ -155,9 +168,7 @@ impl<'a, T: 'a> MemHandle<'a, T> {
     }
 
     /// Returns the raw handle.
-    pub fn as_raw(&self) -> ae_sys::AEGP_MemHandle {
-        self.handle
-    }
+    pub fn as_raw(&self) -> ae_sys::AEGP_MemHandle { self.handle }
 }
 
 impl<'a, T: 'a> Drop for MemHandle<'a, T> {
@@ -194,13 +205,9 @@ impl<'a, T> MemHandleLock<'a, T> {
         }
     }
 
-    pub fn as_ptr(&self) -> *mut T {
-        self.ptr
-    }
+    pub fn as_ptr(&self) -> *mut T { self.ptr }
 }
 
 impl<'a, T> Drop for MemHandleLock<'a, T> {
-    fn drop(&mut self) {
-        self.parent_handle.unlock().unwrap();
-    }
+    fn drop(&mut self) { self.parent_handle.unlock().unwrap(); }
 }

--- a/after-effects/src/aegp/suites/output_module.rs
+++ b/after-effects/src/aegp/suites/output_module.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::aegp::*;
+use crate::*;
 
 define_suite!(
     /// Output Module Suite provides information about and control over output modules
@@ -16,9 +16,7 @@ define_suite!(
 impl OutputModuleSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Retrieves an output module by index from a render queue item.
     pub fn output_module_by_index(
@@ -26,14 +24,12 @@ impl OutputModuleSuite {
         rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
         index: i32,
     ) -> Result<OutputModuleRefHandle, Error> {
-        Ok(OutputModuleRefHandle::from_raw(
-            call_suite_fn_single!(
-                self,
-                AEGP_GetOutputModuleByIndex -> ae_sys::AEGP_OutputModuleRefH,
-                rq_item.as_ptr(),
-                index as ae_sys::A_long
-            )?
-        ))
+        Ok(OutputModuleRefHandle::from_raw(call_suite_fn_single!(
+            self,
+            AEGP_GetOutputModuleByIndex -> ae_sys::AEGP_OutputModuleRefH,
+            rq_item.as_ptr(),
+            index as ae_sys::A_long
+        )?))
     }
 
     /// Retrieves the embedding options for an output module.
@@ -42,15 +38,13 @@ impl OutputModuleSuite {
         rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
         output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
     ) -> Result<EmbeddingType, Error> {
-        Ok(
-            call_suite_fn_single!(
-                self,
-                AEGP_GetEmbedOptions -> ae_sys::AEGP_EmbeddingType,
-                rq_item.as_ptr(),
-                output_module.as_ptr()
-            )?
-            .into()
-        )
+        Ok(call_suite_fn_single!(
+            self,
+            AEGP_GetEmbedOptions -> ae_sys::AEGP_EmbeddingType,
+            rq_item.as_ptr(),
+            output_module.as_ptr()
+        )?
+        .into())
     }
 
     /// Sets the embedding options for an output module.
@@ -75,15 +69,13 @@ impl OutputModuleSuite {
         rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
         output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
     ) -> Result<PostRenderAction, Error> {
-        Ok(
-            call_suite_fn_single!(
-                self,
-                AEGP_GetPostRenderAction -> ae_sys::AEGP_PostRenderAction,
-                rq_item.as_ptr(),
-                output_module.as_ptr()
-            )?
-            .into()
-        )
+        Ok(call_suite_fn_single!(
+            self,
+            AEGP_GetPostRenderAction -> ae_sys::AEGP_PostRenderAction,
+            rq_item.as_ptr(),
+            output_module.as_ptr()
+        )?
+        .into())
     }
 
     /// Sets the post-render action for an output module.
@@ -108,14 +100,12 @@ impl OutputModuleSuite {
         rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
         output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
     ) -> Result<OutputTypes, Error> {
-        Ok(OutputTypes::from_bits_truncate(
-            call_suite_fn_single!(
-                self,
-                AEGP_GetEnabledOutputs -> ae_sys::AEGP_OutputTypes,
-                rq_item.as_ptr(),
-                output_module.as_ptr()
-            )?
-        ))
+        Ok(OutputTypes::from_bits_truncate(call_suite_fn_single!(
+            self,
+            AEGP_GetEnabledOutputs -> ae_sys::AEGP_OutputTypes,
+            rq_item.as_ptr(),
+            output_module.as_ptr()
+        )?))
     }
 
     /// Sets which output types (video, audio) are enabled for an output module.
@@ -140,15 +130,13 @@ impl OutputModuleSuite {
         rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
         output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
     ) -> Result<VideoChannels, Error> {
-        Ok(
-            call_suite_fn_single!(
-                self,
-                AEGP_GetOutputChannels -> ae_sys::AEGP_VideoChannels,
-                rq_item.as_ptr(),
-                output_module.as_ptr()
-            )?
-            .into()
-        )
+        Ok(call_suite_fn_single!(
+            self,
+            AEGP_GetOutputChannels -> ae_sys::AEGP_VideoChannels,
+            rq_item.as_ptr(),
+            output_module.as_ptr()
+        )?
+        .into())
     }
 
     /// Sets the output channels for an output module.
@@ -308,7 +296,7 @@ impl OutputModuleSuite {
         unsafe {
             Ok(
                 U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
-                    .to_string_lossy()
+                    .to_string_lossy(),
             )
         }
     }
@@ -337,13 +325,11 @@ impl OutputModuleSuite {
         &self,
         rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
     ) -> Result<OutputModuleRefHandle, Error> {
-        Ok(OutputModuleRefHandle::from_raw(
-            call_suite_fn_single!(
-                self,
-                AEGP_AddDefaultOutputModule -> ae_sys::AEGP_OutputModuleRefH,
-                rq_item.as_ptr()
-            )?
-        ))
+        Ok(OutputModuleRefHandle::from_raw(call_suite_fn_single!(
+            self,
+            AEGP_AddDefaultOutputModule -> ae_sys::AEGP_OutputModuleRefH,
+            rq_item.as_ptr()
+        )?))
     }
 
     /// Retrieves extra information about an output module.
@@ -372,12 +358,13 @@ impl OutputModuleSuite {
 
         unsafe {
             let format = U16CString::from_ptr_str(
-                MemHandle::<u16>::from_raw(format_handle)?.lock()?.as_ptr()
-            ).to_string_lossy();
+                MemHandle::<u16>::from_raw(format_handle)?.lock()?.as_ptr(),
+            )
+            .to_string_lossy();
 
-            let info = U16CString::from_ptr_str(
-                MemHandle::<u16>::from_raw(info_handle)?.lock()?.as_ptr()
-            ).to_string_lossy();
+            let info =
+                U16CString::from_ptr_str(MemHandle::<u16>::from_raw(info_handle)?.lock()?.as_ptr())
+                    .to_string_lossy();
 
             Ok((format, info, is_sequence != 0, multi_frame != 0))
         }

--- a/after-effects/src/aegp/suites/persistent_data.rs
+++ b/after-effects/src/aegp/suites/persistent_data.rs
@@ -253,7 +253,13 @@ impl PersistentDataSuite {
         default: &str,
         max_result_length: usize,
     ) -> Result<String, Error> {
-        self.string(blob_handle, section_key, value_key, default, max_result_length)
+        self.string(
+            blob_handle,
+            section_key,
+            value_key,
+            default,
+            max_result_length,
+        )
     }
 
     pub fn long(

--- a/after-effects/src/aegp/suites/pf_interface.rs
+++ b/after-effects/src/aegp/suites/pf_interface.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::aegp::*;
+use crate::*;
 use ae_sys::PF_ProgPtr;
 
 define_suite!(
@@ -17,31 +17,45 @@ define_suite!(
 impl PFInterfaceSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Obtain the layer handle of the layer to which the effect is applied.
-    pub fn effect_layer(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>) -> Result<LayerHandle, Error> {
+    pub fn effect_layer(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+    ) -> Result<LayerHandle, Error> {
         Ok(LayerHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetEffectLayer -> ae_sys::AEGP_LayerH, effect_ref.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetEffectLayer -> ae_sys::AEGP_LayerH, effect_ref.as_ptr())?,
         ))
     }
 
     /// Obtain the [`EffectRefHandle`] corresponding to the effect.
-    pub fn new_effect_for_effect(&self, effect_ref: impl AsPtr<PF_ProgPtr>, plugin_id: PluginId) -> Result<EffectRefHandle, Error> {
+    pub fn new_effect_for_effect(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        plugin_id: PluginId,
+    ) -> Result<EffectRefHandle, Error> {
         Ok(EffectRefHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetNewEffectForEffect -> ae_sys::AEGP_EffectRefH, plugin_id, effect_ref.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetNewEffectForEffect -> ae_sys::AEGP_EffectRefH, plugin_id, effect_ref.as_ptr())?,
         ))
     }
 
     /// Retrieve the composition time corresponding to the effect's layer time.
-    pub fn convert_effect_to_comp_time(&self, effect_ref: impl AsPtr<PF_ProgPtr>, time: i32, time_scale: u32) -> Result<Time, Error> {
+    pub fn convert_effect_to_comp_time(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        time: i32,
+        time_scale: u32,
+    ) -> Result<Time, Error> {
         Ok(call_suite_fn_single!(self, AEGP_ConvertEffectToCompTime -> ae_sys::A_Time, effect_ref.as_ptr(), time, time_scale)?.into())
     }
 
     /// Obtain the camera (if any) being used by After Effects to view the effect's layer.
-    pub fn effect_camera(&self, effect_ref: impl AsPtr<PF_ProgPtr>, time: Time) -> Result<Option<LayerHandle>, Error> {
+    pub fn effect_camera(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        time: Time,
+    ) -> Result<Option<LayerHandle>, Error> {
         let camera_handle = call_suite_fn_single!(self, AEGP_GetEffectCamera -> ae_sys::AEGP_LayerH, effect_ref.as_ptr(), &time.into() as *const _)?;
         if camera_handle.is_null() {
             Ok(None)
@@ -60,12 +74,30 @@ impl PFInterfaceSuite {
     /// Also note that our matrix is row-based; OpenGL's is column-based.
     ///
     /// Returns a tuple containing: (matrix, dist_to_image_plane, image_plane_width, image_plane_height)
-    pub fn effect_camera_matrix(&self, effect_ref: impl AsPtr<PF_ProgPtr>, time: Time) -> Result<(Matrix4, f64, i16, i16), Error> {
+    pub fn effect_camera_matrix(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        time: Time,
+    ) -> Result<(Matrix4, f64, i16, i16), Error> {
         let mut matrix: ae_sys::A_Matrix4 = unsafe { std::mem::zeroed() };
         let mut dist_to_image_plane: f64 = 0.0;
         let mut image_plane_width = 0;
         let mut image_plane_height = 0;
-        call_suite_fn!(self, AEGP_GetEffectCameraMatrix, effect_ref.as_ptr(), &time.into() as *const _, &mut matrix, &mut dist_to_image_plane, &mut image_plane_width, &mut image_plane_height)?;
-        Ok((matrix.into(), dist_to_image_plane, image_plane_width, image_plane_height))
+        call_suite_fn!(
+            self,
+            AEGP_GetEffectCameraMatrix,
+            effect_ref.as_ptr(),
+            &time.into() as *const _,
+            &mut matrix,
+            &mut dist_to_image_plane,
+            &mut image_plane_width,
+            &mut image_plane_height
+        )?;
+        Ok((
+            matrix.into(),
+            dist_to_image_plane,
+            image_plane_width,
+            image_plane_height,
+        ))
     }
 }

--- a/after-effects/src/aegp/suites/project.rs
+++ b/after-effects/src/aegp/suites/project.rs
@@ -29,26 +29,42 @@ impl ProjectSuite {
         ))
     }
 
-     /// Retrieves the current time display settings.
-    pub fn project_time_display_config(&self, proj_handle: ProjectHandle) -> Result<TimeDisplayConfig, Error> {
+    /// Retrieves the current time display settings.
+    pub fn project_time_display_config(
+        &self,
+        proj_handle: ProjectHandle,
+    ) -> Result<TimeDisplayConfig, Error> {
         Ok(call_suite_fn_single!( self, AEGP_GetProjectTimeDisplay -> AEGP_TimeDisplay3, proj_handle.into())?.into())
     }
 
-
-     /// Specified [sic] the settings to be used for displaying time.
-    pub fn set_project_time_display_config(&self, proj_handle: ProjectHandle, config: TimeDisplayConfig) -> Result<(), Error> {
+    /// Specified [sic] the settings to be used for displaying time.
+    pub fn set_project_time_display_config(
+        &self,
+        proj_handle: ProjectHandle,
+        config: TimeDisplayConfig,
+    ) -> Result<(), Error> {
         let config: AEGP_TimeDisplay3 = config.into();
-        call_suite_fn!( self, AEGP_SetProjectTimeDisplay, proj_handle.into(), &config)?;
+        call_suite_fn!(
+            self,
+            AEGP_SetProjectTimeDisplay,
+            proj_handle.into(),
+            &config
+        )?;
         Ok(())
     }
 
-
     /// Obtain the current project name
     pub fn project_name(&self, proj_handle: ProjectHandle) -> Result<String, Error> {
-
         let mut buffer = [0i8; (ae_sys::AEGP_MAX_PROJ_NAME_SIZE + 1) as _];
-        call_suite_fn!(self, AEGP_GetProjectName, proj_handle.into(), buffer.as_mut_ptr() as *mut _)?;
-        Ok(unsafe { std::ffi::CStr::from_ptr(buffer.as_ptr()) }.to_string_lossy().into_owned())
+        call_suite_fn!(
+            self,
+            AEGP_GetProjectName,
+            proj_handle.into(),
+            buffer.as_mut_ptr() as *mut _
+        )?;
+        Ok(unsafe { std::ffi::CStr::from_ptr(buffer.as_ptr()) }
+            .to_string_lossy()
+            .into_owned())
     }
 
     /// Get the path of the project (empty string the project hasn’t been saved yet). The path is a handle to a NULL-terminated A_UTF16Char string,
@@ -56,18 +72,32 @@ impl ProjectSuite {
         let mem_handle = call_suite_fn_single!(self, AEGP_GetProjectPath -> ae_sys::AEGP_MemHandle, proj_handle.into())?;
 
         Ok(unsafe {
-            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr()).to_string_lossy()
+            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
+                .to_string_lossy()
         })
     }
+
     /// Returns TRUE if the project has been modified since it was opened.
     pub fn project_is_dirty(&self, proj_handle: ProjectHandle) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_ProjectIsDirty -> ae_sys::A_Boolean, proj_handle.into())? != 0)
+        Ok(
+            call_suite_fn_single!(self, AEGP_ProjectIsDirty -> ae_sys::A_Boolean, proj_handle.into())?
+                != 0,
+        )
     }
 
     /// Saves the entire project to the specified full path.
-    pub fn save_project_to_path(&self, proj_handle: ProjectHandle, path: &str) -> Result<(), Error> {
+    pub fn save_project_to_path(
+        &self,
+        proj_handle: ProjectHandle,
+        path: &str,
+    ) -> Result<(), Error> {
         let path = widestring::U16CString::from_str(path).map_err(|_| Error::InvalidParms)?;
-        call_suite_fn!(self, AEGP_SaveProjectToPath, proj_handle.into(), path.as_ptr())?;
+        call_suite_fn!(
+            self,
+            AEGP_SaveProjectToPath,
+            proj_handle.into(),
+            path.as_ptr()
+        )?;
         Ok(())
     }
 
@@ -91,19 +121,20 @@ impl ProjectSuite {
     /// NOTE: Will close the current project without saving it first!
     pub fn open_project_from_path(&self, path: &str) -> Result<ProjectHandle, Error> {
         let path = widestring::U16CString::from_str(path).map_err(|_| Error::InvalidParms)?;
-        Ok(ProjectHandle::from_raw(call_suite_fn_single!(self, AEGP_OpenProjectFromPath -> AEGP_ProjectH, path.as_ptr())?))
+        Ok(ProjectHandle::from_raw(
+            call_suite_fn_single!(self, AEGP_OpenProjectFromPath -> AEGP_ProjectH, path.as_ptr())?,
+        ))
     }
 
     /// Creates a new project. NOTE: Will close the current project without saving it first!
     pub fn new_project(&self) -> Result<ProjectHandle, Error> {
-        Ok(ProjectHandle::from_raw(call_suite_fn_single!(self, AEGP_NewProject -> AEGP_ProjectH)?))
+        Ok(ProjectHandle::from_raw(
+            call_suite_fn_single!(self, AEGP_NewProject -> AEGP_ProjectH)?,
+        ))
     }
 
     /// Retrieves the project bit depth.
-    pub fn project_bit_depth(
-        &self,
-        proj_handle: ProjectHandle,
-    ) -> Result<ProjectBitDepth, Error> {
+    pub fn project_bit_depth(&self, proj_handle: ProjectHandle) -> Result<ProjectBitDepth, Error> {
         Ok(call_suite_fn_single!( self, AEGP_GetProjectBitDepth -> ae_sys::A_char, proj_handle.into())?.into())
     }
 
@@ -113,9 +144,14 @@ impl ProjectSuite {
         proj_handle: ProjectHandle,
         bit_depth: ProjectBitDepth,
     ) -> Result<(), Error> {
-        Ok(call_suite_fn!(self, AEGP_SetProjectBitDepth, proj_handle.into(), bit_depth.into())?.into())
+        Ok(call_suite_fn!(
+            self,
+            AEGP_SetProjectBitDepth,
+            proj_handle.into(),
+            bit_depth.into()
+        )?
+        .into())
     }
-
 }
 
 register_handle!(AEGP_ProjectH);

--- a/after-effects/src/aegp/suites/register.rs
+++ b/after-effects/src/aegp/suites/register.rs
@@ -98,7 +98,9 @@ impl RegisterSuite {
                 Some(unsafe { &mut *(plugin_refcon as *mut P) })
             };
 
-            let Some((callback, refcon)) = (unsafe { (refcon as *mut (CommandHook<P, T>, T)).as_mut() }) else {
+            let Some((callback, refcon)) =
+                (unsafe { (refcon as *mut (CommandHook<P, T>, T)).as_mut() })
+            else {
                 return Error::Generic.into();
             };
 
@@ -116,15 +118,21 @@ impl RegisterSuite {
 
             match res {
                 Ok(CommandHookStatus::Handled) => {
-                    unsafe { *handled_p = 1; }
+                    unsafe {
+                        *handled_p = 1;
+                    }
                     Error::None
                 }
                 Ok(CommandHookStatus::Unhandled) => {
-                    unsafe { *handled_p = 0; }
+                    unsafe {
+                        *handled_p = 0;
+                    }
                     Error::None
                 }
                 Err(e) => {
-                    unsafe { *handled_p = 0; }
+                    unsafe {
+                        *handled_p = 0;
+                    }
                     e
                 }
             }
@@ -162,7 +170,8 @@ impl RegisterSuite {
                 Some(unsafe { &mut *(plugin_refcon as *mut P) })
             };
 
-            let Some((callback, refcon)) = (unsafe { (refcon as *mut (UpdateMenuHook<P, T>, T)).as_mut() })
+            let Some((callback, refcon)) =
+                (unsafe { (refcon as *mut (UpdateMenuHook<P, T>, T)).as_mut() })
             else {
                 return Error::Generic.into();
             };
@@ -460,15 +469,21 @@ impl RegisterNonAegpSuite {
 
             match res {
                 Ok(CommandHookStatus::Handled) => {
-                    unsafe { *handled_p = 1; }
+                    unsafe {
+                        *handled_p = 1;
+                    }
                     Error::None
                 }
                 Ok(CommandHookStatus::Unhandled) => {
-                    unsafe { *handled_p = 0; }
+                    unsafe {
+                        *handled_p = 0;
+                    }
                     Error::None
                 }
                 Err(e) => {
-                    unsafe { *handled_p = 0; }
+                    unsafe {
+                        *handled_p = 0;
+                    }
                     e
                 }
             }
@@ -500,7 +515,8 @@ impl RegisterNonAegpSuite {
             refcon: AEGP_UpdateMenuRefcon,
             window_type: ae_sys::AEGP_WindowType,
         ) -> sys::PF_Err {
-            let (callback, refcon) = unsafe { &mut *(refcon as *mut (NonAegpUpdateMenuHook<T>, T)) };
+            let (callback, refcon) =
+                unsafe { &mut *(refcon as *mut (NonAegpUpdateMenuHook<T>, T)) };
 
             match callback(refcon, window_type.into()) {
                 Ok(_) => Error::None,

--- a/after-effects/src/aegp/suites/render.rs
+++ b/after-effects/src/aegp/suites/render.rs
@@ -19,9 +19,7 @@ define_suite!(
 impl RenderSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Retrieves an `AEGP_FrameReceiptH` (not the actual pixels) for the frame requested.
     /// Check in this receipt using ``AEGP_CheckinFrame`` to release memory.
@@ -29,10 +27,19 @@ impl RenderSuite {
     /// Create the [`aegp::RenderOptionsHandle`] using the [`aegp::suites::RenderOptions`].
     ///
     /// Optionally, the AEGP can pass a function to be called by After Effects if the user cancels the current render.
-    pub fn render_and_checkout_frame<F: Fn() -> bool>(&self, options: impl AsPtr<AEGP_RenderOptionsH>, cancel_function: Option<F>) -> Result<AEGP_FrameReceiptH, Error> {
-        unsafe extern "C" fn cancel_fn(refcon: *mut std::ffi::c_void, cancel: *mut ae_sys::A_Boolean) -> A_Err {
+    pub fn render_and_checkout_frame<F: Fn() -> bool>(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+        cancel_function: Option<F>,
+    ) -> Result<AEGP_FrameReceiptH, Error> {
+        unsafe extern "C" fn cancel_fn(
+            refcon: *mut std::ffi::c_void,
+            cancel: *mut ae_sys::A_Boolean,
+        ) -> A_Err {
             unsafe {
-                let cb = Box::<Box<dyn Fn() -> bool + Send + Sync + 'static>>::from_raw(refcon as *mut _);
+                let cb = Box::<Box<dyn Fn() -> bool + Send + Sync + 'static>>::from_raw(
+                    refcon as *mut _,
+                );
                 *cancel = cb() as _;
             }
             ae_sys::PF_Err_NONE as ae_sys::PF_Err
@@ -64,10 +71,19 @@ impl RenderSuite {
     /// If you're not doing it for render purposes then it could be okay.
     ///
     /// Optionally, the AEGP can pass a function to be called by After Effects if the user cancels the current render.
-    pub fn render_and_checkout_layer_frame<F: FnMut() -> bool>(&self, options: impl AsPtr<AEGP_LayerRenderOptionsH>, cancel_function: Option<F>) -> Result<AEGP_FrameReceiptH, Error> {
-        unsafe extern "C" fn cancel_fn(refcon: *mut std::ffi::c_void, cancel: *mut ae_sys::A_Boolean) -> A_Err {
+    pub fn render_and_checkout_layer_frame<F: FnMut() -> bool>(
+        &self,
+        options: impl AsPtr<AEGP_LayerRenderOptionsH>,
+        cancel_function: Option<F>,
+    ) -> Result<AEGP_FrameReceiptH, Error> {
+        unsafe extern "C" fn cancel_fn(
+            refcon: *mut std::ffi::c_void,
+            cancel: *mut ae_sys::A_Boolean,
+        ) -> A_Err {
             unsafe {
-                let cb = Box::<Box<dyn Fn() -> bool + Send + Sync + 'static>>::from_raw(refcon as *mut _);
+                let cb = Box::<Box<dyn Fn() -> bool + Send + Sync + 'static>>::from_raw(
+                    refcon as *mut _,
+                );
                 *cancel = cb() as _;
             }
             ae_sys::PF_Err_NONE as ae_sys::PF_Err
@@ -84,9 +100,25 @@ impl RenderSuite {
         )
     }
 
-    pub fn render_and_checkout_layer_frame_async<R: FnMut(AEGP_AsyncRequestId, bool, Error, AEGP_FrameReceiptH)>(&self, options: impl AsPtr<AEGP_LayerRenderOptionsH>, callback: R) -> Result<AEGP_AsyncRequestId, Error> {
-        unsafe extern "C" fn frame_ready_cb(request_id: AEGP_AsyncRequestId, was_canceled: A_Boolean, error: A_Err, receipt: AEGP_FrameReceiptH, refcon: AEGP_AsyncFrameRequestRefcon) -> A_Err {
-            let cb = unsafe { Box::<Box<dyn Fn(AEGP_AsyncRequestId, bool, Error, AEGP_FrameReceiptH)>>::from_raw(refcon as *mut _) };
+    pub fn render_and_checkout_layer_frame_async<
+        R: FnMut(AEGP_AsyncRequestId, bool, Error, AEGP_FrameReceiptH),
+    >(
+        &self,
+        options: impl AsPtr<AEGP_LayerRenderOptionsH>,
+        callback: R,
+    ) -> Result<AEGP_AsyncRequestId, Error> {
+        unsafe extern "C" fn frame_ready_cb(
+            request_id: AEGP_AsyncRequestId,
+            was_canceled: A_Boolean,
+            error: A_Err,
+            receipt: AEGP_FrameReceiptH,
+            refcon: AEGP_AsyncFrameRequestRefcon,
+        ) -> A_Err {
+            let cb = unsafe {
+                Box::<Box<dyn Fn(AEGP_AsyncRequestId, bool, Error, AEGP_FrameReceiptH)>>::from_raw(
+                    refcon as *mut _,
+                )
+            };
             cb(request_id, was_canceled != 0, Error::from(error), receipt);
             ae_sys::PF_Err_NONE as ae_sys::PF_Err
         }
@@ -109,9 +141,12 @@ impl RenderSuite {
     }
 
     /// Retrieves the pixels ([`aegp::WorldHandle`]) associated with the referenced `AEGP_FrameReceiptH`
-    pub fn receipt_world(&self, receipt: impl AsPtr<AEGP_FrameReceiptH>) -> Result<aegp::WorldHandle, Error> {
+    pub fn receipt_world(
+        &self,
+        receipt: impl AsPtr<AEGP_FrameReceiptH>,
+    ) -> Result<aegp::WorldHandle, Error> {
         Ok(aegp::WorldHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetReceiptWorld -> AEGP_WorldH, receipt.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetReceiptWorld -> AEGP_WorldH, receipt.as_ptr())?,
         ))
     }
 
@@ -119,39 +154,59 @@ impl RenderSuite {
     /// Remember that it's possible for only those portions of an image that have been changed to be rendered,
     /// so it's important to be able to check whether or not that includes the portion you need.
     pub fn rendered_region(&self, receipt: impl AsPtr<AEGP_FrameReceiptH>) -> Result<Rect, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetRenderedRegion -> A_LRect, receipt.as_ptr())?.into())
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetRenderedRegion -> A_LRect, receipt.as_ptr())?
+                .into(),
+        )
     }
 
     /// Given two sets of [`aegp::RenderOptions`], After Effects will return `true` if the already-rendered pixels are still valid for the proposed [`aegp::RenderOptions`].
-    pub fn is_rendered_frame_sufficient(&self, rendered_options: impl AsPtr<AEGP_RenderOptionsH>, proposed_options: impl AsPtr<AEGP_RenderOptionsH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsRenderedFrameSufficient -> A_Boolean, rendered_options.as_ptr(), proposed_options.as_ptr())? != 0)
+    pub fn is_rendered_frame_sufficient(
+        &self,
+        rendered_options: impl AsPtr<AEGP_RenderOptionsH>,
+        proposed_options: impl AsPtr<AEGP_RenderOptionsH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsRenderedFrameSufficient -> A_Boolean, rendered_options.as_ptr(), proposed_options.as_ptr())?
+                != 0,
+        )
     }
 
     /// Obtains an [`aegp::SoundDataHandle`] for the given item at the given time, of the given duration, in the given format.
     ///
     /// NOTE: This function, if called as part of [`aegp::suites::Item`], provides a render interruptible using mouse clicks,
     /// unlike the version published here in [`aegp::suites::Render`].
-    pub fn render_new_item_sound_data<F: FnMut() -> bool>(&self, item: impl AsPtr<AEGP_ItemH>, start_time: Time, duration: Time, sound_format: &AEGP_SoundDataFormat, cancel_function: Option<F>) -> Result<aegp::SoundDataHandle, Error> {
-        unsafe extern "C" fn cancel_fn(refcon: *mut std::ffi::c_void, cancel: *mut ae_sys::A_Boolean) -> A_Err {
+    pub fn render_new_item_sound_data<F: FnMut() -> bool>(
+        &self,
+        item: impl AsPtr<AEGP_ItemH>,
+        start_time: Time,
+        duration: Time,
+        sound_format: &AEGP_SoundDataFormat,
+        cancel_function: Option<F>,
+    ) -> Result<aegp::SoundDataHandle, Error> {
+        unsafe extern "C" fn cancel_fn(
+            refcon: *mut std::ffi::c_void,
+            cancel: *mut ae_sys::A_Boolean,
+        ) -> A_Err {
             unsafe {
-                let cb = Box::<Box<dyn Fn() -> bool + Send + Sync + 'static>>::from_raw(refcon as *mut _);
+                let cb = Box::<Box<dyn Fn() -> bool + Send + Sync + 'static>>::from_raw(
+                    refcon as *mut _,
+                );
                 *cancel = cb() as _;
             }
             ae_sys::PF_Err_NONE as ae_sys::PF_Err
         }
         let cancel_function = cancel_function.map(|x| Box::new(Box::new(x)));
 
-        Ok(aegp::SoundDataHandle::from_raw(
-            call_suite_fn_single!(self,
-                AEGP_RenderNewItemSoundData -> AEGP_SoundDataH,
-                item.as_ptr(),
-                &start_time.into(),
-                &duration.into(),
-                sound_format,
-                if cancel_function.is_some() { Some(cancel_fn) } else { None },
-                cancel_function.map_or(std::ptr::null_mut(), |f| Box::into_raw(f) as *mut _)
-            )?
-        ))
+        Ok(aegp::SoundDataHandle::from_raw(call_suite_fn_single!(self,
+            AEGP_RenderNewItemSoundData -> AEGP_SoundDataH,
+            item.as_ptr(),
+            &start_time.into(),
+            &duration.into(),
+            sound_format,
+            if cancel_function.is_some() { Some(cancel_fn) } else { None },
+            cancel_function.map_or(std::ptr::null_mut(), |f| Box::into_raw(f) as *mut _)
+        )?))
     }
 
     /// Retrieves the current `AEGP_TimeStamp` of the project.
@@ -163,26 +218,58 @@ impl RenderSuite {
     /// Returns whether the video of an `AEGP_ItemH` has changed since the given `AEGP_TimeStamp`.
     ///
     /// Note: this does not track changes in audio.
-    pub fn has_item_changed_since_timestamp(&self, item: impl AsPtr<AEGP_ItemH>, start_time: Time, duration: Time, timestamp: &AEGP_TimeStamp) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_HasItemChangedSinceTimestamp -> A_Boolean, item.as_ptr(), &start_time.into(), &duration.into(), timestamp)? != 0)
+    pub fn has_item_changed_since_timestamp(
+        &self,
+        item: impl AsPtr<AEGP_ItemH>,
+        start_time: Time,
+        duration: Time,
+        timestamp: &AEGP_TimeStamp,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_HasItemChangedSinceTimestamp -> A_Boolean, item.as_ptr(), &start_time.into(), &duration.into(), timestamp)?
+                != 0,
+        )
     }
 
     /// Returns whether this frame would be worth rendering externally and checking in to the cache.
     /// A speculative renderer should check this twice: before sending the frame out to render and when it is complete, before calling `AEGP_NewPlatformWorld()` and checking in.
     ///
     /// This function is to be used with [`has_item_changed_since_timestamp()`](Self::has_item_changed_since_timestamp), not alone.
-    pub fn is_item_worthwhile_to_render(&self, render_options: impl AsPtr<AEGP_RenderOptionsH>, timestamp: &AEGP_TimeStamp) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsItemWorthwhileToRender -> A_Boolean, render_options.as_ptr(), timestamp)? != 0)
+    pub fn is_item_worthwhile_to_render(
+        &self,
+        render_options: impl AsPtr<AEGP_RenderOptionsH>,
+        timestamp: &AEGP_TimeStamp,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsItemWorthwhileToRender -> A_Boolean, render_options.as_ptr(), timestamp)?
+                != 0,
+        )
     }
 
     /// Provide a rendered frame (`AEGP_PlatformWorldH`) to After Effects, which adopts it.
     /// `ticks` is the approximate time required to render the frame.
-    pub fn checkin_rendered_frame(&self, render_options: impl AsPtr<AEGP_RenderOptionsH>, timestamp: &AEGP_TimeStamp, ticks_to_render: u32, image: AEGP_PlatformWorldH) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_CheckinRenderedFrame, render_options.as_ptr(), timestamp, ticks_to_render, image)
+    pub fn checkin_rendered_frame(
+        &self,
+        render_options: impl AsPtr<AEGP_RenderOptionsH>,
+        timestamp: &AEGP_TimeStamp,
+        ticks_to_render: u32,
+        image: AEGP_PlatformWorldH,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_CheckinRenderedFrame,
+            render_options.as_ptr(),
+            timestamp,
+            ticks_to_render,
+            image
+        )
     }
 
     /// New in CS6. Retrieve a GUID for a rendered frame. The memory handle passed back must be disposed.
-    pub fn receipt_guid(&self, receipt: impl AsPtr<AEGP_FrameReceiptH>) -> Result<AEGP_MemHandle, Error> {
+    pub fn receipt_guid(
+        &self,
+        receipt: impl AsPtr<AEGP_FrameReceiptH>,
+    ) -> Result<AEGP_MemHandle, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetReceiptGuid -> AEGP_MemHandle, receipt.as_ptr())?)
     }
 }

--- a/after-effects/src/aegp/suites/render_async_manager.rs
+++ b/after-effects/src/aegp/suites/render_async_manager.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use ae_sys::{ PF_AsyncManagerP, AEGP_FrameReceiptH, AEGP_RenderOptionsH, AEGP_LayerRenderOptionsH };
+use ae_sys::{AEGP_FrameReceiptH, AEGP_LayerRenderOptionsH, AEGP_RenderOptionsH, PF_AsyncManagerP};
 
 define_suite!(
     /// For cases where such renders formerly were triggered by side-effect or cancelled implicity
@@ -17,15 +17,23 @@ define_suite!(
 impl RenderAsyncManagerSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
-    pub fn checkout_or_render_item_frame_async_manager(&self, async_manager: impl AsPtr<PF_AsyncManagerP>, purpose_id: u32, ro: impl AsPtr<AEGP_RenderOptionsH>) -> Result<AEGP_FrameReceiptH, Error> {
+    pub fn checkout_or_render_item_frame_async_manager(
+        &self,
+        async_manager: impl AsPtr<PF_AsyncManagerP>,
+        purpose_id: u32,
+        ro: impl AsPtr<AEGP_RenderOptionsH>,
+    ) -> Result<AEGP_FrameReceiptH, Error> {
         call_suite_fn_single!(self, AEGP_CheckoutOrRender_ItemFrame_AsyncManager -> AEGP_FrameReceiptH, async_manager.as_ptr(), purpose_id as _, ro.as_ptr())
     }
 
-    pub fn checkout_or_render_layer_frame_async_manager(&self, async_manager: impl AsPtr<PF_AsyncManagerP>, purpose_id: u32, lro: impl AsPtr<AEGP_LayerRenderOptionsH>) -> Result<AEGP_FrameReceiptH, Error> {
+    pub fn checkout_or_render_layer_frame_async_manager(
+        &self,
+        async_manager: impl AsPtr<PF_AsyncManagerP>,
+        purpose_id: u32,
+        lro: impl AsPtr<AEGP_LayerRenderOptionsH>,
+    ) -> Result<AEGP_FrameReceiptH, Error> {
         call_suite_fn_single!(self, AEGP_CheckoutOrRender_LayerFrame_AsyncManager -> AEGP_FrameReceiptH, async_manager.as_ptr(), purpose_id as _, lro.as_ptr())
     }
 }
@@ -37,11 +45,21 @@ register_handle!(AEGP_FrameReceiptH);
 define_handle_wrapper!(AsyncManager, PF_AsyncManagerP);
 
 impl AsyncManager {
-    pub fn checkout_or_render_item_frame_async_manager(&self, purpose_id: u32, ro: impl AsPtr<AEGP_RenderOptionsH>) -> Result<AEGP_FrameReceiptH, Error> {
-        RenderAsyncManagerSuite::new()?.checkout_or_render_item_frame_async_manager(self.0, purpose_id, ro)
+    pub fn checkout_or_render_item_frame_async_manager(
+        &self,
+        purpose_id: u32,
+        ro: impl AsPtr<AEGP_RenderOptionsH>,
+    ) -> Result<AEGP_FrameReceiptH, Error> {
+        RenderAsyncManagerSuite::new()?
+            .checkout_or_render_item_frame_async_manager(self.0, purpose_id, ro)
     }
 
-    pub fn checkout_or_render_layer_frame_async_manager(&self, purpose_id: u32, lro: impl AsPtr<AEGP_LayerRenderOptionsH>) -> Result<AEGP_FrameReceiptH, Error> {
-        RenderAsyncManagerSuite::new()?.checkout_or_render_layer_frame_async_manager(self.0, purpose_id, lro)
+    pub fn checkout_or_render_layer_frame_async_manager(
+        &self,
+        purpose_id: u32,
+        lro: impl AsPtr<AEGP_LayerRenderOptionsH>,
+    ) -> Result<AEGP_FrameReceiptH, Error> {
+        RenderAsyncManagerSuite::new()?
+            .checkout_or_render_layer_frame_async_manager(self.0, purpose_id, lro)
     }
 }

--- a/after-effects/src/aegp/suites/render_options.rs
+++ b/after-effects/src/aegp/suites/render_options.rs
@@ -1,6 +1,9 @@
-use crate::*;
 use crate::aegp::*;
-use ae_sys::{ AEGP_ItemH, AEGP_RenderOptionsH, A_Time, AEGP_WorldType, AEGP_MatteMode, PF_Field, AEGP_ChannelOrder, AEGP_ItemQuality, A_Boolean };
+use crate::*;
+use ae_sys::{
+    A_Boolean, A_Time, AEGP_ChannelOrder, AEGP_ItemH, AEGP_ItemQuality, AEGP_MatteMode,
+    AEGP_RenderOptionsH, AEGP_WorldType, PF_Field,
+};
 
 define_suite!(
     /// Since we introduced the AEGP API, we've been asked to provide functions for retrieving rendered frames.
@@ -19,25 +22,31 @@ define_suite!(
 impl RenderOptionsSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Returns the [`RenderOptionsHandle`] associated with a given [`aegp::Item`].
     /// If there are no options yet specified, After Effects passes back an [`RenderOptionsHandle`] with render time set to 0,
     /// time step set to the current frame duration, field render set to ``PF_Field_FRAME``, and the depth set to the highest resolution specified within the item.
     ///
     /// The returned object will be disposed on drop
-    pub fn new_from_item(&self, item: impl AsPtr<AEGP_ItemH>, plugin_id: aegp::PluginId) -> Result<RenderOptionsHandle, Error> {
+    pub fn new_from_item(
+        &self,
+        item: impl AsPtr<AEGP_ItemH>,
+        plugin_id: aegp::PluginId,
+    ) -> Result<RenderOptionsHandle, Error> {
         Ok(RenderOptionsHandle::from_raw_owned(
-            call_suite_fn_single!(self, AEGP_NewFromItem -> AEGP_RenderOptionsH, plugin_id, item.as_ptr())?
+            call_suite_fn_single!(self, AEGP_NewFromItem -> AEGP_RenderOptionsH, plugin_id, item.as_ptr())?,
         ))
     }
 
     /// Duplicates the given [`RenderOptionsHandle`].
-    pub fn duplicate(&self, options: impl AsPtr<AEGP_RenderOptionsH>, plugin_id: aegp::PluginId) -> Result<RenderOptionsHandle, Error> {
+    pub fn duplicate(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+        plugin_id: aegp::PluginId,
+    ) -> Result<RenderOptionsHandle, Error> {
         Ok(RenderOptionsHandle::from_raw_owned(
-            call_suite_fn_single!(self, AEGP_Duplicate -> AEGP_RenderOptionsH, plugin_id, options.as_ptr())?
+            call_suite_fn_single!(self, AEGP_Duplicate -> AEGP_RenderOptionsH, plugin_id, options.as_ptr())?,
         ))
     }
 
@@ -47,7 +56,11 @@ impl RenderOptionsSuite {
     }
 
     /// Sets the render time of the given [`RenderOptionsHandle`].
-    pub fn set_time(&self, options: impl AsPtr<AEGP_RenderOptionsH>, time: Time) -> Result<(), Error> {
+    pub fn set_time(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+        time: Time,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetTime, options.as_ptr(), time.into())
     }
 
@@ -57,7 +70,11 @@ impl RenderOptionsSuite {
     }
 
     /// Specifies the time step (duration of a frame) for the referenced [`RenderOptionsHandle`].
-    pub fn set_time_step(&self, options: impl AsPtr<AEGP_RenderOptionsH>, time_step: Time) -> Result<(), Error> {
+    pub fn set_time_step(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+        time_step: Time,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetTimeStep, options.as_ptr(), time_step.into())
     }
 
@@ -67,42 +84,84 @@ impl RenderOptionsSuite {
     }
 
     /// Specifies the field settings for the given [`RenderOptionsHandle`].
-    pub fn set_field_render(&self, options: impl AsPtr<AEGP_RenderOptionsH>, field_render: pf::Field) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetFieldRender, options.as_ptr(), field_render.into())
+    pub fn set_field_render(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+        field_render: pf::Field,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetFieldRender,
+            options.as_ptr(),
+            field_render.into()
+        )
     }
 
     /// Retrieves the field settings for the given [`RenderOptionsHandle`].
-    pub fn field_render(&self, options: impl AsPtr<AEGP_RenderOptionsH>) -> Result<pf::Field, Error> {
+    pub fn field_render(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+    ) -> Result<pf::Field, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetFieldRender -> PF_Field, options.as_ptr())?.into())
     }
 
     /// Specifies the AEGP_WorldType of the output of a given [`RenderOptionsHandle`].
-    pub fn set_world_type(&self, options: impl AsPtr<AEGP_RenderOptionsH>, typ: aegp::WorldType) -> Result<(), Error> {
+    pub fn set_world_type(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+        typ: aegp::WorldType,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetWorldType, options.as_ptr(), typ.into())
     }
 
     /// Retrieves the AEGP_WorldType of the given [`RenderOptionsHandle`].
-    pub fn world_type(&self, options: impl AsPtr<AEGP_RenderOptionsH>) -> Result<aegp::WorldType, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetWorldType -> AEGP_WorldType, options.as_ptr())?.into())
+    pub fn world_type(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+    ) -> Result<aegp::WorldType, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetWorldType -> AEGP_WorldType, options.as_ptr())?
+                .into(),
+        )
     }
 
     /// Specifies the downsample factor (with independent horizontal and vertical settings) for the given [`RenderOptionsHandle`].
-    pub fn set_downsample_factor(&self, options: impl AsPtr<AEGP_RenderOptionsH>, x: i16, y: i16) -> Result<(), Error> {
+    pub fn set_downsample_factor(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+        x: i16,
+        y: i16,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetDownsampleFactor, options.as_ptr(), x, y)
     }
 
     /// Retrieves the downsample factor for the given [`RenderOptionsHandle`].
-    pub fn downsample_factor(&self, options: impl AsPtr<AEGP_RenderOptionsH>) -> Result<(i16, i16), Error> {
+    pub fn downsample_factor(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+    ) -> Result<(i16, i16), Error> {
         call_suite_fn_double!(self, AEGP_GetDownsampleFactor -> i16, i16, options.as_ptr())
     }
 
     /// Specifies the region of interest sub-rectangle for the given [`RenderOptionsHandle`].
-    pub fn set_region_of_interest(&self, options: impl AsPtr<AEGP_RenderOptionsH>, roi: Rect) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetRegionOfInterest, options.as_ptr(), &roi.into())
+    pub fn set_region_of_interest(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+        roi: Rect,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetRegionOfInterest,
+            options.as_ptr(),
+            &roi.into()
+        )
     }
 
     /// Retrieves the region of interest sub-rectangle for the given [`RenderOptionsHandle`].
-    pub fn region_of_interest(&self, options: impl AsPtr<AEGP_RenderOptionsH>) -> Result<Rect, Error> {
+    pub fn region_of_interest(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+    ) -> Result<Rect, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetRegionOfInterest -> ae_sys::A_LRect, options.as_ptr())?.into())
     }
 
@@ -111,47 +170,93 @@ impl RenderOptionsSuite {
     /// - [`MatteMode::Straight`]
     /// - [`MatteMode::PremulBlack`]
     /// - [`MatteMode::PremulBgColor`]
-    pub fn set_matte_mode(&self, options: impl AsPtr<AEGP_RenderOptionsH>, mode: MatteMode) -> Result<(), Error> {
+    pub fn set_matte_mode(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+        mode: MatteMode,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetMatteMode, options.as_ptr(), mode.into())
     }
 
     /// Retrieves the matte mode for the given [`RenderOptionsHandle`].
     pub fn matte_mode(&self, options: impl AsPtr<AEGP_RenderOptionsH>) -> Result<MatteMode, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetMatteMode -> AEGP_MatteMode, options.as_ptr())?.into())
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetMatteMode -> AEGP_MatteMode, options.as_ptr())?
+                .into(),
+        )
     }
 
     /// Specifies the [`ChannelOrder`] for the given [`RenderOptionsHandle`].
     ///
     /// Factoid: this was added to facilitate live linking with Premiere Pro.
-    pub fn set_channel_order(&self, options: impl AsPtr<AEGP_RenderOptionsH>, channel_order: ChannelOrder) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetChannelOrder, options.as_ptr(), channel_order.into())
+    pub fn set_channel_order(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+        channel_order: ChannelOrder,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetChannelOrder,
+            options.as_ptr(),
+            channel_order.into()
+        )
     }
 
     /// Retrieves the [`ChannelOrder`] for the given [`RenderOptionsHandle`].
-    pub fn channel_order(&self, options: impl AsPtr<AEGP_RenderOptionsH>) -> Result<ChannelOrder, Error> {
+    pub fn channel_order(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+    ) -> Result<ChannelOrder, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetChannelOrder -> AEGP_ChannelOrder, options.as_ptr())?.into())
     }
 
     /// Passes back a boolean that is true if the render guide layers setting is on.
-    pub fn render_guide_layers(&self, options: impl AsPtr<AEGP_RenderOptionsH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetRenderGuideLayers -> A_Boolean, options.as_ptr())? != 0)
+    pub fn render_guide_layers(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetRenderGuideLayers -> A_Boolean, options.as_ptr())?
+                != 0,
+        )
     }
 
     /// Specify whether or not to render guide layers.
-    pub fn set_render_guide_layers(&self, options: impl AsPtr<AEGP_RenderOptionsH>, render_them: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetRenderGuideLayers, options.as_ptr(), render_them as _)
+    pub fn set_render_guide_layers(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+        render_them: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetRenderGuideLayers,
+            options.as_ptr(),
+            render_them as _
+        )
     }
 
     /// Get the render quality of the render queue item.
     /// Quality can be either [`ItemQuality::Draft`] or [`ItemQuality::Best`].
-    pub fn render_quality(&self, options: impl AsPtr<AEGP_RenderOptionsH>) -> Result<ItemQuality, Error> {
+    pub fn render_quality(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+    ) -> Result<ItemQuality, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetRenderQuality -> AEGP_ItemQuality, options.as_ptr())?.into())
     }
 
     /// Set the render quality of the render queue item.
     /// Quality can be either [`ItemQuality::Draft`] or [`ItemQuality::Best`].
-    pub fn set_render_quality(&self, options: impl AsPtr<AEGP_RenderOptionsH>, quality: ItemQuality) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetRenderQuality, options.as_ptr(), quality.into())
+    pub fn set_render_quality(
+        &self,
+        options: impl AsPtr<AEGP_RenderOptionsH>,
+        quality: ItemQuality,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetRenderQuality,
+            options.as_ptr(),
+            quality.into()
+        )
     }
 }
 
@@ -162,7 +267,10 @@ define_owned_handle_wrapper!(RenderOptionsHandle, AEGP_RenderOptionsH);
 impl Drop for RenderOptionsHandle {
     fn drop(&mut self) {
         if self.is_owned() {
-            RenderOptionsSuite::new().unwrap().dispose(self.as_ptr()).unwrap();
+            RenderOptionsSuite::new()
+                .unwrap()
+                .dispose(self.as_ptr())
+                .unwrap();
         }
     }
 }
@@ -269,10 +377,15 @@ impl RenderOptions {
     /// time step set to the current frame duration, field render set to ``PF_Field_FRAME``, and the depth set to the highest resolution specified within the item.
     ///
     /// The returned object will be disposed on drop
-    pub fn from_item(layer: impl AsPtr<AEGP_ItemH>, plugin_id: aegp::PluginId) -> Result<Self, Error> {
+    pub fn from_item(
+        layer: impl AsPtr<AEGP_ItemH>,
+        plugin_id: aegp::PluginId,
+    ) -> Result<Self, Error> {
         Ok(Self::from_handle(
-            RenderOptionsSuite::new().unwrap().new_from_item(layer, plugin_id)?,
-            false
+            RenderOptionsSuite::new()
+                .unwrap()
+                .new_from_item(layer, plugin_id)?,
+            false,
         ))
     }
 }

--- a/after-effects/src/aegp/suites/render_queue.rs
+++ b/after-effects/src/aegp/suites/render_queue.rs
@@ -19,9 +19,7 @@ define_suite!(
 impl RenderQueueSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /*
         AEGP_AddCompToRenderQueue(

--- a/after-effects/src/aegp/suites/render_queue_item.rs
+++ b/after-effects/src/aegp/suites/render_queue_item.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::aegp::*;
+use crate::*;
 
 define_suite!(
     /// Render Queue Item Suite provides information about items in the render queue.
@@ -15,9 +15,7 @@ define_suite!(
 impl RenderQueueItemSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Returns the number of items currently in the render queue.
     pub fn num_items(&self) -> Result<i32, Error> {
@@ -27,15 +25,19 @@ impl RenderQueueItemSuite {
     /// Retrieves a render queue item by index.
     pub fn item_by_index(&self, index: i32) -> Result<RQItemRefHandle, Error> {
         Ok(RQItemRefHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetRQItemByIndex -> ae_sys::AEGP_RQItemRefH, index as ae_sys::A_long)?
+            call_suite_fn_single!(self, AEGP_GetRQItemByIndex -> ae_sys::AEGP_RQItemRefH, index as ae_sys::A_long)?,
         ))
     }
 
     /// Retrieves the next render queue item.
     /// Pass `None` for `current_item` to get the first item.
-    pub fn next_item(&self, current_item: Option<RQItemRefHandle>) -> Result<Option<RQItemRefHandle>, Error> {
+    pub fn next_item(
+        &self,
+        current_item: Option<RQItemRefHandle>,
+    ) -> Result<Option<RQItemRefHandle>, Error> {
         let current = current_item.map_or(std::ptr::null_mut(), |h| h.as_ptr());
-        let next = call_suite_fn_single!(self, AEGP_GetNextRQItem -> ae_sys::AEGP_RQItemRefH, current)?;
+        let next =
+            call_suite_fn_single!(self, AEGP_GetNextRQItem -> ae_sys::AEGP_RQItemRefH, current)?;
         if next.is_null() {
             Ok(None)
         } else {
@@ -44,12 +46,21 @@ impl RenderQueueItemSuite {
     }
 
     /// Returns the number of output modules attached to the given render queue item.
-    pub fn num_output_modules(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetNumOutputModulesForRQItem -> ae_sys::A_long, rq_item.as_ptr())? as i32)
+    pub fn num_output_modules(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetNumOutputModulesForRQItem -> ae_sys::A_long, rq_item.as_ptr())?
+                as i32,
+        )
     }
 
     /// Returns the render state of the given render queue item.
-    pub fn render_state(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<RenderItemStatus, Error> {
+    pub fn render_state(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+    ) -> Result<RenderItemStatus, Error> {
         Ok(
             call_suite_fn_single!(self, AEGP_GetRenderState -> ae_sys::AEGP_RenderItemStatusType, rq_item.as_ptr())?
                 .into()
@@ -63,25 +74,35 @@ impl RenderQueueItemSuite {
     /// Returns `Err_RANGE` if you pass a status that is illegal in any case.
     /// Returns `Err_PARAMETER` if you try to pass a status that doesn't make sense
     /// (e.g., trying to queue something for which you haven't set the output path).
-    pub fn set_render_state(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>, status: RenderItemStatus) -> Result<(), Error> {
+    pub fn set_render_state(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        status: RenderItemStatus,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetRenderState, rq_item.as_ptr(), status.into())
     }
 
     /// Returns the time at which the given render queue item started rendering.
     /// Returns `Time { value: 0, scale: 1 }` if not started.
-    pub fn started_time(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<Time, Error> {
+    pub fn started_time(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+    ) -> Result<Time, Error> {
         Ok(
             call_suite_fn_single!(self, AEGP_GetStartedTime -> ae_sys::A_Time, rq_item.as_ptr())?
-                .into()
+                .into(),
         )
     }
 
     /// Returns the elapsed rendering time for the given render queue item.
     /// Returns `Time { value: 0, scale: 1 }` if not rendered.
-    pub fn elapsed_time(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<Time, Error> {
+    pub fn elapsed_time(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+    ) -> Result<Time, Error> {
         Ok(
             call_suite_fn_single!(self, AEGP_GetElapsedTime -> ae_sys::A_Time, rq_item.as_ptr())?
-                .into()
+                .into(),
         )
     }
 
@@ -89,12 +110,16 @@ impl RenderQueueItemSuite {
     pub fn log_type(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<LogType, Error> {
         Ok(
             call_suite_fn_single!(self, AEGP_GetLogType -> ae_sys::AEGP_LogType, rq_item.as_ptr())?
-                .into()
+                .into(),
         )
     }
 
     /// Sets the log type for the given render queue item.
-    pub fn set_log_type(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>, log_type: LogType) -> Result<(), Error> {
+    pub fn set_log_type(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        log_type: LogType,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_SetLogType, rq_item.as_ptr(), log_type.into())
     }
 
@@ -104,7 +129,12 @@ impl RenderQueueItemSuite {
         rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
         output_module: impl AsPtr<ae_sys::AEGP_OutputModuleRefH>,
     ) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_RemoveOutputModule, rq_item.as_ptr(), output_module.as_ptr())
+        call_suite_fn!(
+            self,
+            AEGP_RemoveOutputModule,
+            rq_item.as_ptr(),
+            output_module.as_ptr()
+        )
     }
 
     /// Retrieves the comment for the given render queue item.
@@ -113,21 +143,30 @@ impl RenderQueueItemSuite {
         unsafe {
             Ok(
                 U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
-                    .to_string_lossy()
+                    .to_string_lossy(),
             )
         }
     }
 
     /// Sets the comment for the given render queue item.
-    pub fn set_comment(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>, comment: &str) -> Result<(), Error> {
+    pub fn set_comment(
+        &self,
+        rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>,
+        comment: &str,
+    ) -> Result<(), Error> {
         let comment_utf16 = U16CString::from_str(comment).map_err(|_| Error::InvalidParms)?;
-        call_suite_fn!(self, AEGP_SetComment, rq_item.as_ptr(), comment_utf16.as_ptr())
+        call_suite_fn!(
+            self,
+            AEGP_SetComment,
+            rq_item.as_ptr(),
+            comment_utf16.as_ptr()
+        )
     }
 
     /// Retrieves the composition associated with the given render queue item.
     pub fn comp(&self, rq_item: impl AsPtr<ae_sys::AEGP_RQItemRefH>) -> Result<CompHandle, Error> {
         Ok(CompHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_GetCompFromRQItem -> ae_sys::AEGP_CompH, rq_item.as_ptr())?
+            call_suite_fn_single!(self, AEGP_GetCompFromRQItem -> ae_sys::AEGP_CompH, rq_item.as_ptr())?,
         ))
     }
 

--- a/after-effects/src/aegp/suites/sound_data.rs
+++ b/after-effects/src/aegp/suites/sound_data.rs
@@ -14,12 +14,13 @@ define_suite!(
 impl SoundDataSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Creates a new [`SoundDataHandle`]. It's disposed on drop.
-    pub fn new_sound_data(&self, sound_format: &AEGP_SoundDataFormat) -> Result<SoundDataHandle, Error> {
+    pub fn new_sound_data(
+        &self,
+        sound_format: &AEGP_SoundDataFormat,
+    ) -> Result<SoundDataHandle, Error> {
         Ok(SoundDataHandle::from_raw_owned(
             call_suite_fn_single!(self, AEGP_NewSoundData -> AEGP_SoundDataH, sound_format)?,
         ))
@@ -31,17 +32,26 @@ impl SoundDataSuite {
     }
 
     /// Obtains information about the format of a given [`SoundDataHandle`].
-    pub fn sound_data_format(&self, sound_data: impl AsPtr<AEGP_SoundDataH>) -> Result<AEGP_SoundDataFormat, Error> {
+    pub fn sound_data_format(
+        &self,
+        sound_data: impl AsPtr<AEGP_SoundDataH>,
+    ) -> Result<AEGP_SoundDataFormat, Error> {
         call_suite_fn_single!(self, AEGP_GetSoundDataFormat -> AEGP_SoundDataFormat, sound_data.as_ptr())
     }
 
     /// Locks the [`SoundDataHandle`] in memory
-    pub fn lock_sound_data_samples(&self, sound_data: impl AsPtr<AEGP_SoundDataH>) -> Result<*mut std::ffi::c_void, Error> {
+    pub fn lock_sound_data_samples(
+        &self,
+        sound_data: impl AsPtr<AEGP_SoundDataH>,
+    ) -> Result<*mut std::ffi::c_void, Error> {
         call_suite_fn_single!(self, AEGP_LockSoundDataSamples -> *mut std::ffi::c_void, sound_data.as_ptr())
     }
 
     /// Unlocks an [`SoundDataHandle`].
-    pub fn unlock_sound_data_samples(&self, sound_data: impl AsPtr<AEGP_SoundDataH>) -> Result<(), Error> {
+    pub fn unlock_sound_data_samples(
+        &self,
+        sound_data: impl AsPtr<AEGP_SoundDataH>,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_UnlockSoundDataSamples, sound_data.as_ptr())
     }
 

--- a/after-effects/src/aegp/suites/stream.rs
+++ b/after-effects/src/aegp/suites/stream.rs
@@ -1,6 +1,6 @@
-use crate::*;
 use crate::aegp::*;
-use ae_sys::{ AEGP_LayerH, AEGP_MaskRefH, AEGP_StreamRefH, AEGP_EffectRefH};
+use crate::*;
+use ae_sys::{AEGP_EffectRefH, AEGP_LayerH, AEGP_MaskRefH, AEGP_StreamRefH};
 
 define_suite!(
     /// Access and manipulate the values of a layer's streams. For paint and text streams, use [`DynamicStreamSuite`] instead.
@@ -13,22 +13,36 @@ define_suite!(
 impl StreamSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Determines if the given stream is appropriate for the given layer.
-    pub fn is_stream_legal(&self, layer_handle: impl AsPtr<AEGP_LayerH>, stream: LayerStream) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsStreamLegal -> ae_sys::A_Boolean, layer_handle.as_ptr(), stream.into())? != 0)
+    pub fn is_stream_legal(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        stream: LayerStream,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsStreamLegal -> ae_sys::A_Boolean, layer_handle.as_ptr(), stream.into())?
+                != 0,
+        )
     }
 
     /// Given a stream, returns whether or not a stream is time-variant (and can be keyframed).
-    pub fn can_vary_over_time(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_CanVaryOverTime -> ae_sys::A_Boolean, stream_ref.as_ptr())? != 0)
+    pub fn can_vary_over_time(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_CanVaryOverTime -> ae_sys::A_Boolean, stream_ref.as_ptr())?
+                != 0,
+        )
     }
 
     /// Retrieves an [`KeyframeInterpolationMask`] indicating which interpolation types are valid for the [`StreamReferenceHandle`].
-    pub fn valid_interpolations(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<KeyframeInterpolationMask, Error> {
+    pub fn valid_interpolations(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<KeyframeInterpolationMask, Error> {
         Ok(KeyframeInterpolationMask::from_bits_truncate(
             call_suite_fn_single!(self, AEGP_GetValidInterpolations -> ae_sys::AEGP_KeyInterpolationMask, stream_ref.as_ptr())?,
         ))
@@ -37,7 +51,12 @@ impl StreamSuite {
     /// Get a layer's data stream.
     ///
     /// Note that this will not provide keyframe access; Use the [`KeyframeSuite`](aegp::suites::Keyframe) instead.
-    pub fn new_layer_stream(&self, layer_handle: impl AsPtr<AEGP_LayerH>, plugin_id: PluginId, stream_name: LayerStream) -> Result<StreamReferenceHandle, Error> {
+    pub fn new_layer_stream(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        plugin_id: PluginId,
+        stream_name: LayerStream,
+    ) -> Result<StreamReferenceHandle, Error> {
         Ok(StreamReferenceHandle(
             call_suite_fn_single!(self, AEGP_GetNewLayerStream -> ae_sys::AEGP_StreamRefH, plugin_id, layer_handle.as_ptr(), stream_name.into())?,
             true, // is_owned
@@ -45,12 +64,23 @@ impl StreamSuite {
     }
 
     /// Get number of parameter streams associated with an effect.
-    pub fn effect_num_param_streams(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetEffectNumParamStreams -> ae_sys::A_long, effect_ref.as_ptr())? as i32)
+    pub fn effect_num_param_streams(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetEffectNumParamStreams -> ae_sys::A_long, effect_ref.as_ptr())?
+                as i32,
+        )
     }
 
     /// Get an effect's parameter stream.
-    pub fn new_effect_stream_by_index(&self, effect_ref: impl AsPtr<AEGP_EffectRefH>, plugin_id: PluginId, index: i32) -> Result<StreamReferenceHandle, Error> {
+    pub fn new_effect_stream_by_index(
+        &self,
+        effect_ref: impl AsPtr<AEGP_EffectRefH>,
+        plugin_id: PluginId,
+        index: i32,
+    ) -> Result<StreamReferenceHandle, Error> {
         Ok(StreamReferenceHandle(
             call_suite_fn_single!(self, AEGP_GetNewEffectStreamByIndex -> ae_sys::AEGP_StreamRefH, plugin_id, effect_ref.as_ptr(), index)?,
             true, // is_owned
@@ -60,7 +90,12 @@ impl StreamSuite {
     /// Get a mask's stream.
     ///
     /// Also see the [`MaskSuite`](aegp::suites::Mask) and [`MaskOutlineSuite`](aegp::suites::MaskOutline) for additional Mask functions.
-    pub fn new_mask_stream(&self, mask_ref: impl AsPtr<AEGP_MaskRefH>, plugin_id: PluginId, stream: MaskStream) -> Result<StreamReferenceHandle, Error> {
+    pub fn new_mask_stream(
+        &self,
+        mask_ref: impl AsPtr<AEGP_MaskRefH>,
+        plugin_id: PluginId,
+        stream: MaskStream,
+    ) -> Result<StreamReferenceHandle, Error> {
         Ok(StreamReferenceHandle(
             call_suite_fn_single!(self, AEGP_GetNewMaskStream -> ae_sys::AEGP_StreamRefH, plugin_id, mask_ref.as_ptr(), stream.into())?,
             true, // is_owned
@@ -77,47 +112,90 @@ impl StreamSuite {
     /// Get name of the stream (localized or forced English).
     ///
     /// NOTE: if `force_english` is `true`, the default name will override any stream renaming which has been done (either programatically, or by the user).
-    pub fn stream_name(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId, force_english: bool) -> Result<String, Error> {
+    pub fn stream_name(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+        force_english: bool,
+    ) -> Result<String, Error> {
         let mem_handle = call_suite_fn_single!(self, AEGP_GetStreamName -> ae_sys::AEGP_MemHandle, plugin_id, stream_ref.as_ptr(), force_english as _)?;
         // Create a mem handle each and lock it.
         // When the lock goes out of scope it unlocks and when the handle goes out of scope it gives the memory back to Ae.
         Ok(unsafe {
-            U16CString::from_ptr_str(
-                MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr(),
-            ).to_string_lossy()
+            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
+                .to_string_lossy()
         })
     }
 
     /// Get stream units, formatted as text (localized or forced English).
-    pub fn stream_units_text(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, force_english: bool) -> Result<String, Error> {
+    pub fn stream_units_text(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        force_english: bool,
+    ) -> Result<String, Error> {
         let mut name = [0i8; ae_sys::AEGP_MAX_STREAM_NAME_SIZE as usize + 1];
-        call_suite_fn!(self, AEGP_GetStreamUnitsText, stream_ref.as_ptr(), force_english as _, name.as_mut_ptr() as _)?;
-        Ok(unsafe { std::ffi::CStr::from_ptr(name.as_ptr()) }.to_string_lossy().into_owned())
+        call_suite_fn!(
+            self,
+            AEGP_GetStreamUnitsText,
+            stream_ref.as_ptr(),
+            force_english as _,
+            name.as_mut_ptr() as _
+        )?;
+        Ok(unsafe { std::ffi::CStr::from_ptr(name.as_ptr()) }
+            .to_string_lossy()
+            .into_owned())
     }
 
     /// Get stream's flags, as well as minimum and maximum values (as floats), if the stream *has* mins and maxes.
     ///
     /// Returns a tuple containing ([`StreamFlags`], `Option<min>`, `Option<max>`).
-    pub fn stream_properties(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<(StreamFlags, Option<f64>, Option<f64>), Error> {
+    pub fn stream_properties(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<(StreamFlags, Option<f64>, Option<f64>), Error> {
         let mut flags = 0;
         let mut min = 0.0;
         let mut max = 0.0;
-        call_suite_fn!(self, AEGP_GetStreamProperties, stream_ref.as_ptr(), &mut flags, &mut min, &mut max)?;
+        call_suite_fn!(
+            self,
+            AEGP_GetStreamProperties,
+            stream_ref.as_ptr(),
+            &mut flags,
+            &mut min,
+            &mut max
+        )?;
         let flags = StreamFlags::from_bits_truncate(flags);
-        let min = if flags.contains(StreamFlags::HAS_MIN) { Some(min) } else { None };
-        let max = if flags.contains(StreamFlags::HAS_MAX) { Some(max) } else { None };
+        let min = if flags.contains(StreamFlags::HAS_MIN) {
+            Some(min)
+        } else {
+            None
+        };
+        let max = if flags.contains(StreamFlags::HAS_MAX) {
+            Some(max)
+        } else {
+            None
+        };
         Ok((flags, min, max))
     }
 
     /// Returns whether or not the stream is affected by expressions.
-    pub fn is_stream_timevarying(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsStreamTimevarying -> ae_sys::A_Boolean, stream_ref.as_ptr())? != 0)
+    pub fn is_stream_timevarying(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsStreamTimevarying -> ae_sys::A_Boolean, stream_ref.as_ptr())?
+                != 0,
+        )
     }
 
     /// Get type (dimension) of a stream.
     ///
     /// NOTE: always returns [`StreamType::ThreeDSpatial`] for position, regardless of whether or not the layer is 3D.
-    pub fn stream_type(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<StreamType, Error> {
+    pub fn stream_type(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<StreamType, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetStreamType -> ae_sys::AEGP_StreamType, stream_ref.as_ptr())?.into())
     }
 
@@ -127,7 +205,14 @@ impl StreamSuite {
     // is wasteful and potentially slow.
     /// Get value, at a time you specify, of stream. `value` must be disposed by the plug-in.
     /// The `time_mode` indicates whether the time is in compositions or layer time.
-    pub fn new_stream_value(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId, time_mode: TimeMode, time: Time, sample_stream_pre_expression: bool) -> Result<StreamValue, Error> {
+    pub fn new_stream_value(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+        time_mode: TimeMode,
+        time: Time,
+        sample_stream_pre_expression: bool,
+    ) -> Result<StreamValue, Error> {
         let type_ = self.stream_type(stream_ref.as_ptr())?;
 
         let mut stream_value2 = call_suite_fn_single!(self,
@@ -146,13 +231,23 @@ impl StreamSuite {
     }
 
     /// Dispose of stream value. Always deallocate values passed to the plug-in.
-    pub fn dispose_stream_value(&self, stream_value: &mut ae_sys::AEGP_StreamValue2) -> Result<(), Error> {
+    pub fn dispose_stream_value(
+        &self,
+        stream_value: &mut ae_sys::AEGP_StreamValue2,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_DisposeStreamValue, stream_value)
     }
 
     /// NOTE: This convenience function is only valid for streams with primitive data types, and not for `StreamType::ArbBlock`, `StreamType::Marker` or `StreamType::MaskOutline`.
     /// For these and other complex types, use [`new_stream_value()`](Self::new_stream_value), described above.
-    pub fn layer_stream_value(&self, layer_handle: impl AsPtr<AEGP_LayerH>, stream: LayerStream, time_mode: TimeMode, time: Time, pre_expression: bool) -> Result<StreamValue, Error> {
+    pub fn layer_stream_value(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        stream: LayerStream,
+        time_mode: TimeMode,
+        time: Time,
+        pre_expression: bool,
+    ) -> Result<StreamValue, Error> {
         let (stream_value, stream_type) = call_suite_fn_double!(self,
             AEGP_GetLayerStreamValue -> ae_sys::AEGP_StreamVal2, ae_sys::AEGP_StreamType,
             layer_handle.as_ptr(),
@@ -166,35 +261,71 @@ impl StreamSuite {
     }
 
     /// Determines whether expressions are enabled on the given [`StreamReferenceHandle`].
-    pub fn expression_state(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetExpressionState -> ae_sys::A_Boolean, plugin_id, stream_ref.as_ptr())? != 0)
+    pub fn expression_state(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetExpressionState -> ae_sys::A_Boolean, plugin_id, stream_ref.as_ptr())?
+                != 0,
+        )
     }
 
     /// Set whether expressions are enabled on the given [`StreamReferenceHandle`].
-    pub fn set_expression_state(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId, enabled: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetExpressionState, plugin_id, stream_ref.as_ptr(), enabled as u8)
+    pub fn set_expression_state(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+        enabled: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetExpressionState,
+            plugin_id,
+            stream_ref.as_ptr(),
+            enabled as u8
+        )
     }
 
     /// Get the expression string for the given [`StreamReferenceHandle`].
-    pub fn expression_string(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId) -> Result<String, Error> {
+    pub fn expression_string(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+    ) -> Result<String, Error> {
         let mem_handle = call_suite_fn_single!(self, AEGP_GetExpression -> ae_sys::AEGP_MemHandle, plugin_id, stream_ref.as_ptr())?;
         // Create a mem handle each and lock it.
         // When the lock goes out of scope it unlocks and when the handle goes out of scope it gives the memory back to Ae.
         Ok(unsafe {
-            U16CString::from_ptr_str(
-                MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr(),
-            ).to_string_lossy()
+            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
+                .to_string_lossy()
         })
     }
 
     /// Set the expression string for the given [`StreamReferenceHandle`].
-    pub fn set_expression_string(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId, expression: &str) -> Result<(), Error> {
+    pub fn set_expression_string(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+        expression: &str,
+    ) -> Result<(), Error> {
         let expression = U16CString::from_str(expression).map_err(|_| Error::InvalidParms)?;
-        call_suite_fn!(self, AEGP_SetExpression, plugin_id, stream_ref.as_ptr(), expression.as_ptr())
+        call_suite_fn!(
+            self,
+            AEGP_SetExpression,
+            plugin_id,
+            stream_ref.as_ptr(),
+            expression.as_ptr()
+        )
     }
 
     /// Duplicate a given [`StreamReferenceHandle`].
-    pub fn duplicate_stream(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId) -> Result<StreamReferenceHandle, Error> {
+    pub fn duplicate_stream(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+    ) -> Result<StreamReferenceHandle, Error> {
         Ok(StreamReferenceHandle(
             call_suite_fn_single!(self, AEGP_DuplicateStreamRef -> ae_sys::AEGP_StreamRefH, plugin_id, stream_ref.as_ptr())?,
             true, // is_owned
@@ -222,12 +353,14 @@ define_suite!(
 impl DynamicStreamSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Retrieves the [`StreamReferenceHandle`] corresponding to the layer. This function is used to initiate a recursive walk of the layer's streams.
-    pub fn new_stream_ref_for_layer(&self, layer_handle: impl AsPtr<AEGP_LayerH>, plugin_id: PluginId) -> Result<StreamReferenceHandle, Error> {
+    pub fn new_stream_ref_for_layer(
+        &self,
+        layer_handle: impl AsPtr<AEGP_LayerH>,
+        plugin_id: PluginId,
+    ) -> Result<StreamReferenceHandle, Error> {
         Ok(StreamReferenceHandle(
             call_suite_fn_single!(self, AEGP_GetNewStreamRefForLayer -> ae_sys::AEGP_StreamRefH, plugin_id, layer_handle.as_ptr())?,
             true, // is_owned
@@ -235,7 +368,11 @@ impl DynamicStreamSuite {
     }
 
     /// Retrieves the [`StreamReferenceHandle`] corresponding to the mask.
-    pub fn new_stream_ref_for_mask(&self, mask_ref: impl AsPtr<AEGP_MaskRefH>, plugin_id: PluginId) -> Result<StreamReferenceHandle, Error> {
+    pub fn new_stream_ref_for_mask(
+        &self,
+        mask_ref: impl AsPtr<AEGP_MaskRefH>,
+        plugin_id: PluginId,
+    ) -> Result<StreamReferenceHandle, Error> {
         Ok(StreamReferenceHandle(
             call_suite_fn_single!(self, AEGP_GetNewStreamRefForMask -> ae_sys::AEGP_StreamRefH, plugin_id, mask_ref.as_ptr())?,
             true, // is_owned
@@ -246,23 +383,38 @@ impl DynamicStreamSuite {
     ///
     /// The initial layer has a depth of 0.
     pub fn stream_depth(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetStreamDepth -> ae_sys::A_long, stream_ref.as_ptr())? as i32)
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetStreamDepth -> ae_sys::A_long, stream_ref.as_ptr())?
+                as i32,
+        )
     }
 
     /// Retrieves the grouping type for the given [`StreamReferenceHandle`].
-    pub fn stream_grouping_type(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<StreamGroupingType, Error> {
+    pub fn stream_grouping_type(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<StreamGroupingType, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetStreamGroupingType -> ae_sys::AEGP_StreamGroupingType, stream_ref.as_ptr())?.into())
     }
 
     /// Retrieves the number of streams associated with the given [`StreamReferenceHandle`].
     ///
     /// This function will return an error if called with an [`StreamReferenceHandle`] with type [`StreamGroupingType::Leaf`].
-    pub fn num_streams_in_group(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetNumStreamsInGroup -> ae_sys::A_long, stream_ref.as_ptr())? as i32)
+    pub fn num_streams_in_group(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetNumStreamsInGroup -> ae_sys::A_long, stream_ref.as_ptr())?
+                as i32,
+        )
     }
 
     /// Retrieves the flags for a given [`StreamReferenceHandle`].
-    pub fn dynamic_stream_flags(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<DynamicStreamFlags, Error> {
+    pub fn dynamic_stream_flags(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<DynamicStreamFlags, Error> {
         Ok(DynamicStreamFlags::from_bits_retain(call_suite_fn_single!(
             self,
             AEGP_GetDynamicStreamFlags -> ae_sys::AEGP_DynStreamFlags,
@@ -276,13 +428,35 @@ impl DynamicStreamSuite {
     ///
     /// This call may be used to dynamically show or hide parameters, by setting and clearing [`DynamicStreamFlags::Hidden`].
     /// However, [`DynamicStreamFlags::Disabled`] may not be set.
-    pub fn set_dynamic_stream_flag(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, flag: DynamicStreamFlags, undoable: bool, enabled: bool) -> Result<(), Error> {
-        debug_assert_eq!(flag.bits().count_ones(), 1, "AEGP_SetDynamicStreamFlag expects a single flag");
-        call_suite_fn!(self, AEGP_SetDynamicStreamFlag, stream_ref.as_ptr(), flag.bits(), undoable as _, enabled as _)
+    pub fn set_dynamic_stream_flag(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        flag: DynamicStreamFlags,
+        undoable: bool,
+        enabled: bool,
+    ) -> Result<(), Error> {
+        debug_assert_eq!(
+            flag.bits().count_ones(),
+            1,
+            "AEGP_SetDynamicStreamFlag expects a single flag"
+        );
+        call_suite_fn!(
+            self,
+            AEGP_SetDynamicStreamFlag,
+            stream_ref.as_ptr(),
+            flag.bits(),
+            undoable as _,
+            enabled as _
+        )
     }
 
     /// Retrieves a sub-stream by index from a given [`StreamReferenceHandle`]. Cannot be used on streams of type [`StreamGroupingType::Leaf`].
-    pub fn new_stream_ref_by_index(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId, index: i32) -> Result<StreamReferenceHandle, Error> {
+    pub fn new_stream_ref_by_index(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+        index: i32,
+    ) -> Result<StreamReferenceHandle, Error> {
         Ok(StreamReferenceHandle(
             call_suite_fn_single!(self, AEGP_GetNewStreamRefByIndex -> ae_sys::AEGP_StreamRefH, plugin_id, stream_ref.as_ptr(), index)?,
             true, // is_owned
@@ -308,7 +482,12 @@ impl DynamicStreamSuite {
     /// * `"ADBE Transform Group"`
     /// * `"ADBE Light Options Group"`
     /// * `"ADBE Camera Options Group"`
-    pub fn new_stream_ref_by_match_name(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId, match_name: &str) -> Result<StreamReferenceHandle, Error> {
+    pub fn new_stream_ref_by_match_name(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+        match_name: &str,
+    ) -> Result<StreamReferenceHandle, Error> {
         let match_name = CString::new(match_name).map_err(|_| Error::InvalidParms)?;
         Ok(StreamReferenceHandle(
             call_suite_fn_single!(self, AEGP_GetNewStreamRefByMatchname -> ae_sys::AEGP_StreamRefH, plugin_id, stream_ref.as_ptr(), match_name.as_ptr())?,
@@ -328,13 +507,21 @@ impl DynamicStreamSuite {
     /// Sets the new index of the specified [`StreamReferenceHandle`]. Undoable.
     /// Only valid for children of [`StreamGroupingType::IndexedGroup`].
     /// The [`StreamReferenceHandle`] is updated to refer to the newly-ordered stream.
-    pub fn reorder_stream(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, new_index: i32) -> Result<(), Error> {
+    pub fn reorder_stream(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        new_index: i32,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_ReorderStream, stream_ref.as_ptr(), new_index)
     }
 
     /// Duplicates the specified stream and appends it to the stream group. Undoable.
     /// Only valid for children of type [`StreamGroupingType::IndexedGroup`].
-    pub fn duplicate_stream(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId) -> Result<i32, Error> {
+    pub fn duplicate_stream(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, AEGP_DuplicateStream -> i32, plugin_id, stream_ref.as_ptr())
     }
 
@@ -344,19 +531,35 @@ impl DynamicStreamSuite {
     /// NOTE: If you retrieve the name with `force_english` set to `true`, you will get the canonical, unchanged name of the stream.
     ///
     /// Note: Use this on an effect stream's group to change the display name of an effect.
-    pub fn set_stream_name(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, name: &str) -> Result<(), Error> {
+    pub fn set_stream_name(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        name: &str,
+    ) -> Result<(), Error> {
         let name = U16CString::from_str(name).map_err(|_| Error::InvalidParms)?;
         call_suite_fn!(self, AEGP_SetStreamName, stream_ref.as_ptr(), name.as_ptr())
     }
 
     /// Returns whether or not it is currently possible to add a stream through the API.
-    pub fn can_add_stream(&self, group_stream: impl AsPtr<AEGP_StreamRefH>, match_name: &str) -> Result<bool, Error> {
+    pub fn can_add_stream(
+        &self,
+        group_stream: impl AsPtr<AEGP_StreamRefH>,
+        match_name: &str,
+    ) -> Result<bool, Error> {
         let match_name = CString::new(match_name).map_err(|_| Error::InvalidParms)?;
-        Ok(call_suite_fn_single!(self, AEGP_CanAddStream -> ae_sys::A_Boolean, group_stream.as_ptr(), match_name.as_ptr())? != 0)
+        Ok(
+            call_suite_fn_single!(self, AEGP_CanAddStream -> ae_sys::A_Boolean, group_stream.as_ptr(), match_name.as_ptr())?
+                != 0,
+        )
     }
 
     /// Adds a stream to the specified stream group. Undoable. Only valid for [`StreamGroupingType::IndexedGroup`].
-    pub fn add_stream(&self, group_stream: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId, match_name: &str) -> Result<StreamReferenceHandle, Error> {
+    pub fn add_stream(
+        &self,
+        group_stream: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+        match_name: &str,
+    ) -> Result<StreamReferenceHandle, Error> {
         let match_name = CString::new(match_name).map_err(|_| Error::InvalidParms)?;
         Ok(StreamReferenceHandle(
             call_suite_fn_single!(self, AEGP_AddStream -> ae_sys::AEGP_StreamRefH, plugin_id, group_stream.as_ptr(), match_name.as_ptr())?,
@@ -370,13 +573,25 @@ impl DynamicStreamSuite {
     pub fn match_name(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<String, Error> {
         let mut buffer = [0u8; ae_sys::AEGP_MAX_STREAM_MATCH_NAME_SIZE as usize];
 
-        call_suite_fn!(self, AEGP_GetMatchName, stream_ref.as_ptr(), buffer.as_mut_ptr() as _)?;
+        call_suite_fn!(
+            self,
+            AEGP_GetMatchName,
+            stream_ref.as_ptr(),
+            buffer.as_mut_ptr() as _
+        )?;
 
-        Ok(std::ffi::CStr::from_bytes_until_nul(&buffer).map_err(|_| Error::InvalidParms)?.to_string_lossy().into_owned())
+        Ok(std::ffi::CStr::from_bytes_until_nul(&buffer)
+            .map_err(|_| Error::InvalidParms)?
+            .to_string_lossy()
+            .into_owned())
     }
 
     /// Retrieves an [`StreamReferenceHandle`] for the parent of the specified [`StreamReferenceHandle`].
-    pub fn new_parent_stream_ref(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, plugin_id: PluginId) -> Result<StreamReferenceHandle, Error> {
+    pub fn new_parent_stream_ref(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        plugin_id: PluginId,
+    ) -> Result<StreamReferenceHandle, Error> {
         Ok(StreamReferenceHandle(
             call_suite_fn_single!(self, AEGP_GetNewParentStreamRef -> ae_sys::AEGP_StreamRefH, plugin_id, stream_ref.as_ptr())?,
             true, // is_owned
@@ -386,8 +601,14 @@ impl DynamicStreamSuite {
     /// Returns whether or not the specified [`StreamReferenceHandle`] has been modified.
     ///
     /// Note: the same result is available through the After Effect user interface by typing "UU" with the composition selected.
-    pub fn stream_is_modified(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetStreamIsModified -> ae_sys::A_Boolean, stream_ref.as_ptr())? != 0)
+    pub fn stream_is_modified(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetStreamIsModified -> ae_sys::A_Boolean, stream_ref.as_ptr())?
+                != 0,
+        )
     }
 
     /// Retrieves the index of a given stream, relative to its parent stream.
@@ -396,8 +617,14 @@ impl DynamicStreamSuite {
     ///
     /// NOTE: As mentioned *elsewhere*, [`StreamReferenceHandle`]s don't persist across function calls.
     /// If streams are re-ordered, added or removed, all [`StreamReferenceHandle`]s previously retrieved may be invalidated.
-    pub fn stream_index_in_parent(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetStreamIndexInParent -> ae_sys::A_long, stream_ref.as_ptr())? as i32)
+    pub fn stream_index_in_parent(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetStreamIndexInParent -> ae_sys::A_long, stream_ref.as_ptr())?
+                as i32,
+        )
     }
 
     /// Valid on leaf streams only. Returns true if this stream is a multidimensional stream that can have its dimensions separated, though they may not be currently separated.
@@ -407,24 +634,49 @@ impl DynamicStreamSuite {
     /// A Leader isn't always separated, call [`are_dimensions_separated()`](Self::are_dimensions_separated) to find out if it is.
     /// As of CS4, the only stream that is ever separarated is the layer's Position property.
     /// Please *do not* write code assuming that, we anticipate allowing separation of more streams in the future.
-    pub fn is_separation_leader(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsSeparationLeader -> ae_sys::A_Boolean, stream_ref.as_ptr())? != 0)
+    pub fn is_separation_leader(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsSeparationLeader -> ae_sys::A_Boolean, stream_ref.as_ptr())?
+                != 0,
+        )
     }
 
     /// Methods such as [`new_keyframe_value()`](aegp::suites::Keyframe::new_keyframe_value) that work on keyframe indices will most definitely *not* work on the Leader property, you will need to retrieve and operate on the Followers explicitly.
-    pub fn are_dimensions_separated(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_AreDimensionsSeparated -> ae_sys::A_Boolean, stream_ref.as_ptr())? != 0)
+    pub fn are_dimensions_separated(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_AreDimensionsSeparated -> ae_sys::A_Boolean, stream_ref.as_ptr())?
+                != 0,
+        )
     }
 
     /// Valid only if [`is_separation_leader()`](Self::is_separation_leader) is `true`.
-    pub fn set_dimensions_separated(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, separated: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_SetDimensionsSeparated, stream_ref.as_ptr(), separated as u8)
+    pub fn set_dimensions_separated(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        separated: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_SetDimensionsSeparated,
+            stream_ref.as_ptr(),
+            separated as u8
+        )
     }
 
     /// Retrieve the Follower stream corresponding to a given dimension of the Leader stream.
     ///
     /// `dim` can range from `0` to `AEGP_GetStreamValueDimensionality(leader_streamH) - 1`.
-    pub fn separation_follower(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>, dimension: i16) -> Result<StreamReferenceHandle, Error> {
+    pub fn separation_follower(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+        dimension: i16,
+    ) -> Result<StreamReferenceHandle, Error> {
         Ok(StreamReferenceHandle(
             call_suite_fn_single!(self, AEGP_GetSeparationFollower -> ae_sys::AEGP_StreamRefH, stream_ref.as_ptr(), dimension)?,
             true, // is_owned
@@ -434,12 +686,21 @@ impl DynamicStreamSuite {
     /// Valid on leaf streams only.
     /// Returns `true` if this stream is a one dimensional property that represents one of the dimensions of a Leader.
     /// You can retrieve stream from the Leader using [`separation_follower()`](Self::separation_follower).
-    pub fn is_separation_follower(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_IsSeparationFollower -> ae_sys::A_Boolean, stream_ref.as_ptr())? != 0)
+    pub fn is_separation_follower(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_IsSeparationFollower -> ae_sys::A_Boolean, stream_ref.as_ptr())?
+                != 0,
+        )
     }
 
     /// Valid on separation Followers only, returns the Leader it is part of.
-    pub fn separation_leader(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<StreamReferenceHandle, Error> {
+    pub fn separation_leader(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<StreamReferenceHandle, Error> {
         Ok(StreamReferenceHandle(
             call_suite_fn_single!(self, AEGP_GetSeparationLeader -> ae_sys::AEGP_StreamRefH, stream_ref.as_ptr())?,
             true, // is_owned
@@ -447,7 +708,10 @@ impl DynamicStreamSuite {
     }
 
     /// Valid on separation Followers only, returns which dimension of the Leader it corresponds to.
-    pub fn separation_dimension(&self, stream_ref: impl AsPtr<AEGP_StreamRefH>) -> Result<i16, Error> {
+    pub fn separation_dimension(
+        &self,
+        stream_ref: impl AsPtr<AEGP_StreamRefH>,
+    ) -> Result<i16, Error> {
         Ok(call_suite_fn_single!(self, AEGP_GetSeparationDimension -> i16, stream_ref.as_ptr())?)
     }
 }
@@ -692,9 +956,7 @@ impl StreamValue {
     /// Convert the `ae_sys::AEGP_StreamVal2` to a [`StreamValue`].
     pub fn from_sys(type_: impl Into<StreamType>, val: ae_sys::AEGP_StreamVal2) -> Self {
         match type_.into() {
-            StreamType::NoData => {
-                Self::None
-            },
+            StreamType::NoData => Self::None,
             StreamType::ThreeDSpatial => unsafe {
                 Self::ThreeDSpatial {
                     x: val.three_d.x,
@@ -721,28 +983,20 @@ impl StreamValue {
                     y: val.two_d.y,
                 }
             },
-            StreamType::OneD => unsafe {
-                Self::OneD(val.one_d)
-            },
+            StreamType::OneD => unsafe { Self::OneD(val.one_d) },
             StreamType::Color => unsafe {
                 Self::Color {
                     alpha: val.color.alphaF,
-                    red:   val.color.redF,
+                    red: val.color.redF,
                     green: val.color.greenF,
-                    blue:  val.color.blueF,
+                    blue: val.color.blueF,
                 }
             },
             // StreamType::ArbBlock => unsafe {},
             // StreamType::Marker => unsafe {},
-            StreamType::LayerId => unsafe {
-                Self::LayerId(val.layer_id)
-            },
-            StreamType::MaskId => unsafe {
-                Self::MaskId(val.mask_id)
-            },
-            StreamType::Mask => unsafe {
-                Self::Mask(MaskOutlineHandle::from_raw(val.mask))
-            },
+            StreamType::LayerId => unsafe { Self::LayerId(val.layer_id) },
+            StreamType::MaskId => unsafe { Self::MaskId(val.mask_id) },
+            StreamType::Mask => unsafe { Self::Mask(MaskOutlineHandle::from_raw(val.mask)) },
             StreamType::TextDocument => unsafe {
                 Self::TextDocument(TextDocumentHandle::from_raw(val.text_documentH))
             },
@@ -755,47 +1009,39 @@ impl StreamValue {
         match self {
             Self::None => unsafe { std::mem::zeroed() },
             Self::FourD(x, y, z, w) => AEGP_StreamVal2 {
-                four_d:  [*x, *y, *z, *w]
+                four_d: [*x, *y, *z, *w],
             },
-            Self::ThreeD        { x, y, z } |
-            Self::ThreeDSpatial { x, y, z } => AEGP_StreamVal2 {
+            Self::ThreeD { x, y, z } | Self::ThreeDSpatial { x, y, z } => AEGP_StreamVal2 {
                 three_d: ae_sys::AEGP_ThreeDVal {
                     x: *x,
                     y: *y,
                     z: *z,
-                }
+                },
             },
-            Self::TwoD        { x, y } |
-            Self::TwoDSpatial { x, y } => AEGP_StreamVal2 {
-                two_d: ae_sys::AEGP_TwoDVal {
-                    x: *x,
-                    y: *y,
-                }
+            Self::TwoD { x, y } | Self::TwoDSpatial { x, y } => AEGP_StreamVal2 {
+                two_d: ae_sys::AEGP_TwoDVal { x: *x, y: *y },
             },
-            Self::OneD(x) => AEGP_StreamVal2 {
-                one_d: *x
-            },
-            Self::Color { alpha, red, green, blue } => AEGP_StreamVal2 {
+            Self::OneD(x) => AEGP_StreamVal2 { one_d: *x },
+            Self::Color {
+                alpha,
+                red,
+                green,
+                blue,
+            } => AEGP_StreamVal2 {
                 color: ae_sys::AEGP_ColorVal {
                     alphaF: *alpha,
-                    redF:   *red,
+                    redF: *red,
                     greenF: *green,
-                    blueF:  *blue,
-                }
+                    blueF: *blue,
+                },
             },
             // Self::ArbBlock => {},
             // Self::Marker => {},
-            Self::LayerId(x) => AEGP_StreamVal2 {
-                layer_id: *x
-            },
-            Self::MaskId(x) => AEGP_StreamVal2 {
-                mask_id: *x
-            },
-            Self::Mask(x) => AEGP_StreamVal2 {
-                mask: x.as_ptr()
-            },
+            Self::LayerId(x) => AEGP_StreamVal2 { layer_id: *x },
+            Self::MaskId(x) => AEGP_StreamVal2 { mask_id: *x },
+            Self::Mask(x) => AEGP_StreamVal2 { mask: x.as_ptr() },
             Self::TextDocument(x) => AEGP_StreamVal2 {
-                text_documentH: x.as_ptr()
+                text_documentH: x.as_ptr(),
             },
         }
     }
@@ -1146,6 +1392,9 @@ define_suite_item_wrapper!(
 impl Stream {
     /// Returns the [`Keyframes`] struct to manipulate keyframes on this stream.
     pub fn keyframes(&self) -> Result<Keyframes, Error> {
-        Ok(Keyframes::from_handle(StreamReferenceHandle::from_raw(self.handle.as_ptr()), false))
+        Ok(Keyframes::from_handle(
+            StreamReferenceHandle::from_raw(self.handle.as_ptr()),
+            false,
+        ))
     }
 }

--- a/after-effects/src/aegp/suites/utility.rs
+++ b/after-effects/src/aegp/suites/utility.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::aegp::*;
+use crate::*;
 
 pub struct ErrReportState((ae_sys::AEGP_ErrReportState, bool));
 impl Drop for ErrReportState {
@@ -22,9 +22,7 @@ define_suite!(
 impl UtilitySuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Displays dialog with name of the AEGP followed by the string passed.
     pub fn report_info(&self, plugin_id: PluginId, info_string: &str) -> Result<(), Error> {
@@ -35,17 +33,37 @@ impl UtilitySuite {
     /// New in CC. Displays dialog with name of the AEGP followed by the unicode string passed.
     pub fn report_info_unicode(&self, plugin_id: PluginId, info_string: &str) -> Result<(), Error> {
         let info_string = U16CString::from_str(info_string).map_err(|_| Error::InvalidParms)?;
-        call_suite_fn!(self, AEGP_ReportInfoUnicode, plugin_id, info_string.as_ptr())
+        call_suite_fn!(
+            self,
+            AEGP_ReportInfoUnicode,
+            plugin_id,
+            info_string.as_ptr()
+        )
     }
 
     /// Silences errors until the `ErrReportState` is dropped.
-    pub fn start_quiet_errors(&self, report_quieted_errors_on_drop: bool) -> Result<ErrReportState, Error> {
-        Ok(ErrReportState((call_suite_fn_single!(self, AEGP_StartQuietErrors -> ae_sys::AEGP_ErrReportState)?, report_quieted_errors_on_drop)))
+    pub fn start_quiet_errors(
+        &self,
+        report_quieted_errors_on_drop: bool,
+    ) -> Result<ErrReportState, Error> {
+        Ok(ErrReportState((
+            call_suite_fn_single!(self, AEGP_StartQuietErrors -> ae_sys::AEGP_ErrReportState)?,
+            report_quieted_errors_on_drop,
+        )))
     }
 
     /// Re-enables errors.
-    pub fn end_quiet_errors(&self, err_state: ae_sys::AEGP_ErrReportState, report_quieted_errors: bool) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_EndQuietErrors, report_quieted_errors as _, &err_state as *const _ as *mut _)
+    pub fn end_quiet_errors(
+        &self,
+        err_state: ae_sys::AEGP_ErrReportState,
+        report_quieted_errors: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_EndQuietErrors,
+            report_quieted_errors as _,
+            &err_state as *const _ as *mut _
+        )
     }
 
     /// Add action(s) to the undo queue. The user may undo any actions between this and [`Self::end_undo_group`].
@@ -56,14 +74,16 @@ impl UtilitySuite {
     }
 
     /// Ends the undo list.
-    pub fn end_undo_group(&self) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_EndUndoGroup,)
-    }
+    pub fn end_undo_group(&self) -> Result<(), Error> { call_suite_fn!(self, AEGP_EndUndoGroup,) }
 
     /// Returns an [`PluginId`], which effect plug-ins can then use in calls to many functions throughout the AEGP API.
     /// Effects should only call this function once, during [`Command::GlobalSetup`], and save the [`PluginId`] for later use.
     /// The first parameter can be a value you expect to retrieve later with the [`RegisterSuite`], and the second parameter should be the plug-in's match name.
-    pub fn register_with_aegp_refcon<T: AegpSeal>(&self, global_refcon: T, plugin_name: &str) -> Result<PluginId, Error> {
+    pub fn register_with_aegp_refcon<T: AegpSeal>(
+        &self,
+        global_refcon: T,
+        plugin_name: &str,
+    ) -> Result<PluginId, Error> {
         let refcon = Box::into_raw(Box::new(global_refcon));
         let plugin_name = CString::new(plugin_name).map_err(|_| Error::InvalidParms)?;
         call_suite_fn_single!(self, AEGP_RegisterWithAEGP -> ae_sys::AEGP_PluginID, refcon as _, plugin_name.as_ptr())
@@ -95,13 +115,15 @@ impl UtilitySuite {
 
     /// Retrieves the foreground color from the paint palette.
     pub fn paint_palette_foreground_color(&self) -> Result<pf::PixelF64, Error> {
-        let color = call_suite_fn_single!(self, AEGP_PaintPalGetForeColor -> ae_sys::AEGP_ColorVal)?;
+        let color =
+            call_suite_fn_single!(self, AEGP_PaintPalGetForeColor -> ae_sys::AEGP_ColorVal)?;
         Ok(unsafe { std::mem::transmute(color) })
     }
 
     /// Retrieves the background color from the paint palette.
     pub fn paint_palette_background_color(&self) -> Result<pf::PixelF64, Error> {
-        let color = call_suite_fn_single!(self, AEGP_PaintPalGetBackColor -> ae_sys::AEGP_ColorVal)?;
+        let color =
+            call_suite_fn_single!(self, AEGP_PaintPalGetBackColor -> ae_sys::AEGP_ColorVal)?;
         Ok(unsafe { std::mem::transmute(color) })
     }
 
@@ -147,12 +169,18 @@ impl UtilitySuite {
 
     /// Returns whether or not the fill color is frontmost. If it isn't, the stroke color is frontmost.
     pub fn character_palette_is_fill_color_ui_frontmost(&self) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_CharPalIsFillColorUIFrontmost -> ae_sys::A_Boolean)? != 0)
+        Ok(
+            call_suite_fn_single!(self, AEGP_CharPalIsFillColorUIFrontmost -> ae_sys::A_Boolean)?
+                != 0,
+        )
     }
 
     /// Returns an [`Ratio`] interpretation of the given `f64`. Useful for horizontal scale factor interpretation.
     pub fn convert_fp_long_to_hsf_ratio(&self, number: f64) -> Result<Ratio, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_ConvertFpLongToHSFRatio -> ae_sys::A_Ratio, number)?.into())
+        Ok(
+            call_suite_fn_single!(self, AEGP_ConvertFpLongToHSFRatio -> ae_sys::A_Ratio, number)?
+                .into(),
+        )
     }
 
     /// Returns an `f64` interpretation of the given [`Ratio`]. Useful for horizontal scale factor interpretation.
@@ -180,11 +208,22 @@ impl UtilitySuite {
     }
 
     /// Writes a message to the debug log, or to the OS command line if After Effects was launched with the "-debug" option.
-    pub fn write_to_debug_log(&self, subsystem: &str, event_type: &str, info: &str) -> Result<(), Error> {
+    pub fn write_to_debug_log(
+        &self,
+        subsystem: &str,
+        event_type: &str,
+        info: &str,
+    ) -> Result<(), Error> {
         let subsystem = CString::new(subsystem).map_err(|_| Error::InvalidParms)?;
         let event_type = CString::new(event_type).map_err(|_| Error::InvalidParms)?;
         let info = CString::new(info).map_err(|_| Error::InvalidParms)?;
-        call_suite_fn!(self, AEGP_WriteToDebugLog, subsystem.as_ptr(), event_type.as_ptr(), info.as_ptr())
+        call_suite_fn!(
+            self,
+            AEGP_WriteToDebugLog,
+            subsystem.as_ptr(),
+            event_type.as_ptr(),
+            info.as_ptr()
+        )
     }
 
     /// Retrieves the last error message displayed to the user, and its associated error number.
@@ -192,7 +231,10 @@ impl UtilitySuite {
     pub fn last_error_message(&self) -> Result<(String, Error), Error> {
         let mut buffer = vec![0u8; 512];
         let err = call_suite_fn_single!(self, AEGP_GetLastErrorMessage -> ae_sys::A_Err, buffer.len() as _, buffer.as_mut_ptr() as *mut _)?;
-        Ok((String::from_utf8_lossy(&buffer).to_string(), Error::from(err)))
+        Ok((
+            String::from_utf8_lossy(&buffer).to_string(),
+            Error::from(err),
+        ))
     }
 
     /// Returns `true` if scripting is available to the plug-in.
@@ -205,7 +247,12 @@ impl UtilitySuite {
     /// The script passed in can be in either UTF-8 or the current application encoding (if `platform_encoding` is passed in as `true`).
     ///
     /// Returns a tuple containing `(result, error_string)`. The result is the value of the last line of the script.
-    pub fn execute_script(&self, plugin_id: PluginId, script: &str, platform_encoding: bool) -> Result<(String, String), Error> {
+    pub fn execute_script(
+        &self,
+        plugin_id: PluginId,
+        script: &str,
+        platform_encoding: bool,
+    ) -> Result<(String, String), Error> {
         let script = CString::new(script).map_err(|_| Error::InvalidParms)?;
         let (result, error_string) = call_suite_fn_double!(self,
             AEGP_ExecuteScript -> ae_sys::AEGP_MemHandle, ae_sys::AEGP_MemHandle,
@@ -214,16 +261,23 @@ impl UtilitySuite {
             platform_encoding as _
         )?;
 
-        let result       = MemHandle::<u8>::from_raw(result)?;
+        let result = MemHandle::<u8>::from_raw(result)?;
         let error_string = MemHandle::<u8>::from_raw(error_string)?;
-        let result_len       = result.len()?;
+        let result_len = result.len()?;
         let error_string_len = error_string.len()?;
-        let result       = unsafe { std::slice::from_raw_parts(result      .lock()?.as_ptr(), result_len) };
-        let error_string = unsafe { std::slice::from_raw_parts(error_string.lock()?.as_ptr(), error_string_len) };
+        let result = unsafe { std::slice::from_raw_parts(result.lock()?.as_ptr(), result_len) };
+        let error_string =
+            unsafe { std::slice::from_raw_parts(error_string.lock()?.as_ptr(), error_string_len) };
 
         Ok((
-            std::str::from_utf8(result)      .map_err(|_| Error::InvalidParms)?.trim_end_matches('\0').to_owned(),
-            std::str::from_utf8(error_string).map_err(|_| Error::InvalidParms)?.trim_end_matches('\0').to_owned()
+            std::str::from_utf8(result)
+                .map_err(|_| Error::InvalidParms)?
+                .trim_end_matches('\0')
+                .to_owned(),
+            std::str::from_utf8(error_string)
+                .map_err(|_| Error::InvalidParms)?
+                .trim_end_matches('\0')
+                .to_owned(),
         ))
     }
 
@@ -236,7 +290,12 @@ impl UtilitySuite {
     /// Always returns `NULL` on Windows (you can use an OS-specific entry point to capture your DLLInstance).
     pub fn plugin_platform_ref(&self, plugin_id: PluginId) -> Result<*mut std::ffi::c_void, Error> {
         let mut plat_ref = std::ptr::null_mut();
-        call_suite_fn!(self, AEGP_GetPluginPlatformRef, plugin_id, &mut plat_ref as *mut _ as *mut _)?;
+        call_suite_fn!(
+            self,
+            AEGP_GetPluginPlatformRef,
+            plugin_id,
+            &mut plat_ref as *mut _ as *mut _
+        )?;
         Ok(plat_ref)
     }
 
@@ -251,14 +310,17 @@ impl UtilitySuite {
     /// - [`GetPathTypes::UserPlugin`] - The suite specific location of user specific plug-ins.
     /// - [`GetPathTypes::AllUserPlugin`] - The suite specific location of plug-ins shared by all users.
     /// - [`GetPathTypes::App`] - The After Effects .exe or .app location. Not plug-in specific.
-    pub fn plugin_paths(&self, plugin_id: PluginId, path_type: GetPathTypes) -> Result<String, Error> {
+    pub fn plugin_paths(
+        &self,
+        plugin_id: PluginId,
+        path_type: GetPathTypes,
+    ) -> Result<String, Error> {
         let mem_handle = call_suite_fn_single!(self, AEGP_GetPluginPaths -> ae_sys::AEGP_MemHandle, plugin_id, path_type.into())?;
         // Create a mem handle each and lock it.
         // When the lock goes out of scope it unlocks and when the handle goes out of scope it gives the memory back to Ae.
         Ok(unsafe {
-            U16CString::from_ptr_str(
-                MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr(),
-            ).to_string_lossy()
+            U16CString::from_ptr_str(MemHandle::<u16>::from_raw(mem_handle)?.lock()?.as_ptr())
+                .to_string_lossy()
         })
     }
 }

--- a/after-effects/src/aegp/suites/world.rs
+++ b/after-effects/src/aegp/suites/world.rs
@@ -1,6 +1,6 @@
-use crate::*;
 use crate::aegp::*;
-use ae_sys::{ AEGP_WorldH, AEGP_PlatformWorldH };
+use crate::*;
+use ae_sys::{AEGP_PlatformWorldH, AEGP_WorldH};
 
 define_suite!(
     /// [`World`]s are the common format used throughout the AEGP APIs to describe frames of pixels.
@@ -13,14 +13,18 @@ define_suite!(
 impl WorldSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Returns an allocated, initialized [`WorldHandle`].
-    pub fn new_world(&self, plugin_id: PluginId, world_type: WorldType, width: u32, height: u32) -> Result<WorldHandle, Error> {
+    pub fn new_world(
+        &self,
+        plugin_id: PluginId,
+        world_type: WorldType,
+        width: u32,
+        height: u32,
+    ) -> Result<WorldHandle, Error> {
         Ok(WorldHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_New -> ae_sys::AEGP_WorldH, plugin_id, world_type.into(), width as _, height as _)?
+            call_suite_fn_single!(self, AEGP_New -> ae_sys::AEGP_WorldH, plugin_id, world_type.into(), width as _, height as _)?,
         ))
     }
 
@@ -31,74 +35,125 @@ impl WorldSuite {
 
     /// Returns the type of a given [`WorldHandle`]
     pub fn world_type(&self, world: impl AsPtr<AEGP_WorldH>) -> Result<WorldType, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetType -> ae_sys::AEGP_WorldType, world.as_ptr())?.into())
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetType -> ae_sys::AEGP_WorldType, world.as_ptr())?
+                .into(),
+        )
     }
 
     /// Returns the width and height of the given [`WorldHandle`].
     pub fn size(&self, world: impl AsPtr<AEGP_WorldH>) -> Result<(i32, i32), Error> {
         let (width, height) = call_suite_fn_double!(self, AEGP_GetSize -> ae_sys::A_long, ae_sys::A_long, world.as_ptr())?;
-        Ok((
-            width as i32,
-            height as i32
-        ))
+        Ok((width as i32, height as i32))
     }
 
     /// Returns the rowbytes for the given [`WorldHandle`].
     pub fn row_bytes(&self, world: impl AsPtr<AEGP_WorldH>) -> Result<usize, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetRowBytes -> ae_sys::A_u_long, world.as_ptr())? as usize)
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetRowBytes -> ae_sys::A_u_long, world.as_ptr())?
+                as usize,
+        )
     }
 
     /// Returns the base address of the [`WorldHandle`] for use in pixel iteration functions.
     ///
     /// Will return an error if used on a non-8bpc world.
-    pub fn base_addr8(&self, world_handle: impl AsPtr<AEGP_WorldH>) -> Result<*mut pf::Pixel8, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetBaseAddr8 -> *mut ae_sys::PF_Pixel8, world_handle.as_ptr())? as _)
+    pub fn base_addr8(
+        &self,
+        world_handle: impl AsPtr<AEGP_WorldH>,
+    ) -> Result<*mut pf::Pixel8, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetBaseAddr8 -> *mut ae_sys::PF_Pixel8, world_handle.as_ptr())?
+                as _,
+        )
     }
 
     /// Returns the base address of the [`WorldHandle`] for use in pixel iteration functions.
     ///
     /// Will return an error if used on a non-16bpc world.
-    pub fn base_addr16(&self, world_handle: impl AsPtr<AEGP_WorldH>) -> Result<*mut pf::Pixel16, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetBaseAddr16 -> *mut ae_sys::PF_Pixel16, world_handle.as_ptr())? as _)
+    pub fn base_addr16(
+        &self,
+        world_handle: impl AsPtr<AEGP_WorldH>,
+    ) -> Result<*mut pf::Pixel16, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetBaseAddr16 -> *mut ae_sys::PF_Pixel16, world_handle.as_ptr())?
+                as _,
+        )
     }
 
     /// Returns the base address of the [`WorldHandle`] for use in pixel iteration functions.
     ///
     /// Will return an error if used on a non-32bpc world.
-    pub fn base_addr32(&self, world_handle: impl AsPtr<AEGP_WorldH>) -> Result<*mut pf::PixelF32, Error> {
-        Ok(call_suite_fn_single!(self, AEGP_GetBaseAddr32 -> *mut ae_sys::PF_PixelFloat, world_handle.as_ptr())? as _)
+    pub fn base_addr32(
+        &self,
+        world_handle: impl AsPtr<AEGP_WorldH>,
+    ) -> Result<*mut pf::PixelF32, Error> {
+        Ok(
+            call_suite_fn_single!(self, AEGP_GetBaseAddr32 -> *mut ae_sys::PF_PixelFloat, world_handle.as_ptr())?
+                as _,
+        )
     }
 
     /// Populates a [`Layer`] representing the given [`WorldHandle`], for use with numerous pixel processing callbacks.
     ///
     /// NOTE: This does not give your plug-in ownership of the world referenced; destroy the source [`WorldHandle`] only if you allocated it.
-    pub fn fill_out_pf_effect_world(&self, world: impl AsPtr<AEGP_WorldH>, handle: &mut ae_sys::PF_EffectWorld) -> Result<(), Error> {
-       call_suite_fn!(self, AEGP_FillOutPFEffectWorld, world.as_ptr(), handle)
+    pub fn fill_out_pf_effect_world(
+        &self,
+        world: impl AsPtr<AEGP_WorldH>,
+        handle: &mut ae_sys::PF_EffectWorld,
+    ) -> Result<(), Error> {
+        call_suite_fn!(self, AEGP_FillOutPFEffectWorld, world.as_ptr(), handle)
     }
 
     /// Performs a fast blur on a given [`WorldHandle`].
-    pub fn fast_blur(&self, world: impl AsPtr<AEGP_WorldH>, radius: f64, mode: ModeFlags, quality: Quality) -> Result<(), Error> {
-        call_suite_fn!(self, AEGP_FastBlur, radius, mode.into(), quality.into(), world.as_ptr())
+    pub fn fast_blur(
+        &self,
+        world: impl AsPtr<AEGP_WorldH>,
+        radius: f64,
+        mode: ModeFlags,
+        quality: Quality,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AEGP_FastBlur,
+            radius,
+            mode.into(),
+            quality.into(),
+            world.as_ptr()
+        )
     }
 
     /// Creates a new [`PlatformWorldHandle`] (a pixel world native to the execution platform).
-    pub fn new_platform_world(&self, plugin_id: PluginId, world_type: WorldType, width: i32, height: i32) -> Result<PlatformWorldHandle, Error> {
+    pub fn new_platform_world(
+        &self,
+        plugin_id: PluginId,
+        world_type: WorldType,
+        width: i32,
+        height: i32,
+    ) -> Result<PlatformWorldHandle, Error> {
         Ok(PlatformWorldHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_NewPlatformWorld -> ae_sys::AEGP_PlatformWorldH, plugin_id, world_type.into(), width, height)?
+            call_suite_fn_single!(self, AEGP_NewPlatformWorld -> ae_sys::AEGP_PlatformWorldH, plugin_id, world_type.into(), width, height)?,
         ))
     }
 
     /// Disposes of an [`PlatformWorldHandle`].
-    pub fn dispose_platform_world(&self, world: impl AsPtr<AEGP_PlatformWorldH>) -> Result<(), Error> {
+    pub fn dispose_platform_world(
+        &self,
+        world: impl AsPtr<AEGP_PlatformWorldH>,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, AEGP_DisposePlatformWorld, world.as_ptr())
     }
 
     /// Retrieves an [`WorldHandle`] referring to the given [`PlatformWorldHandle`].
     ///
     /// NOTE: This doesn't allocate a new world, it simply provides a reference to an existing one.
-    pub fn new_reference_from_platform_world(&self, plugin_id: PluginId, platform_world: impl AsPtr<AEGP_PlatformWorldH>) -> Result<WorldHandle, Error> {
+    pub fn new_reference_from_platform_world(
+        &self,
+        plugin_id: PluginId,
+        platform_world: impl AsPtr<AEGP_PlatformWorldH>,
+    ) -> Result<WorldHandle, Error> {
         Ok(WorldHandle::from_raw(
-            call_suite_fn_single!(self, AEGP_NewReferenceFromPlatformWorld -> ae_sys::AEGP_WorldH, plugin_id, platform_world.as_ptr())?
+            call_suite_fn_single!(self, AEGP_NewReferenceFromPlatformWorld -> ae_sys::AEGP_WorldH, plugin_id, platform_world.as_ptr())?,
         ))
     }
 }
@@ -159,7 +214,12 @@ define_suite_item_wrapper!(
 );
 
 impl World {
-    pub fn new(plugin_id: PluginId, world_type: WorldType, width: u32, height: u32) -> Result<Self, Error> {
+    pub fn new(
+        plugin_id: PluginId,
+        world_type: WorldType,
+        width: u32,
+        height: u32,
+    ) -> Result<Self, Error> {
         let suite = WorldSuite::new()?;
         Ok(Self {
             handle: suite.new_world(plugin_id, world_type, width, height)?,

--- a/after-effects/src/aeio.rs
+++ b/after-effects/src/aeio.rs
@@ -1,5 +1,5 @@
-use crate::ae_sys;
 use crate::AsPtr;
+use crate::ae_sys;
 
 register_handle!(AEIO_InSpecH);
 define_handle_wrapper!(InSpecHandle, AEIO_InSpecH);

--- a/after-effects/src/cross_thread_type.rs
+++ b/after-effects/src/cross_thread_type.rs
@@ -11,8 +11,8 @@
 ///
 /// Example usage:
 /// ```
-/// use serde::{Serialize, Deserialize};
 /// use after_effects as ae;
+/// use serde::{Deserialize, Serialize};
 ///
 /// #[derive(Default, Serialize, Deserialize)]
 /// struct MyInstance {

--- a/after-effects/src/drawbot/mod.rs
+++ b/after-effects/src/drawbot/mod.rs
@@ -7,28 +7,22 @@ define_handle_wrapper!(SupplierRef, DRAWBOT_SupplierRef);
 define_handle_wrapper!(SurfaceRef, DRAWBOT_SurfaceRef);
 
 pub mod suites {
-    pub(crate) mod supplier; pub use supplier::SupplierSuite as Supplier;
-    pub(crate) mod surface;  pub use surface::SurfaceSuite as Surface;
+    pub(crate) mod supplier;
+    pub use supplier::SupplierSuite as Supplier;
+    pub(crate) mod surface;
+    pub use surface::SurfaceSuite as Surface;
 }
 
-pub use suites::supplier::{
-    PixelLayout,
-    Supplier,
-};
+pub use suites::supplier::{PixelLayout, Supplier};
 pub use suites::surface::{
-    FillType,
-    TextAlignment,
-    TextTruncation,
-    InterpolationPolicy,
-    AntiAliasPolicy,
-    Surface,
+    AntiAliasPolicy, FillType, InterpolationPolicy, Surface, TextAlignment, TextTruncation,
 };
 
-pub type PointF32  = ae_sys::DRAWBOT_PointF32;
+pub type PointF32 = ae_sys::DRAWBOT_PointF32;
 pub type ColorRgba = ae_sys::DRAWBOT_ColorRGBA;
-pub type RectF32   = ae_sys::DRAWBOT_RectF32;
+pub type RectF32 = ae_sys::DRAWBOT_RectF32;
 pub type MatrixF32 = ae_sys::DRAWBOT_MatrixF32;
-pub type Rect32    = ae_sys::DRAWBOT_Rect32;
+pub type Rect32 = ae_sys::DRAWBOT_Rect32;
 
 // ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
 
@@ -47,40 +41,44 @@ impl Drawbot {
     /// Get the supplier reference.
     pub fn supplier(&self) -> Result<Supplier, Error> {
         Ok(Supplier::from_raw(
-            call_suite_fn_single!(self.suite, GetSupplier -> ae_sys::DRAWBOT_SupplierRef, self.handle)?
+            call_suite_fn_single!(self.suite, GetSupplier -> ae_sys::DRAWBOT_SupplierRef, self.handle)?,
         ))
     }
 
     /// Get the surface reference.
     pub fn surface(&self) -> Result<Surface, Error> {
         Ok(Surface::from_raw(
-            call_suite_fn_single!(self.suite, GetSurface -> ae_sys::DRAWBOT_SurfaceRef, self.handle)?
+            call_suite_fn_single!(self.suite, GetSurface -> ae_sys::DRAWBOT_SurfaceRef, self.handle)?,
         ))
     }
 
     /// Fills the path with overlay theme foreground color.
     ///
     /// Optionally draw the shadow using the overlay theme shadow color.
-    pub fn fill_theme_path(&self, path: impl AsPtr<ae_sys::DRAWBOT_PathRef>, draw_shadow: bool) -> Result<(), Error> {
+    pub fn fill_theme_path(
+        &self,
+        path: impl AsPtr<ae_sys::DRAWBOT_PathRef>,
+        draw_shadow: bool,
+    ) -> Result<(), Error> {
         let suite = pf::suites::EffectCustomUIOverlayTheme::new()?;
         suite.fill_path(self.handle, path, draw_shadow)
     }
 
     /// Fills a square vertex around the center point using the overlay theme foreground color and vertex size.
-    pub fn fill_theme_vertex(&self, center_point: FloatPoint, draw_shadow: bool) -> Result<(), Error> {
+    pub fn fill_theme_vertex(
+        &self,
+        center_point: FloatPoint,
+        draw_shadow: bool,
+    ) -> Result<(), Error> {
         let suite = pf::suites::EffectCustomUIOverlayTheme::new()?;
         suite.fill_vertex(self.handle, center_point, draw_shadow)
     }
 }
 impl AsPtr<ae_sys::DRAWBOT_DrawRef> for Drawbot {
-    fn as_ptr(&self) -> ae_sys::DRAWBOT_DrawRef {
-        self.handle
-    }
+    fn as_ptr(&self) -> ae_sys::DRAWBOT_DrawRef { self.handle }
 }
 impl AsPtr<ae_sys::DRAWBOT_DrawRef> for &Drawbot {
-    fn as_ptr(&self) -> ae_sys::DRAWBOT_DrawRef {
-        self.handle
-    }
+    fn as_ptr(&self) -> ae_sys::DRAWBOT_DrawRef { self.handle }
 }
 
 // ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
@@ -99,12 +97,20 @@ pub struct Pen {
 impl Pen {
     /// Set pen dash pattern.
     pub fn set_dash_pattern(&mut self, dashes: Vec<f32>) -> Result<(), Error> {
-        call_suite_fn!(self.suite, SetDashPattern, self.handle, dashes.as_ptr(), dashes.len() as _)
+        call_suite_fn!(
+            self.suite,
+            SetDashPattern,
+            self.handle,
+            dashes.as_ptr(),
+            dashes.len() as _
+        )
     }
 }
 impl Drop for Pen {
     fn drop(&mut self) {
-        self.supplier_suite.release_object(self.handle as *mut _).unwrap();
+        self.supplier_suite
+            .release_object(self.handle as *mut _)
+            .unwrap();
     }
 }
 
@@ -116,7 +122,9 @@ pub struct Brush {
 }
 impl Drop for Brush {
     fn drop(&mut self) {
-        self.supplier_suite.release_object(self.handle as *mut _).unwrap();
+        self.supplier_suite
+            .release_object(self.handle as *mut _)
+            .unwrap();
     }
 }
 
@@ -128,7 +136,9 @@ pub struct Font {
 }
 impl Drop for Font {
     fn drop(&mut self) {
-        self.supplier_suite.release_object(self.handle as *mut _).unwrap();
+        self.supplier_suite
+            .release_object(self.handle as *mut _)
+            .unwrap();
     }
 }
 
@@ -153,7 +163,9 @@ impl Image {
 }
 impl Drop for Image {
     fn drop(&mut self) {
-        self.supplier_suite.release_object(self.handle as *mut _).unwrap();
+        self.supplier_suite
+            .release_object(self.handle as *mut _)
+            .unwrap();
     }
 }
 
@@ -183,7 +195,12 @@ impl Path {
     }
 
     /// Add a cubic bezier to the path.
-    pub fn bezier_to(&mut self, pt1: &PointF32, pt2: &PointF32, pt3: &PointF32) -> Result<(), Error> {
+    pub fn bezier_to(
+        &mut self,
+        pt1: &PointF32,
+        pt2: &PointF32,
+        pt3: &PointF32,
+    ) -> Result<(), Error> {
         call_suite_fn!(self.suite, BezierTo, self.handle, pt1, pt2, pt3)
     }
 
@@ -193,8 +210,22 @@ impl Path {
     }
 
     /// Add a arc to the path. Zero start degrees == 3 o'clock. Sweep is clockwise. Units for angle are in degrees.
-    pub fn add_arc(&mut self, center: &PointF32, radius: f32, start_angle: f32, sweep: f32) -> Result<(), Error> {
-        call_suite_fn!(self.suite, AddArc, self.handle, center, radius, start_angle, sweep)
+    pub fn add_arc(
+        &mut self,
+        center: &PointF32,
+        radius: f32,
+        start_angle: f32,
+        sweep: f32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self.suite,
+            AddArc,
+            self.handle,
+            center,
+            radius,
+            start_angle,
+            sweep
+        )
     }
 
     /// Add a rounded rect to the path.
@@ -206,11 +237,35 @@ impl Path {
 
         self.move_to(x + r, y)?;
         self.line_to(x + w - r, y)?;
-        self.add_arc(&PointF32 { x: x + w - r, y: y + r }, r, -90.0, 90.0)?;
+        self.add_arc(
+            &PointF32 {
+                x: x + w - r,
+                y: y + r,
+            },
+            r,
+            -90.0,
+            90.0,
+        )?;
         self.line_to(x + w, y + h - r)?;
-        self.add_arc(&PointF32 { x: x + w - r, y: y + h - r }, r, 0.0, 90.0)?;
+        self.add_arc(
+            &PointF32 {
+                x: x + w - r,
+                y: y + h - r,
+            },
+            r,
+            0.0,
+            90.0,
+        )?;
         self.line_to(x + r, y + h)?;
-        self.add_arc(&PointF32 { x: x + r, y: y + h - r }, r, 90.0, 90.0)?;
+        self.add_arc(
+            &PointF32 {
+                x: x + r,
+                y: y + h - r,
+            },
+            r,
+            90.0,
+            90.0,
+        )?;
         self.line_to(x, y + r)?;
         self.add_arc(&PointF32 { x: x + r, y: y + r }, r, 180.0, 90.0)?;
 
@@ -218,23 +273,19 @@ impl Path {
     }
 
     /// Close the path.
-    pub fn close(&mut self) -> Result<(), Error> {
-        call_suite_fn!(self.suite, Close, self.handle)
-    }
+    pub fn close(&mut self) -> Result<(), Error> { call_suite_fn!(self.suite, Close, self.handle) }
 }
 impl AsPtr<ae_sys::DRAWBOT_PathRef> for Path {
-    fn as_ptr(&self) -> ae_sys::DRAWBOT_PathRef {
-        self.handle
-    }
+    fn as_ptr(&self) -> ae_sys::DRAWBOT_PathRef { self.handle }
 }
 impl AsPtr<ae_sys::DRAWBOT_PathRef> for &Path {
-    fn as_ptr(&self) -> ae_sys::DRAWBOT_PathRef {
-        self.handle
-    }
+    fn as_ptr(&self) -> ae_sys::DRAWBOT_PathRef { self.handle }
 }
 impl Drop for Path {
     fn drop(&mut self) {
-        self.supplier_suite.release_object(self.handle as *mut _).unwrap();
+        self.supplier_suite
+            .release_object(self.handle as *mut _)
+            .unwrap();
     }
 }
 

--- a/after-effects/src/drawbot/suites/supplier.rs
+++ b/after-effects/src/drawbot/suites/supplier.rs
@@ -12,12 +12,15 @@ define_suite!(
 impl SupplierSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Create a new pen.
-    pub fn new_pen(&self, supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>, color: &ColorRgba, size: f32) -> Result<Pen, Error> {
+    pub fn new_pen(
+        &self,
+        supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>,
+        color: &ColorRgba,
+        size: f32,
+    ) -> Result<Pen, Error> {
         let pen_ref = call_suite_fn_single!(self, NewPen -> ae_sys::DRAWBOT_PenRef, supplier_ref.as_ptr(), color, size)?;
         Ok(Pen {
             handle: pen_ref,
@@ -27,7 +30,11 @@ impl SupplierSuite {
     }
 
     /// Create a new brush.
-    pub fn new_brush(&self, supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>, color: &ColorRgba) -> Result<Brush, Error> {
+    pub fn new_brush(
+        &self,
+        supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>,
+        color: &ColorRgba,
+    ) -> Result<Brush, Error> {
         let brush_ref = call_suite_fn_single!(self, NewBrush -> ae_sys::DRAWBOT_BrushRef, supplier_ref.as_ptr(), color)?;
         Ok(Brush {
             handle: brush_ref,
@@ -36,17 +43,30 @@ impl SupplierSuite {
     }
 
     /// Check if current supplier supports text.
-    pub fn supports_text(&self, supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, SupportsText -> ae_sys::DRAWBOT_Boolean, supplier_ref.as_ptr())? != 0)
+    pub fn supports_text(
+        &self,
+        supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, SupportsText -> ae_sys::DRAWBOT_Boolean, supplier_ref.as_ptr())?
+                != 0,
+        )
     }
 
     /// Get the default font size.
-    pub fn default_font_size(&self, supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>) -> Result<f32, Error> {
+    pub fn default_font_size(
+        &self,
+        supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>,
+    ) -> Result<f32, Error> {
         Ok(call_suite_fn_single!(self, GetDefaultFontSize -> f32, supplier_ref.as_ptr())?)
     }
 
     /// Create a new font with default settings.
-    pub fn new_default_font(&self, supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>, font_size: f32) -> Result<Font, Error> {
+    pub fn new_default_font(
+        &self,
+        supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>,
+        font_size: f32,
+    ) -> Result<Font, Error> {
         let font_ref = call_suite_fn_single!(self, NewDefaultFont -> ae_sys::DRAWBOT_FontRef, supplier_ref.as_ptr(), font_size)?;
         Ok(Font {
             handle: font_ref,
@@ -55,7 +75,15 @@ impl SupplierSuite {
     }
 
     /// Create a new image from buffer passed to `pixel_data`.
-    pub fn new_image_from_buffer(&self, supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>, width: usize, height: usize, row_bytes: usize, pixel_layout: PixelLayout, pixel_data: &[u8]) -> Result<Image, Error> {
+    pub fn new_image_from_buffer(
+        &self,
+        supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>,
+        width: usize,
+        height: usize,
+        row_bytes: usize,
+        pixel_layout: PixelLayout,
+        pixel_data: &[u8],
+    ) -> Result<Image, Error> {
         assert!(row_bytes * height <= pixel_data.len());
 
         let image_ref = call_suite_fn_single!(
@@ -77,7 +105,8 @@ impl SupplierSuite {
 
     /// Create a new path.
     pub fn new_path(&self, supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>) -> Result<Path, Error> {
-        let path_ref = call_suite_fn_single!(self, NewPath -> ae_sys::DRAWBOT_PathRef, supplier_ref.as_ptr())?;
+        let path_ref =
+            call_suite_fn_single!(self, NewPath -> ae_sys::DRAWBOT_PathRef, supplier_ref.as_ptr())?;
         Ok(Path {
             handle: path_ref,
             suite: crate::Suite::new()?,
@@ -86,23 +115,47 @@ impl SupplierSuite {
     }
 
     /// Check if the supplier supports BGRA pixel layout.
-    pub fn supports_pixel_layout_bgra(&self, supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, SupportsPixelLayoutBGRA -> ae_sys::DRAWBOT_Boolean, supplier_ref.as_ptr())? != 0)
+    pub fn supports_pixel_layout_bgra(
+        &self,
+        supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, SupportsPixelLayoutBGRA -> ae_sys::DRAWBOT_Boolean, supplier_ref.as_ptr())?
+                != 0,
+        )
     }
 
     /// Check if the supplier prefers BGRA pixel layout.
-    pub fn prefers_pixel_layout_bgra(&self, supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, PrefersPixelLayoutBGRA -> ae_sys::DRAWBOT_Boolean, supplier_ref.as_ptr())? != 0)
+    pub fn prefers_pixel_layout_bgra(
+        &self,
+        supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, PrefersPixelLayoutBGRA -> ae_sys::DRAWBOT_Boolean, supplier_ref.as_ptr())?
+                != 0,
+        )
     }
 
     /// Check if the supplier supports ARGB pixel layout.
-    pub fn supports_pixel_layout_argb(&self, supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, SupportsPixelLayoutARGB -> ae_sys::DRAWBOT_Boolean, supplier_ref.as_ptr())? != 0)
+    pub fn supports_pixel_layout_argb(
+        &self,
+        supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, SupportsPixelLayoutARGB -> ae_sys::DRAWBOT_Boolean, supplier_ref.as_ptr())?
+                != 0,
+        )
     }
 
     /// Check if the supplier prefers ARGB pixel layout.
-    pub fn prefers_pixel_layout_argb(&self, supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, PrefersPixelLayoutARGB -> ae_sys::DRAWBOT_Boolean, supplier_ref.as_ptr())? != 0)
+    pub fn prefers_pixel_layout_argb(
+        &self,
+        supplier_ref: impl AsPtr<DRAWBOT_SupplierRef>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, PrefersPixelLayoutARGB -> ae_sys::DRAWBOT_Boolean, supplier_ref.as_ptr())?
+                != 0,
+        )
     }
 
     /// Retain (increase reference count on) any object (pen, brush, path, etc). For example, it should be used when any object is copied and the copied object should be retained.

--- a/after-effects/src/drawbot/suites/surface.rs
+++ b/after-effects/src/drawbot/suites/surface.rs
@@ -12,86 +12,196 @@ define_suite!(
 impl SurfaceSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Push the current surface state onto the stack. It should be popped to retrieve old state.
     ///
     /// It is required to restore state if you are going to clip or transform a surface or change the interpolation or anti-aliasing policy.
-    pub fn push_state_stack(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>) -> Result<(), Error> {
+    pub fn push_state_stack(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, PushStateStack, surface_ref.as_ptr(),)
     }
 
     /// Pop the last pushed surface state off the stack.
-    pub fn pop_state_stack(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>) -> Result<(), Error> {
+    pub fn pop_state_stack(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, PopStateStack, surface_ref.as_ptr(),)
     }
 
     /// Paint a rectangle with a color on the surface.
-    pub fn paint_rect(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>, color: &ColorRgba, rect: &RectF32) -> Result<(), Error> {
+    pub fn paint_rect(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+        color: &ColorRgba,
+        rect: &RectF32,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, PaintRect, surface_ref.as_ptr(), color, rect)
     }
 
     /// Fill a path using a brush and fill type.
-    pub fn fill_path(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>, brush: &Brush, path: &Path, fill_type: FillType) -> Result<(), Error> {
-        call_suite_fn!(self, FillPath, surface_ref.as_ptr(), brush.handle, path.handle, fill_type.into())
+    pub fn fill_path(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+        brush: &Brush,
+        path: &Path,
+        fill_type: FillType,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            FillPath,
+            surface_ref.as_ptr(),
+            brush.handle,
+            path.handle,
+            fill_type.into()
+        )
     }
 
     /// Stroke a path using a pen.
-    pub fn stroke_path(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>, pen: &Pen, path: &Path) -> Result<(), Error> {
-        call_suite_fn!(self, StrokePath, surface_ref.as_ptr(), pen.handle, path.handle)
+    pub fn stroke_path(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+        pen: &Pen,
+        path: &Path,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            StrokePath,
+            surface_ref.as_ptr(),
+            pen.handle,
+            path.handle
+        )
     }
 
     /// Clip the surface.
-    pub fn clip(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>, supplier: &Supplier, rect: &Rect32) -> Result<(), Error> {
+    pub fn clip(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+        supplier: &Supplier,
+        rect: &Rect32,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, Clip, surface_ref.as_ptr(), supplier.as_ptr(), rect)
     }
 
     /// Get clip bounds.
-    pub fn clip_bounds(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>) -> Result<Rect32, Error> {
+    pub fn clip_bounds(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+    ) -> Result<Rect32, Error> {
         call_suite_fn_single!(self, GetClipBounds -> ae_sys::DRAWBOT_Rect32, surface_ref.as_ptr())
     }
 
     /// Checks whether a rect is within the clip bounds.
-    pub fn is_within_clip_bounds(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>, rect: &Rect32) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, IsWithinClipBounds -> ae_sys::DRAWBOT_Boolean, surface_ref.as_ptr(), rect)? != 0)
+    pub fn is_within_clip_bounds(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+        rect: &Rect32,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, IsWithinClipBounds -> ae_sys::DRAWBOT_Boolean, surface_ref.as_ptr(), rect)?
+                != 0,
+        )
     }
 
     /// Transform the last surface state.
-    pub fn transform(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>, matrix: &MatrixF32) -> Result<(), Error> {
+    pub fn transform(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+        matrix: &MatrixF32,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, Transform, surface_ref.as_ptr(), matrix as _,)
     }
 
     /// Draw a string.
-    pub fn draw_string(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>, brush: &Brush, font: &Font, string: &str, origin: &PointF32, alignment_style: TextAlignment, truncation_style: TextTruncation, truncation_width: f32) -> Result<(), Error> {
+    pub fn draw_string(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+        brush: &Brush,
+        font: &Font,
+        string: &str,
+        origin: &PointF32,
+        alignment_style: TextAlignment,
+        truncation_style: TextTruncation,
+        truncation_width: f32,
+    ) -> Result<(), Error> {
         let string = widestring::U16CString::from_str(string).map_err(|_| Error::InvalidParms)?;
 
-        call_suite_fn!(self, DrawString, surface_ref.as_ptr(), brush.handle, font.handle, string.as_ptr(), origin, alignment_style.into(), truncation_style.into(), truncation_width)
+        call_suite_fn!(
+            self,
+            DrawString,
+            surface_ref.as_ptr(),
+            brush.handle,
+            font.handle,
+            string.as_ptr(),
+            origin,
+            alignment_style.into(),
+            truncation_style.into(),
+            truncation_width
+        )
     }
 
     /// Draw an image created using [`new_image_from_buffer()`](super::Supplier::new_image_from_buffer) on the surface. Alpha = [0.0, 1.0].
-    pub fn draw_image(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>, image: &Image, origin: &PointF32, alpha: f32) -> Result<(), Error> {
-        call_suite_fn!(self, DrawImage, surface_ref.as_ptr(), image.handle, origin, alpha)
+    pub fn draw_image(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+        image: &Image,
+        origin: &PointF32,
+        alpha: f32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            DrawImage,
+            surface_ref.as_ptr(),
+            image.handle,
+            origin,
+            alpha
+        )
     }
 
     /// Set the interpolation policy.
-    pub fn set_interpolation_policy(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>, interp: InterpolationPolicy) -> Result<(), Error> {
-        call_suite_fn!(self, SetInterpolationPolicy, surface_ref.as_ptr(), interp.into())
+    pub fn set_interpolation_policy(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+        interp: InterpolationPolicy,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            SetInterpolationPolicy,
+            surface_ref.as_ptr(),
+            interp.into()
+        )
     }
 
     /// Get the interpolation policy.
-    pub fn interpolation_policy(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>) -> Result<InterpolationPolicy, Error> {
+    pub fn interpolation_policy(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+    ) -> Result<InterpolationPolicy, Error> {
         Ok(call_suite_fn_single!(self, GetInterpolationPolicy -> ae_sys::DRAWBOT_InterpolationPolicy, surface_ref.as_ptr())?.into())
     }
 
     /// Set the anti-alias policy.
-    pub fn set_anti_alias_policy(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>, policy: AntiAliasPolicy) -> Result<(), Error> {
-        call_suite_fn!(self, SetAntiAliasPolicy, surface_ref.as_ptr(), policy.into())
+    pub fn set_anti_alias_policy(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+        policy: AntiAliasPolicy,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            SetAntiAliasPolicy,
+            surface_ref.as_ptr(),
+            policy.into()
+        )
     }
 
     /// Get the anti-alias policy.
-    pub fn anti_alias_policy(&self, surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>) -> Result<AntiAliasPolicy, Error> {
+    pub fn anti_alias_policy(
+        &self,
+        surface_ref: impl AsPtr<DRAWBOT_SurfaceRef>,
+    ) -> Result<AntiAliasPolicy, Error> {
         Ok(call_suite_fn_single!(self, GetAntiAliasPolicy -> ae_sys::DRAWBOT_AntiAliasPolicy, surface_ref.as_ptr())?.into())
     }
 

--- a/after-effects/src/lib.rs
+++ b/after-effects/src/lib.rs
@@ -5,7 +5,7 @@ use after_effects_sys as ae_sys;
 use num_traits::identities::Zero;
 use std::{
     cell::RefCell,
-    cmp::{max, min, PartialEq, PartialOrd},
+    cmp::{PartialEq, PartialOrd, max, min},
     error,
     fmt::Display,
     ops::{Add, RemAssign},
@@ -35,16 +35,16 @@ use pr_string::*;
 
 // re-exports
 pub use after_effects_sys as sys;
-pub use log;
 pub use cstr_literal;
 pub use fastrand;
+pub use log;
+#[cfg(target_os = "macos")]
+pub use oslog;
 pub use parking_lot;
 pub use paste;
 pub use serde;
 #[cfg(target_os = "windows")]
 pub use win_dbg_logger;
-#[cfg(target_os = "macos")]
-pub use oslog;
 
 thread_local! {
     pub(crate) static PICA_BASIC_SUITE: RefCell<*const ae_sys::SPBasicSuite> = const { RefCell::new(ptr::null_mut()) };
@@ -175,27 +175,29 @@ define_enum! {
 impl From<Error> for &'static str {
     fn from(error: Error) -> &'static str {
         match error {
-            Error::Generic                  => "Generic error.",
-            Error::Struct                   => "Wrong struct.",
-            Error::Parameter                => "Wrong parameter.",
-            Error::OutOfMemory              => "Out of memory.",
-            Error::WrongThread              => "Call made from wrong thread.",
-            Error::ConstProjectModification => "Project changes must originate in the UI/Main thread.",
-            Error::MissingSuite             => "Could not aquire suite.",
-            Error::InternalStructDamaged    => "Internal struct is damaged.",
-            Error::InvalidIndex             => "Out of range, or action not allowed on this index.",
+            Error::Generic => "Generic error.",
+            Error::Struct => "Wrong struct.",
+            Error::Parameter => "Wrong parameter.",
+            Error::OutOfMemory => "Out of memory.",
+            Error::WrongThread => "Call made from wrong thread.",
+            Error::ConstProjectModification => {
+                "Project changes must originate in the UI/Main thread."
+            }
+            Error::MissingSuite => "Could not aquire suite.",
+            Error::InternalStructDamaged => "Internal struct is damaged.",
+            Error::InvalidIndex => "Out of range, or action not allowed on this index.",
             Error::UnrecogizedParameterType => "Unrecognized parameter type",
-            Error::InvalidCallback          => "Invalid callback.",
-            Error::BadCallbackParameter     => "Bad callback parameter.",
-            Error::InterruptCancel          => "Rendering interrupted.",
-            Error::CannotParseKeyframeText  => "Keyframe data damaged.",
-            Error::None                     => "No error",
-            Error::StringNotFound           => "StringNotFound",
-            Error::StringBufferTooSmall     => "StringBufferTooSmall",
-            Error::InvalidParms             => "InvalidParms",
-            Error::Reserved11               => "Reserved11",
-            Error::Unknown10007             => "Unknown10007",
-            Error::NotInComputeCache        => "Value not found in compute cache.",
+            Error::InvalidCallback => "Invalid callback.",
+            Error::BadCallbackParameter => "Bad callback parameter.",
+            Error::InterruptCancel => "Rendering interrupted.",
+            Error::CannotParseKeyframeText => "Keyframe data damaged.",
+            Error::None => "No error",
+            Error::StringNotFound => "StringNotFound",
+            Error::StringBufferTooSmall => "StringBufferTooSmall",
+            Error::InvalidParms => "InvalidParms",
+            Error::Reserved11 => "Reserved11",
+            Error::Unknown10007 => "Unknown10007",
+            Error::NotInComputeCache => "Value not found in compute cache.",
         }
     }
 }
@@ -208,15 +210,11 @@ impl Display for Error {
 }
 
 impl error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
 }
 
 impl From<std::collections::TryReserveError> for Error {
-    fn from(_: std::collections::TryReserveError) -> Self {
-        Error::OutOfMemory
-    }
+    fn from(_: std::collections::TryReserveError) -> Self { Error::OutOfMemory }
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -224,17 +222,11 @@ impl From<std::collections::TryReserveError> for Error {
 pub struct Matrix3([[f64; 3]; 3]);
 impl From<Matrix3> for ae_sys::A_Matrix3 {
     #[inline]
-    fn from(val: Matrix3) -> Self {
-        ae_sys::A_Matrix3 {
-            mat: val.0
-        }
-    }
+    fn from(val: Matrix3) -> Self { ae_sys::A_Matrix3 { mat: val.0 } }
 }
 impl From<ae_sys::A_Matrix3> for Matrix3 {
     #[inline]
-    fn from(item: ae_sys::A_Matrix3) -> Self  {
-        Self(item.mat)
-    }
+    fn from(item: ae_sys::A_Matrix3) -> Self { Self(item.mat) }
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -243,17 +235,11 @@ pub struct Matrix4([[f64; 4]; 4]);
 
 impl From<Matrix4> for ae_sys::A_Matrix4 {
     #[inline]
-    fn from(val: Matrix4) -> Self {
-        ae_sys::A_Matrix4 {
-            mat: val.0
-        }
-    }
+    fn from(val: Matrix4) -> Self { ae_sys::A_Matrix4 { mat: val.0 } }
 }
 impl From<ae_sys::A_Matrix4> for Matrix4 {
     #[inline]
-    fn from(item: ae_sys::A_Matrix4) -> Self  {
-        Self(item.mat)
-    }
+    fn from(item: ae_sys::A_Matrix4) -> Self { Self(item.mat) }
 }
 
 impl Matrix4 {
@@ -301,9 +287,7 @@ fn test_from() {
 #[cfg(feature = "nalgebra")]
 impl From<Matrix4> for nalgebra::Matrix4<f64> {
     #[inline]
-    fn from(m: Matrix4) -> Self {
-        nalgebra::Matrix4::<f64>::from_row_slice(m.as_slice())
-    }
+    fn from(m: Matrix4) -> Self { nalgebra::Matrix4::<f64>::from_row_slice(m.as_slice()) }
 }
 
 #[cfg(feature = "nalgebra")]
@@ -430,8 +414,24 @@ define_struct! {
         bottom: i32,
     }
 }
-define_struct_conv!(ae_sys::A_LegacyRect, Rect { left, top, right, bottom });
-define_struct_conv!(ae_sys::PF_LRect,     Rect { left, top, right, bottom });
+define_struct_conv!(
+    ae_sys::A_LegacyRect,
+    Rect {
+        left,
+        top,
+        right,
+        bottom
+    }
+);
+define_struct_conv!(
+    ae_sys::PF_LRect,
+    Rect {
+        left,
+        top,
+        right,
+        bottom
+    }
+);
 
 impl Rect {
     pub fn empty() -> Self {
@@ -443,27 +443,23 @@ impl Rect {
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        (self.left >= self.right) || (self.top >= self.bottom)
-    }
-    pub fn width(&self) -> i32 {
-        self.right - self.left
-    }
-    pub fn height(&self) -> i32 {
-        self.bottom - self.top
-    }
+    pub fn is_empty(&self) -> bool { (self.left >= self.right) || (self.top >= self.bottom) }
+
+    pub fn width(&self) -> i32 { self.right - self.left }
+
+    pub fn height(&self) -> i32 { self.bottom - self.top }
+
     pub fn origin(&self) -> Point {
         Point {
             h: self.left,
             v: self.top,
         }
     }
-    pub fn set_width(&mut self, width: i32) {
-        self.right = self.left + width
-    }
-    pub fn set_height(&mut self, height: i32) {
-        self.bottom = self.top + height
-    }
+
+    pub fn set_width(&mut self, width: i32) { self.right = self.left + width }
+
+    pub fn set_height(&mut self, height: i32) { self.bottom = self.top + height }
+
     pub fn set_origin(&mut self, origin: Point) {
         self.left = origin.h;
         self.top = origin.v;
@@ -555,14 +551,15 @@ pub enum Ownership<'a, T: Clone> {
 impl<'a, T: Clone> Clone for Ownership<'a, T> {
     fn clone(&self) -> Self {
         match self {
-            Self::AfterEffects(ptr)    => Self::Rust((*ptr).clone()),
+            Self::AfterEffects(ptr) => Self::Rust((*ptr).clone()),
             Self::AfterEffectsMut(ptr) => Self::Rust((*ptr).clone()),
-            Self::Rust(ptr)            => Self::Rust(ptr.clone()),
+            Self::Rust(ptr) => Self::Rust(ptr.clone()),
         }
     }
 }
 impl<'a, T: Clone> std::ops::Deref for Ownership<'a, T> {
     type Target = T;
+
     fn deref(&self) -> &Self::Target {
         match self {
             Self::AfterEffects(ptr) => ptr,
@@ -588,12 +585,13 @@ impl<'a, T: Clone> ReadOnlyOwnership<'a, T> {
     pub fn clone(&self) -> Ownership<'a, T> {
         match self {
             Self::AfterEffects(ptr) => Ownership::Rust((*ptr).clone()),
-            Self::Rust(ptr)         => Ownership::Rust(ptr.clone()),
+            Self::Rust(ptr) => Ownership::Rust(ptr.clone()),
         }
     }
 }
 impl<'a, T: Clone> std::ops::Deref for ReadOnlyOwnership<'a, T> {
     type Target = T;
+
     fn deref(&self) -> &Self::Target {
         match self {
             Self::AfterEffects(ptr) => ptr,
@@ -608,6 +606,7 @@ pub enum PointerOwnership<T> {
 }
 impl<T> std::ops::Deref for PointerOwnership<T> {
     type Target = T;
+
     fn deref(&self) -> &Self::Target {
         match self {
             Self::AfterEffects(ptr) => unsafe { &**ptr },
@@ -647,9 +646,7 @@ impl PicaBasicSuiteHandle {
     }
 
     #[inline]
-    pub fn as_ptr(&self) -> *const ae_sys::SPBasicSuite {
-        self.pica_basic_suite_ptr
-    }
+    pub fn as_ptr(&self) -> *const ae_sys::SPBasicSuite { self.pica_basic_suite_ptr }
 }
 
 pub(crate) trait Suite {
@@ -666,5 +663,6 @@ pub trait AsPtr<T> {
 
 pub trait AsMutPtr<T> {
     fn as_mut_ptr(&mut self) -> T
-    where T: Sized;
+    where
+        T: Sized;
 }

--- a/after-effects/src/macros.rs
+++ b/after-effects/src/macros.rs
@@ -12,9 +12,14 @@ macro_rules! ae_acquire_suite_ptr {
             {
                 after_effects_sys::kSPNoError => Ok(suite_ptr.assume_init()),
                 _ => {
-                    log::error!("Suite not found: {} {} {}", stringify!($type), stringify!($name), stringify!($version));
+                    log::error!(
+                        "Suite not found: {} {} {}",
+                        stringify!($type),
+                        stringify!($name),
+                        stringify!($version)
+                    );
                     Err($crate::Error::MissingSuite)
-                },
+                }
             }
         }
     }};
@@ -130,9 +135,7 @@ macro_rules! define_handle_wrapper_v2 {
 macro_rules! register_handle {
     ($data_type:ident) => {
         impl AsPtr<after_effects_sys::$data_type> for after_effects_sys::$data_type {
-            fn as_ptr(&self) -> after_effects_sys::$data_type {
-                *self
-            }
+            fn as_ptr(&self) -> after_effects_sys::$data_type { *self }
         }
     };
 }
@@ -142,34 +145,22 @@ macro_rules! define_handle_wrapper {
         pub struct $wrapper_pretty_name(pub(crate) after_effects_sys::$data_type);
 
         impl $wrapper_pretty_name {
-            pub fn from_raw(raw_handle: after_effects_sys::$data_type) -> Self {
-                Self(raw_handle)
-            }
+            pub fn from_raw(raw_handle: after_effects_sys::$data_type) -> Self { Self(raw_handle) }
 
-            pub fn is_null(&self) -> bool {
-                self.0.is_null()
-            }
+            pub fn is_null(&self) -> bool { self.0.is_null() }
         }
 
         impl From<$wrapper_pretty_name> for after_effects_sys::$data_type {
-            fn from(handle_wrapper: $wrapper_pretty_name) -> Self {
-                handle_wrapper.as_ptr()
-            }
+            fn from(handle_wrapper: $wrapper_pretty_name) -> Self { handle_wrapper.as_ptr() }
         }
         impl AsRef<after_effects_sys::$data_type> for $wrapper_pretty_name {
-            fn as_ref(&self) -> &after_effects_sys::$data_type {
-                &self.0
-            }
+            fn as_ref(&self) -> &after_effects_sys::$data_type { &self.0 }
         }
         impl AsPtr<after_effects_sys::$data_type> for $wrapper_pretty_name {
-            fn as_ptr(&self) -> after_effects_sys::$data_type {
-                self.0
-            }
+            fn as_ptr(&self) -> after_effects_sys::$data_type { self.0 }
         }
         impl AsPtr<after_effects_sys::$data_type> for &$wrapper_pretty_name {
-            fn as_ptr(&self) -> after_effects_sys::$data_type {
-                self.0
-            }
+            fn as_ptr(&self) -> after_effects_sys::$data_type { self.0 }
         }
     };
 }
@@ -186,24 +177,16 @@ macro_rules! define_struct_wrapper {
             }
         }
         impl AsRef<after_effects_sys::$data_type> for $wrapper_pretty_name {
-            fn as_ref(&self) -> &after_effects_sys::$data_type {
-                unsafe { &*self.0 }
-            }
+            fn as_ref(&self) -> &after_effects_sys::$data_type { unsafe { &*self.0 } }
         }
         impl AsMut<after_effects_sys::$data_type> for $wrapper_pretty_name {
-            fn as_mut(&mut self) -> &mut after_effects_sys::$data_type {
-                unsafe { &mut *self.0 }
-            }
+            fn as_mut(&mut self) -> &mut after_effects_sys::$data_type { unsafe { &mut *self.0 } }
         }
         impl AsPtr<*mut after_effects_sys::$data_type> for $wrapper_pretty_name {
-            fn as_ptr(&self) -> *mut after_effects_sys::$data_type {
-                self.0
-            }
+            fn as_ptr(&self) -> *mut after_effects_sys::$data_type { self.0 }
         }
         impl AsPtr<*mut after_effects_sys::$data_type> for &$wrapper_pretty_name {
-            fn as_ptr(&self) -> *mut after_effects_sys::$data_type {
-                self.0
-            }
+            fn as_ptr(&self) -> *mut after_effects_sys::$data_type { self.0 }
         }
     };
 }
@@ -217,42 +200,29 @@ macro_rules! define_owned_handle_wrapper {
             pub fn from_raw(raw_handle: after_effects_sys::$data_type) -> Self {
                 Self(raw_handle, false)
             }
+
             pub fn from_raw_owned(raw_handle: after_effects_sys::$data_type) -> Self {
                 Self(raw_handle, true)
             }
 
-            pub fn as_ptr(&self) -> after_effects_sys::$data_type {
-                self.0
-            }
+            pub fn as_ptr(&self) -> after_effects_sys::$data_type { self.0 }
 
-            pub fn set_owned(&mut self, is_owned: bool) {
-                self.1 = is_owned;
-            }
+            pub fn set_owned(&mut self, is_owned: bool) { self.1 = is_owned; }
 
-            pub fn is_owned(&self) -> bool {
-                self.1
-            }
+            pub fn is_owned(&self) -> bool { self.1 }
         }
 
         impl From<$wrapper_pretty_name> for after_effects_sys::$data_type {
-            fn from(handle_wrapper: $wrapper_pretty_name) -> Self {
-                handle_wrapper.as_ptr()
-            }
+            fn from(handle_wrapper: $wrapper_pretty_name) -> Self { handle_wrapper.as_ptr() }
         }
         impl AsRef<after_effects_sys::$data_type> for $wrapper_pretty_name {
-            fn as_ref(&self) -> &after_effects_sys::$data_type {
-                &self.0
-            }
+            fn as_ref(&self) -> &after_effects_sys::$data_type { &self.0 }
         }
         impl AsPtr<after_effects_sys::$data_type> for $wrapper_pretty_name {
-            fn as_ptr(&self) -> after_effects_sys::$data_type {
-                self.0
-            }
+            fn as_ptr(&self) -> after_effects_sys::$data_type { self.0 }
         }
         impl AsPtr<after_effects_sys::$data_type> for &$wrapper_pretty_name {
-            fn as_ptr(&self) -> after_effects_sys::$data_type {
-                self.0
-            }
+            fn as_ptr(&self) -> after_effects_sys::$data_type { self.0 }
         }
     };
 }
@@ -613,23 +583,15 @@ macro_rules! define_ptr_wrapper {
         pub struct $wrapper_pretty_name(pub(crate) *const after_effects_sys::$data_type);
 
         impl $wrapper_pretty_name {
-            pub fn from_raw(raw_ptr: *const after_effects_sys::$data_type) -> Self {
-                Self(raw_ptr)
-            }
+            pub fn from_raw(raw_ptr: *const after_effects_sys::$data_type) -> Self { Self(raw_ptr) }
 
-            pub fn as_ptr(&self) -> *const after_effects_sys::$data_type {
-                self.0
-            }
+            pub fn as_ptr(&self) -> *const after_effects_sys::$data_type { self.0 }
 
-            pub fn is_null(&self) -> bool {
-                self.0.is_null()
-            }
+            pub fn is_null(&self) -> bool { self.0.is_null() }
         }
 
         impl From<$wrapper_pretty_name> for *const after_effects_sys::$data_type {
-            fn from(ptr_wrapper: $wrapper_pretty_name) -> Self {
-                ptr_wrapper.as_ptr()
-            }
+            fn from(ptr_wrapper: $wrapper_pretty_name) -> Self { ptr_wrapper.as_ptr() }
         }
     };
 }

--- a/after-effects/src/pf/command.rs
+++ b/after-effects/src/pf/command.rs
@@ -172,7 +172,9 @@ pub enum Command {
     ///
     GetFlattenedSequenceData,
     ///
-    TranslateParamsToPrefs { extra: *mut ae_sys::PF_TranslateParamsToPrefsExtra },
+    TranslateParamsToPrefs {
+        extra: *mut ae_sys::PF_TranslateParamsToPrefsExtra,
+    },
     /// GPU equivalent to the existing [`Command::SmartRender`] selector.
     ///
     /// At render time, either the [`Command::SmartRender`] or the [`Command::SmartRenderGpu`] selector will be called, depending on whether the effect is expected to produce a CPU or GPU frame as output.
@@ -277,7 +279,9 @@ impl Command {
                 extra: EventExtra::from_raw(extra as *mut ae_sys::PF_EventExtra),
             },
             RawCommand::GetExternalDependencies => Command::GetExternalDependencies {
-                extra: ExternalDependenciesExtra::from_raw(extra as *mut ae_sys::PF_ExtDependenciesExtra),
+                extra: ExternalDependenciesExtra::from_raw(
+                    extra as *mut ae_sys::PF_ExtDependenciesExtra,
+                ),
             },
             RawCommand::CompletelyGeneral => Command::CompletelyGeneral,
             RawCommand::QueryDynamicFlags => Command::QueryDynamicFlags,
@@ -305,7 +309,7 @@ impl Command {
             },
             RawCommand::GpuDeviceSetdown => Command::GpuDeviceSetdown {
                 extra: GpuDeviceSetdownExtra::from_raw(extra as *mut _),
-            }
+            },
         }
     }
 

--- a/after-effects/src/pf/effect.rs
+++ b/after-effects/src/pf/effect.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use ae_sys::{ PF_TimeDisplay, prFieldType, PrTime, PrTimelineID, A_long };
+use ae_sys::{A_long, PF_TimeDisplay, PrTime, PrTimelineID, prFieldType};
 
 register_handle!(PF_ProgPtr);
 define_handle_wrapper!(EffectHandle, PF_ProgPtr);
@@ -239,7 +239,11 @@ define_suite_item_wrapper!(
 impl Effect {
     /// Obtain the camera (if any) being used by After Effects to view the effect's layer.
     pub fn camera(&self, time: Time) -> Result<Option<aegp::Layer>, Error> {
-        let Ok(ref suite) = *self.pf_interface else { return Err(Error::MissingSuite); };
-        suite.effect_camera(self.handle.as_ptr(), time).map(|x| x.map(Into::into))
+        let Ok(ref suite) = *self.pf_interface else {
+            return Err(Error::MissingSuite);
+        };
+        suite
+            .effect_camera(self.handle.as_ptr(), time)
+            .map(|x| x.map(Into::into))
     }
 }

--- a/after-effects/src/pf/events.rs
+++ b/after-effects/src/pf/events.rs
@@ -24,13 +24,9 @@ bitflags! {
 define_struct_wrapper!(ClickEventInfo, PF_DoClickEventInfo);
 
 impl ClickEventInfo {
-    pub fn screen_point(&self) -> Point {
-        self.as_ref().screen_point.into()
-    }
+    pub fn screen_point(&self) -> Point { self.as_ref().screen_point.into() }
 
-    pub fn num_clicks(&self) -> u32 {
-        self.as_ref().num_clicks as _
-    }
+    pub fn num_clicks(&self) -> u32 { self.as_ref().num_clicks as _ }
 }
 
 impl std::fmt::Debug for ClickEventInfo {
@@ -76,7 +72,7 @@ pub enum Event {
     Idle,
     AdjustCursor(AdjustCursorEventInfo), // Sent when mouse moves over custom UI.
     Keydown(KeyDownEventInfo),           // Sends keycodes or unicode characters.
-    MouseExited,                         // Notification that the mouse is no longer over a specific view (layer or comp only).
+    MouseExited, // Notification that the mouse is no longer over a specific view (layer or comp only).
 }
 
 define_struct_wrapper!(EventExtra, PF_EventExtra);
@@ -91,7 +87,13 @@ impl std::fmt::Debug for EventExtra {
         dbg.field("current_frame", &self.current_frame());
         dbg.field("param_title_frame", &self.param_title_frame());
         dbg.field("horiz_offset", &self.horiz_offset());
-        if [ae_sys::PF_Event_DO_CLICK, ae_sys::PF_Event_DRAG, ae_sys::PF_Event_ADJUST_CURSOR].contains(&self.as_ref().e_type) {
+        if [
+            ae_sys::PF_Event_DO_CLICK,
+            ae_sys::PF_Event_DRAG,
+            ae_sys::PF_Event_ADJUST_CURSOR,
+        ]
+        .contains(&self.as_ref().e_type)
+        {
             dbg.field("modifiers", &self.modifiers());
         }
         if [ae_sys::PF_Event_DO_CLICK, ae_sys::PF_Event_DRAG].contains(&self.as_ref().e_type) {
@@ -128,13 +130,15 @@ impl EventExtra {
         match self.as_ref().e_type {
             ae_sys::PF_Event_NEW_CONTEXT => Event::NewContext,
             ae_sys::PF_Event_ACTIVATE => Event::Activate,
-            ae_sys::PF_Event_DO_CLICK => {
-                Event::Click(ClickEventInfo::from_raw(unsafe { &self.as_ref().u.do_click as *const _ as *mut _ }))
-            }
-            ae_sys::PF_Event_DRAG => {
-                Event::Drag(ClickEventInfo::from_raw(unsafe { &self.as_ref().u.do_click as *const _ as *mut _ }))
-            }
-            ae_sys::PF_Event_DRAW => Event::Draw(DrawEventInfo::from_raw(unsafe { &self.as_ref().u.draw as *const _ as *mut _ })),
+            ae_sys::PF_Event_DO_CLICK => Event::Click(ClickEventInfo::from_raw(unsafe {
+                &self.as_ref().u.do_click as *const _ as *mut _
+            })),
+            ae_sys::PF_Event_DRAG => Event::Drag(ClickEventInfo::from_raw(unsafe {
+                &self.as_ref().u.do_click as *const _ as *mut _
+            })),
+            ae_sys::PF_Event_DRAW => Event::Draw(DrawEventInfo::from_raw(unsafe {
+                &self.as_ref().u.draw as *const _ as *mut _
+            })),
             ae_sys::PF_Event_DEACTIVATE => Event::Deactivate,
             ae_sys::PF_Event_CLOSE_CONTEXT => Event::CloseContext,
             ae_sys::PF_Event_IDLE => Event::Idle,
@@ -143,9 +147,9 @@ impl EventExtra {
                     &self.as_ref().u.adjust_cursor as *const _ as *mut _
                 }))
             }
-            ae_sys::PF_Event_KEYDOWN => {
-                Event::Keydown(KeyDownEventInfo::from_raw(unsafe { &self.as_ref().u.key_down as *const _ as *mut _ }))
-            }
+            ae_sys::PF_Event_KEYDOWN => Event::Keydown(KeyDownEventInfo::from_raw(unsafe {
+                &self.as_ref().u.key_down as *const _ as *mut _
+            })),
             ae_sys::PF_Event_MOUSE_EXITED => Event::MouseExited,
             _ => unreachable!(),
         }
@@ -155,41 +159,36 @@ impl EventExtra {
         self.as_mut().u.adjust_cursor.set_cursor = cursor.into();
     }
 
-    pub fn window_type(&self) -> WindowType {
-        unsafe { **self.as_ref().contextH }.w_type.into()
-    }
+    pub fn window_type(&self) -> WindowType { unsafe { **self.as_ref().contextH }.w_type.into() }
 
     pub fn set_event_out_flags(&mut self, flags: EventOutFlags) {
         self.as_mut().evt_out_flags = flags.bits() as _;
     }
 
-    pub fn param_index(&self) -> usize {
-        self.as_ref().effect_win.index as _
-    }
+    pub fn param_index(&self) -> usize { self.as_ref().effect_win.index as _ }
 
-    pub fn effect_area(&self) -> EffectArea {
-        self.as_ref().effect_win.area.into()
-    }
+    pub fn effect_area(&self) -> EffectArea { self.as_ref().effect_win.area.into() }
 
-    pub fn current_frame(&self) -> Rect {
-        self.as_ref().effect_win.current_frame.into()
-    }
+    pub fn current_frame(&self) -> Rect { self.as_ref().effect_win.current_frame.into() }
 
-    pub fn param_title_frame(&self) -> Rect {
-        self.as_ref().effect_win.param_title_frame.into()
-    }
+    pub fn param_title_frame(&self) -> Rect { self.as_ref().effect_win.param_title_frame.into() }
 
-    pub fn horiz_offset(&self) -> i32 {
-        self.as_ref().effect_win.horiz_offset
-    }
+    pub fn horiz_offset(&self) -> i32 { self.as_ref().effect_win.horiz_offset }
 
     pub fn modifiers(&self) -> Modifiers {
         debug_assert!(
-            [ae_sys::PF_Event_DO_CLICK, ae_sys::PF_Event_DRAG, ae_sys::PF_Event_ADJUST_CURSOR].contains(&self.as_ref().e_type),
+            [
+                ae_sys::PF_Event_DO_CLICK,
+                ae_sys::PF_Event_DRAG,
+                ae_sys::PF_Event_ADJUST_CURSOR
+            ]
+            .contains(&self.as_ref().e_type),
             "The modifiers() method is only valid if event() is Click, Drag or AdjustCursor."
         );
         if self.as_ref().e_type == ae_sys::PF_Event_ADJUST_CURSOR {
-            return unsafe { Modifiers::from_bits_truncate(self.as_ref().u.adjust_cursor.modifiers as _) }
+            return unsafe {
+                Modifiers::from_bits_truncate(self.as_ref().u.adjust_cursor.modifiers as _)
+            };
         }
 
         unsafe { Modifiers::from_bits_truncate(self.as_ref().u.do_click.modifiers as _) }
@@ -243,17 +242,17 @@ impl EventExtra {
     /// Panics unless the event is `Click`, `Drag`, `AdjustCursor` or `Keydown`.
     pub fn screen_point(&self) -> Point {
         match self.as_ref().e_type {
-            ae_sys::PF_Event_DO_CLICK | ae_sys::PF_Event_DRAG => {
-                unsafe { self.as_ref().u.do_click.screen_point.into() }
-            }
-            ae_sys::PF_Event_ADJUST_CURSOR => {
-                unsafe { self.as_ref().u.adjust_cursor.screen_point.into() }
-            }
-            ae_sys::PF_Event_KEYDOWN => {
-                unsafe { self.as_ref().u.key_down.screen_point.into() }
-            }
+            ae_sys::PF_Event_DO_CLICK | ae_sys::PF_Event_DRAG => unsafe {
+                self.as_ref().u.do_click.screen_point.into()
+            },
+            ae_sys::PF_Event_ADJUST_CURSOR => unsafe {
+                self.as_ref().u.adjust_cursor.screen_point.into()
+            },
+            ae_sys::PF_Event_KEYDOWN => unsafe { self.as_ref().u.key_down.screen_point.into() },
             _ => {
-                panic!("The screen_point() method is only valid if event() is Click, Drag, AdjustCursor or Keydown.")
+                panic!(
+                    "The screen_point() method is only valid if event() is Click, Drag, AdjustCursor or Keydown."
+                )
             }
         }
     }
@@ -265,87 +264,126 @@ impl EventExtra {
     pub fn callbacks(&self) -> EventCallbacks<'_> {
         EventCallbacks {
             ptr: &self.as_ref().cbs,
-            ctx: self.as_ref().contextH
+            ctx: self.as_ref().contextH,
         }
     }
 }
 
 pub struct EventCallbacks<'a> {
     ptr: &'a ae_sys::PF_EventCallbacks,
-    ctx: ae_sys::PF_ContextH
+    ctx: ae_sys::PF_ContextH,
 }
 
 impl<'a> EventCallbacks<'a> {
-    pub fn layer_to_comp(&self, curr_time: i32, time_scale: u32, pt: &mut ae_sys::PF_FixedPoint) -> Result<(), Error> {
+    pub fn layer_to_comp(
+        &self,
+        curr_time: i32,
+        time_scale: u32,
+        pt: &mut ae_sys::PF_FixedPoint,
+    ) -> Result<(), Error> {
         let ret = unsafe {
-            ((*self.ptr).layer_to_comp.unwrap())((*self.ptr).refcon, self.ctx, curr_time, time_scale as _, pt)
+            ((*self.ptr).layer_to_comp.unwrap())(
+                (*self.ptr).refcon,
+                self.ctx,
+                curr_time,
+                time_scale as _,
+                pt,
+            )
         };
         match ret {
             0 => Ok(()),
-            e => Err(Error::from(e))
+            e => Err(Error::from(e)),
         }
     }
 
-    pub fn comp_to_layer(&self, curr_time: i32, time_scale: u32, pt: &mut ae_sys::PF_FixedPoint) -> Result<(), Error> {
+    pub fn comp_to_layer(
+        &self,
+        curr_time: i32,
+        time_scale: u32,
+        pt: &mut ae_sys::PF_FixedPoint,
+    ) -> Result<(), Error> {
         let ret = unsafe {
-            ((*self.ptr).comp_to_layer.unwrap())((*self.ptr).refcon, self.ctx, curr_time, time_scale as _, pt)
+            ((*self.ptr).comp_to_layer.unwrap())(
+                (*self.ptr).refcon,
+                self.ctx,
+                curr_time,
+                time_scale as _,
+                pt,
+            )
         };
         match ret {
             0 => Ok(()),
-            e => Err(Error::from(e))
+            e => Err(Error::from(e)),
         }
     }
 
     pub fn source_to_frame(&self, pt: &mut ae_sys::PF_FixedPoint) -> Result<(), Error> {
-        let ret = unsafe {
-            ((*self.ptr).source_to_frame.unwrap())((*self.ptr).refcon, self.ctx, pt)
-        };
+        let ret =
+            unsafe { ((*self.ptr).source_to_frame.unwrap())((*self.ptr).refcon, self.ctx, pt) };
         match ret {
             0 => Ok(()),
-            e => Err(Error::from(e))
+            e => Err(Error::from(e)),
         }
     }
 
     pub fn frame_to_source(&self, pt: &mut ae_sys::PF_FixedPoint) -> Result<(), Error> {
-        let ret = unsafe {
-            ((*self.ptr).frame_to_source.unwrap())((*self.ptr).refcon, self.ctx, pt)
-        };
+        let ret =
+            unsafe { ((*self.ptr).frame_to_source.unwrap())((*self.ptr).refcon, self.ctx, pt) };
         match ret {
             0 => Ok(()),
-            e => Err(Error::from(e))
+            e => Err(Error::from(e)),
         }
     }
 
-    pub fn comp2layer_xform(&self, curr_time: i32, time_scale: u32) -> Result<Option<Matrix3>, Error> {
+    pub fn comp2layer_xform(
+        &self,
+        curr_time: i32,
+        time_scale: u32,
+    ) -> Result<Option<Matrix3>, Error> {
         let mut exists: ae_sys::A_long = 0;
         let mut matrix: ae_sys::PF_FloatMatrix = unsafe { std::mem::zeroed() };
         let ret = unsafe {
-            ((*self.ptr).get_comp2layer_xform.unwrap())((*self.ptr).refcon, self.ctx, curr_time, time_scale as _, &mut exists, &mut matrix)
+            ((*self.ptr).get_comp2layer_xform.unwrap())(
+                (*self.ptr).refcon,
+                self.ctx,
+                curr_time,
+                time_scale as _,
+                &mut exists,
+                &mut matrix,
+            )
         };
         match ret {
-            0 => Ok(if exists == 1 { Some(unsafe { std::mem::transmute(matrix) }) } else { None }),
-            e => Err(Error::from(e))
+            0 => Ok(if exists == 1 {
+                Some(unsafe { std::mem::transmute(matrix) })
+            } else {
+                None
+            }),
+            e => Err(Error::from(e)),
         }
     }
 
     pub fn layer2comp_xform(&self, curr_time: i32, time_scale: u32) -> Result<Matrix3, Error> {
         let mut matrix: ae_sys::PF_FloatMatrix = unsafe { std::mem::zeroed() };
         let ret = unsafe {
-            ((*self.ptr).get_layer2comp_xform.unwrap())((*self.ptr).refcon, self.ctx, curr_time, time_scale as _, &mut matrix)
+            ((*self.ptr).get_layer2comp_xform.unwrap())(
+                (*self.ptr).refcon,
+                self.ctx,
+                curr_time,
+                time_scale as _,
+                &mut matrix,
+            )
         };
         match ret {
             0 => Ok(unsafe { std::mem::transmute(matrix) }),
-            e => Err(Error::from(e))
+            e => Err(Error::from(e)),
         }
     }
 
     pub fn info_draw_color(&self, color: Pixel8) -> Result<(), Error> {
-        let ret = unsafe {
-            ((*self.ptr).info_draw_color.unwrap())((*self.ptr).refcon, color)
-        };
+        let ret = unsafe { ((*self.ptr).info_draw_color.unwrap())((*self.ptr).refcon, color) };
         match ret {
             0 => Ok(()),
-            e => Err(Error::from(e))
+            e => Err(Error::from(e)),
         }
     }
 
@@ -353,11 +391,15 @@ impl<'a> EventCallbacks<'a> {
         let text1 = std::ffi::CString::new(text1).unwrap();
         let text2 = std::ffi::CString::new(text2).unwrap();
         let ret = unsafe {
-            ((*self.ptr).info_draw_text.unwrap())((*self.ptr).refcon, text1.as_ptr(), text2.as_ptr())
+            ((*self.ptr).info_draw_text.unwrap())(
+                (*self.ptr).refcon,
+                text1.as_ptr(),
+                text2.as_ptr(),
+            )
         };
         match ret {
             0 => Ok(()),
-            e => Err(Error::from(e))
+            e => Err(Error::from(e)),
         }
     }
 }

--- a/after-effects/src/pf/external_dependencies.rs
+++ b/after-effects/src/pf/external_dependencies.rs
@@ -3,9 +3,7 @@ use crate::*;
 define_struct_wrapper!(ExternalDependenciesExtra, PF_ExtDependenciesExtra);
 
 impl ExternalDependenciesExtra {
-    pub fn check_type(&self) -> DepCheckType {
-        unsafe { (*self.0).check_type.into() }
-    }
+    pub fn check_type(&self) -> DepCheckType { unsafe { (*self.0).check_type.into() } }
 
     pub fn set_dependencies_str(&mut self, text: &str) -> Result<(), Error> {
         let suite = pf::suites::Handle::new()?;

--- a/after-effects/src/pf/gpu.rs
+++ b/after-effects/src/pf/gpu.rs
@@ -17,26 +17,26 @@ pub struct GpuDeviceSetupExtra {
     pub(crate) ptr: *mut ae_sys::PF_GPUDeviceSetupExtra,
 }
 impl AsRef<ae_sys::PF_GPUDeviceSetupExtra> for GpuDeviceSetupExtra {
-    fn as_ref(&self) -> &ae_sys::PF_GPUDeviceSetupExtra {
-        unsafe { &*self.ptr }
-    }
+    fn as_ref(&self) -> &ae_sys::PF_GPUDeviceSetupExtra { unsafe { &*self.ptr } }
 }
 impl GpuDeviceSetupExtra {
     pub fn from_raw(ptr: *mut ae_sys::PF_GPUDeviceSetupExtra) -> Self {
         assert!(!ptr.is_null());
         Self { ptr }
     }
-    pub fn as_ptr(&self) -> *mut ae_sys::PF_GPUDeviceSetupExtra {
-        self.ptr
-    }
+
+    pub fn as_ptr(&self) -> *mut ae_sys::PF_GPUDeviceSetupExtra { self.ptr }
+
     pub fn what_gpu(&self) -> GpuFramework {
         assert!(!self.as_ref().input.is_null());
         unsafe { (*self.as_ref().input).what_gpu.into() }
     }
+
     pub fn device_index(&self) -> usize {
         assert!(!self.as_ref().input.is_null());
         unsafe { (*self.as_ref().input).device_index as usize }
     }
+
     pub fn set_gpu_data<T: Any>(&mut self, val: T) {
         assert!(!self.as_ref().output.is_null());
         let boxed: Box<Box<dyn Any>> = Box::new(Box::new(val));
@@ -51,26 +51,26 @@ pub struct GpuDeviceSetdownExtra {
     pub(crate) ptr: *mut ae_sys::PF_GPUDeviceSetdownExtra,
 }
 impl AsRef<ae_sys::PF_GPUDeviceSetdownExtra> for GpuDeviceSetdownExtra {
-    fn as_ref(&self) -> &ae_sys::PF_GPUDeviceSetdownExtra {
-        unsafe { &*self.ptr }
-    }
+    fn as_ref(&self) -> &ae_sys::PF_GPUDeviceSetdownExtra { unsafe { &*self.ptr } }
 }
 impl GpuDeviceSetdownExtra {
     pub fn from_raw(ptr: *mut ae_sys::PF_GPUDeviceSetdownExtra) -> Self {
         assert!(!ptr.is_null());
         Self { ptr }
     }
-    pub fn as_ptr(&self) -> *mut ae_sys::PF_GPUDeviceSetdownExtra {
-        self.ptr
-    }
+
+    pub fn as_ptr(&self) -> *mut ae_sys::PF_GPUDeviceSetdownExtra { self.ptr }
+
     pub fn what_gpu(&self) -> GpuFramework {
         assert!(!self.as_ref().input.is_null());
         unsafe { (*self.as_ref().input).what_gpu.into() }
     }
+
     pub fn device_index(&self) -> usize {
         assert!(!self.as_ref().input.is_null());
         unsafe { (*self.as_ref().input).device_index as usize }
     }
+
     /// # Panics
     /// Panics if the stored GPU data is not of type `T`.
     pub fn gpu_data_mut<'a, T: Any>(&'a mut self) -> &'a mut T {
@@ -83,6 +83,7 @@ impl GpuDeviceSetdownExtra {
             None => panic!("Invalid type for gpu_data"),
         }
     }
+
     /// # Panics
     /// Panics if the stored GPU data is not of type `T`.
     pub fn gpu_data<'a, T: Any>(&'a self) -> &'a T {
@@ -95,6 +96,7 @@ impl GpuDeviceSetdownExtra {
             None => panic!("Invalid type for gpu_data"),
         }
     }
+
     /// # Panics
     /// Panics if the stored GPU data is not of type `T`.
     pub fn destroy_gpu_data<T: Any>(&mut self) {

--- a/after-effects/src/pf/handles.rs
+++ b/after-effects/src/pf/handles.rs
@@ -33,7 +33,9 @@ impl<'a, T> HandleLock<'a, T> {
 
 impl<'a, T> Drop for HandleLock<'a, T> {
     fn drop(&mut self) {
-        self.parent_handle.suite.unlock_handle(self.parent_handle.handle);
+        self.parent_handle
+            .suite
+            .unlock_handle(self.parent_handle.handle);
     }
 }
 
@@ -51,11 +53,7 @@ impl<T> BorrowedHandleLock<T> {
                 if ptr.is_null() {
                     return Err(Error::Generic);
                 }
-                Ok(BorrowedHandleLock {
-                    suite,
-                    handle,
-                    ptr
-                })
+                Ok(BorrowedHandleLock { suite, handle, ptr })
             }
             Err(_) => Err(Error::InvalidCallback),
         }
@@ -63,19 +61,14 @@ impl<T> BorrowedHandleLock<T> {
 }
 impl<T> std::ops::Deref for BorrowedHandleLock<T> {
     type Target = T;
-    fn deref(&self) -> &T {
-        unsafe { &*self.ptr }
-    }
+
+    fn deref(&self) -> &T { unsafe { &*self.ptr } }
 }
 impl<T> std::ops::DerefMut for BorrowedHandleLock<T> {
-    fn deref_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.ptr }
-    }
+    fn deref_mut(&mut self) -> &mut T { unsafe { &mut *self.ptr } }
 }
 impl<T> Drop for BorrowedHandleLock<T> {
-    fn drop(&mut self) {
-        self.suite.unlock_handle(self.handle);
-    }
+    fn drop(&mut self) { self.suite.unlock_handle(self.handle); }
 }
 
 impl<'a, T: 'a> Handle<'a, T> {
@@ -154,9 +147,7 @@ impl<'a, T: 'a> Handle<'a, T> {
         }
     }
 
-    pub fn size(&self) -> usize {
-        self.suite.handle_size(self.handle) as usize
-    }
+    pub fn size(&self) -> usize { self.suite.handle_size(self.handle) as usize }
 
     /*
     pub fn resize(&mut self, size: usize) -> Result<(), Error> {
@@ -166,14 +157,12 @@ impl<'a, T: 'a> Handle<'a, T> {
     pub fn from_raw(handle: ae_sys::PF_Handle, owned: bool) -> Result<Handle<'a, T>, Error> {
         assert!(!handle.is_null());
         match pf::suites::Handle::new() {
-            Ok(suite) => {
-                Ok(Handle {
-                    suite,
-                    handle,
-                    owned,
-                    _marker: PhantomData,
-                })
-            }
+            Ok(suite) => Ok(Handle {
+                suite,
+                handle,
+                owned,
+                _marker: PhantomData,
+            }),
             Err(_) => Err(Error::InvalidCallback),
         }
     }
@@ -196,9 +185,7 @@ impl<'a, T: 'a> Handle<'a, T> {
     }
 
     /// Returns the raw handle.
-    pub fn as_raw(&self) -> ae_sys::PF_Handle {
-        self.handle
-    }
+    pub fn as_raw(&self) -> ae_sys::PF_Handle { self.handle }
 }
 
 impl<'a, T: 'a> Drop for Handle<'a, T> {
@@ -220,7 +207,9 @@ pub struct FlatHandleLock<'a, 'b: 'a> {
 
 impl<'a, 'b> Drop for FlatHandleLock<'a, 'b> {
     fn drop(&mut self) {
-        self.parent_handle.suite.unlock_handle(self.parent_handle.handle);
+        self.parent_handle
+            .suite
+            .unlock_handle(self.parent_handle.handle);
     }
 }
 
@@ -238,7 +227,6 @@ pub struct FlatHandle<'a> {
 
 impl<'a> FlatHandle<'a> {
     pub fn new(slice: impl Into<Vec<u8>>) -> Result<FlatHandle<'a>, Error> {
-
         let suite = pf::suites::Handle::new()?;
         let vector = slice.into();
 
@@ -309,14 +297,10 @@ impl<'a> FlatHandle<'a> {
     }
 
     #[inline]
-    pub fn as_ptr(&self) -> *const u8 {
-        unsafe { *(self.handle as *const *const u8) }
-    }
+    pub fn as_ptr(&self) -> *const u8 { unsafe { *(self.handle as *const *const u8) } }
 
     #[inline]
-    pub fn as_ptr_mut(&self) -> *mut u8 {
-        unsafe { *(self.handle as *const *mut u8) }
-    }
+    pub fn as_ptr_mut(&self) -> *mut u8 { unsafe { *(self.handle as *const *mut u8) } }
 
     #[inline]
     pub fn to_vec(&self) -> Vec<u8> {
@@ -332,9 +316,7 @@ impl<'a> FlatHandle<'a> {
     }
 
     #[inline]
-    pub fn size(&self) -> usize {
-        self.suite.handle_size(self.handle) as usize
-    }
+    pub fn size(&self) -> usize { self.suite.handle_size(self.handle) as usize }
 
     #[inline]
     pub fn from_raw(handle: ae_sys::PF_Handle) -> Result<FlatHandle<'a>, Error> {
@@ -397,9 +379,7 @@ impl<'a> FlatHandle<'a> {
     }
 
     #[inline]
-    pub fn as_raw(&self) -> ae_sys::PF_Handle {
-        self.handle
-    }
+    pub fn as_raw(&self) -> ae_sys::PF_Handle { self.handle }
 }
 /*
 impl<'a> Clone for FlatHandle<'a> {

--- a/after-effects/src/pf/in_data.rs
+++ b/after-effects/src/pf/in_data.rs
@@ -19,9 +19,7 @@ pub struct InData {
 }
 
 impl AsRef<ae_sys::PF_InData> for InData {
-    fn as_ref(&self) -> &ae_sys::PF_InData {
-        unsafe { &*self.ptr }
-    }
+    fn as_ref(&self) -> &ae_sys::PF_InData { unsafe { &*self.ptr } }
 }
 
 impl InData {
@@ -30,9 +28,7 @@ impl InData {
         Self { ptr }
     }
 
-    pub fn as_ptr(&self) -> *const ae_sys::PF_InData {
-        self.ptr
-    }
+    pub fn as_ptr(&self) -> *const ae_sys::PF_InData { self.ptr }
 
     /// The identifier of the invoking application.
     /// If your plug-in is running in After Effects, appl_id contains the application creator code ‘FXTC’.
@@ -55,26 +51,18 @@ impl InData {
 
     /// The current quality setting, either PF_Quality_HI or PF_Quality_LO. Effects should perform faster in LO, and more accurately in HI.
     /// The graphics utility callbacks perform differently between LO and HI quality; so should your effect! This field is defined during all frame and sequence selectors.
-    pub fn quality(&self) -> Quality {
-        unsafe { (*self.ptr).quality.into() }
-    }
+    pub fn quality(&self) -> Quality { unsafe { (*self.ptr).quality.into() } }
 
     /// Valid only if PF_OutFlag_PIX_INDEPENDENT was set during [`Command::GlobalSetup`].
     /// Check this field to see if you can process just the upper or lower field.
-    pub fn field(&self) -> Field {
-        unsafe { (*self.ptr).field.into() }
-    }
+    pub fn field(&self) -> Field { unsafe { (*self.ptr).field.into() } }
 
     /// The intersection of the visible portions of the input and output layers; encloses the composition rectangle transformed into layer coordinates.
     /// Iterating over only this rectangle of pixels can speed your effect dramatically. See extent_hint Usage later in this chapter regarding proper usage.
-    pub fn extent_hint(&self) -> Rect {
-        Rect::from(unsafe { (*self.ptr).extent_hint })
-    }
+    pub fn extent_hint(&self) -> Rect { Rect::from(unsafe { (*self.ptr).extent_hint }) }
 
     /// Create the [`Effect`] instance to get access to various utility functions.
-    pub fn effect(&self) -> Effect {
-        Effect::from_raw(unsafe { (*self.ptr).effect_ref })
-    }
+    pub fn effect(&self) -> Effect { Effect::from_raw(unsafe { (*self.ptr).effect_ref }) }
 
     /// Opaque data that must be passed to most of the various callback routines.
     /// After Effects uses this to identify your plug-in.
@@ -89,15 +77,11 @@ impl InData {
 
     /// Width of the source layer, which are not necessarily the same as the width and height fields in the input image parameter.
     /// Buffer resizing effects can cause this difference. Not affected by downsampling.
-    pub fn width(&self) -> i32 {
-        unsafe { (*self.ptr).width }
-    }
+    pub fn width(&self) -> i32 { unsafe { (*self.ptr).width } }
 
     /// Height of the source layer, which are not necessarily the same as the width and height fields in the input image parameter.
     /// Buffer resizing effects can cause this difference. Not affected by downsampling.
-    pub fn height(&self) -> i32 {
-        unsafe { (*self.ptr).height }
-    }
+    pub fn height(&self) -> i32 { unsafe { (*self.ptr).height } }
 
     /// The frame number of the current frame being rendered, valid during [`Command::Render`].
     /// This is the current frame in the layer, not in any composition.
@@ -139,9 +123,7 @@ impl InData {
     /// To handle time stretching, composition frame rate changes, and time remapping, After Effects may ask effects to render at non-integral times (between two frames).
     /// Be prepared for this; don’t assume that you’ll only be asked for frames on frame boundaries.
     /// NOTE: As of CS3 (8.0), effects may be asked to render at negative current times. Deal!
-    pub fn current_time(&self) -> i32 {
-        unsafe { (*self.ptr).current_time }
-    }
+    pub fn current_time(&self) -> i32 { unsafe { (*self.ptr).current_time } }
 
     /// The duration of the current source frame being rendered. In several situations with nested compositions, this source frame duration may be
     /// different than the time span between frames in the layer (`local_time_step`).
@@ -153,25 +135,19 @@ impl InData {
     /// or time remapping is applied to the outer composition. This value will be 0 during [`Command::SequenceSetup`] if it is not constant for all frames.
     /// It will be set correctly during [`Command::FrameSetup`] and [`Command::FrameSetdown`] selectors.
     /// WARNING: This can be zero, so check it before you divide.
-    pub fn time_step(&self) -> i32 {
-        unsafe { (*self.ptr).time_step }
-    }
+    pub fn time_step(&self) -> i32 { unsafe { (*self.ptr).time_step } }
 
     /// Time difference between frames in the layer. Affected by any time stretch applied to a layer.
     /// Can be negative if the layer is time-reversed.
     /// Unlike time_step, this value is constant from one frame to the next.
     /// This value can be converted to seconds by dividing by `time_scale`.
     /// For a step value that is constant over the entire frame range of the layer, use `local_time_step`, which is based on the composition’s framerate and layer stretch.
-    pub fn local_time_step(&self) -> i32 {
-        unsafe { (*self.ptr).local_time_step }
-    }
+    pub fn local_time_step(&self) -> i32 { unsafe { (*self.ptr).local_time_step } }
 
     /// The units per second that `current_time`, `time_step`, `local_time_step` and `total_time` are in.
     /// If `time_scale` is 30, then the units of `current_time`, `time_step`, `local_time_step` and `total_time` are in 30ths of a second.
     /// The `time_step` might then be 3, indicating that the sequence is actually being rendered at 10 frames per second. `total_time` might be 105, indicating that the sequence is 3.5 seconds long.
-    pub fn time_scale(&self) -> u32 {
-        unsafe { (*self.ptr).time_scale }
-    }
+    pub fn time_scale(&self) -> u32 { unsafe { (*self.ptr).time_scale } }
 
     /// Origin of the source image in the input buffer.
     /// Valid only when sent with a frame selector.
@@ -203,17 +179,13 @@ impl InData {
     /// Effects need the downsampling factors to interpret scalar parameters representing pixel distances in the image (like sliders).
     /// For example, a blur of 4 pixels should be interpreted as a blur of 2 pixels if the downsample factor is 1/2 in each direction (downsample factors are represented as ratios.)
     /// Valid only during [`Command::SequenceSetup`], [`Command::SequenceResetup`], [`Command::FrameSetup`], [`Command::Render`]
-    pub fn downsample_x(&self) -> RationalScale {
-        unsafe { (*self.ptr).downsample_x.into() }
-    }
+    pub fn downsample_x(&self) -> RationalScale { unsafe { (*self.ptr).downsample_x.into() } }
 
     /// Point control parameters and layer parameter dimensions are automatically adjusted to compensate for a user telling After Effects to render only every nth pixel.
     /// Effects need the downsampling factors to interpret scalar parameters representing pixel distances in the image (like sliders).
     /// For example, a blur of 4 pixels should be interpreted as a blur of 2 pixels if the downsample factor is 1/2 in each direction (downsample factors are represented as ratios.)
     /// Valid only during [`Command::SequenceSetup`], [`Command::SequenceResetup`], [`Command::FrameSetup`], [`Command::Render`]
-    pub fn downsample_y(&self) -> RationalScale {
-        unsafe { (*self.ptr).downsample_y.into() }
-    }
+    pub fn downsample_y(&self) -> RationalScale { unsafe { (*self.ptr).downsample_y.into() } }
 
     /// Effects specification version, Indicate the version you need to run successfully during [`Command::GlobalSetup`].
     #[inline]
@@ -271,28 +243,18 @@ impl InData {
     }
 
     /// Allows access to functions in the [`InteractCallbacks`] struct.
-    pub fn interact(&self) -> InteractCallbacks {
-        InteractCallbacks::new(*self)
-    }
+    pub fn interact(&self) -> InteractCallbacks { InteractCallbacks::new(*self) }
 
     /// Allows access to functions in the [`UtilCallbacks`] struct.
-    pub fn utils(&self) -> UtilCallbacks {
-        UtilCallbacks::new(*self)
-    }
+    pub fn utils(&self) -> UtilCallbacks { UtilCallbacks::new(*self) }
 }
 
 impl AsPtr<*const ae_sys::PF_InData> for *const ae_sys::PF_InData {
-    fn as_ptr(&self) -> *const ae_sys::PF_InData {
-        *self
-    }
+    fn as_ptr(&self) -> *const ae_sys::PF_InData { *self }
 }
 impl AsPtr<*const ae_sys::PF_InData> for InData {
-    fn as_ptr(&self) -> *const ae_sys::PF_InData {
-        self.ptr
-    }
+    fn as_ptr(&self) -> *const ae_sys::PF_InData { self.ptr }
 }
 impl AsPtr<*const ae_sys::PF_InData> for &InData {
-    fn as_ptr(&self) -> *const ae_sys::PF_InData {
-        self.ptr
-    }
+    fn as_ptr(&self) -> *const ae_sys::PF_InData { self.ptr }
 }

--- a/after-effects/src/pf/interact_callbacks.rs
+++ b/after-effects/src/pf/interact_callbacks.rs
@@ -14,9 +14,7 @@ use crate::*;
 pub struct InteractCallbacks(InData);
 
 impl InteractCallbacks {
-    pub fn new(in_data: InData) -> Self {
-        Self(in_data)
-    }
+    pub fn new(in_data: InData) -> Self { Self(in_data) }
 
     /// The checkout_param callback allows you to inquire param values at times other than the current one, and allows you to access layer params other
     /// than the default input layer and the output layer. See the notes on the "params" structure at the end of this file.
@@ -28,11 +26,26 @@ impl InteractCallbacks {
     /// IMPORTANT: Due to 13.5 threading changes, checking out a layer param that is not `<none>` inside of `UPDATE_PARAMS_UI` will return
     /// a frame with black pixels to avoid render requests and possible deadlock.
     /// In other selectors the actual render will be triggered as it did before.
-    pub fn checkout_param(&self, index: i32, what_time: i32, time_step: i32, time_scale: u32) -> Result<ae_sys::PF_ParamDef, Error> {
+    pub fn checkout_param(
+        &self,
+        index: i32,
+        what_time: i32,
+        time_step: i32,
+        time_scale: u32,
+    ) -> Result<ae_sys::PF_ParamDef, Error> {
         let in_data = unsafe { &(*self.0.as_ptr()) };
         let mut param: ae_sys::PF_ParamDef = unsafe { std::mem::zeroed() };
         param.param_type = ae_sys::PF_Param_RESERVED;
-        match unsafe { in_data.inter.checkout_param.unwrap()(in_data.effect_ref, index as _, what_time as _, time_step as _, time_scale as _, &mut param) } {
+        match unsafe {
+            in_data.inter.checkout_param.unwrap()(
+                in_data.effect_ref,
+                index as _,
+                what_time as _,
+                time_step as _,
+                time_scale as _,
+                &mut param,
+            )
+        } {
             0 => Ok(param),
             e => Err(Error::from(e)),
         }
@@ -43,7 +56,9 @@ impl InteractCallbacks {
     /// Once checked in, the fields in the `PF_ParamDef` will no longer be valid.
     pub fn checkin_param(&self, param: &ae_sys::PF_ParamDef) -> Result<(), Error> {
         let in_data = unsafe { &(*self.0.as_ptr()) };
-        match unsafe { in_data.inter.checkin_param.unwrap()(in_data.effect_ref, param as *const _ as *mut _) } {
+        match unsafe {
+            in_data.inter.checkin_param.unwrap()(in_data.effect_ref, param as *const _ as *mut _)
+        } {
             0 => Ok(()),
             e => Err(Error::from(e)),
         }
@@ -54,7 +69,13 @@ impl InteractCallbacks {
     /// Currently you can only add params at the end, and only at [`Command::ParamsSetup`] time.
     pub fn add_param(&self, index: i32, def: &ae_sys::PF_ParamDef) -> Result<(), Error> {
         let in_data = unsafe { &(*self.0.as_ptr()) };
-        match unsafe { in_data.inter.add_param.unwrap()(in_data.effect_ref, index as _, def as *const _ as *mut _) } {
+        match unsafe {
+            in_data.inter.add_param.unwrap()(
+                in_data.effect_ref,
+                index as _,
+                def as *const _ as *mut _,
+            )
+        } {
             0 => Ok(()),
             e => Err(Error::from(e)),
         }
@@ -83,7 +104,9 @@ impl InteractCallbacks {
     /// It is better to call it, say, once per scanline, unless your filter is really really slow.
     pub fn progress(&self, current: i32, total: i32) -> Result<(), Error> {
         let in_data = unsafe { &(*self.0.as_ptr()) };
-        match unsafe { in_data.inter.progress.unwrap()(in_data.effect_ref, current as _, total as _) } {
+        match unsafe {
+            in_data.inter.progress.unwrap()(in_data.effect_ref, current as _, total as _)
+        } {
             0 => Ok(()),
             e => Err(Error::from(e)),
         }
@@ -92,7 +115,9 @@ impl InteractCallbacks {
     /// Register a custom user interface element. See [Effect UI and events](https://ae-plugins.docsforadobe.dev/effect-ui-events/effect-ui-events.html). Note: The `PF_UIAlignment` flags are not honored.
     pub fn register_ui(&self, custom_ui_info: CustomUIInfo) -> Result<(), Error> {
         let in_data = unsafe { &(*self.0.as_ptr()) };
-        match unsafe { in_data.inter.register_ui.unwrap()(in_data.effect_ref, custom_ui_info.as_ptr() as _) } {
+        match unsafe {
+            in_data.inter.register_ui.unwrap()(in_data.effect_ref, custom_ui_info.as_ptr() as _)
+        } {
             0 => Ok(()),
             e => Err(Error::from(e)),
         }

--- a/after-effects/src/pf/layer.rs
+++ b/after-effects/src/pf/layer.rs
@@ -4,7 +4,7 @@ use ae_sys::PF_LayerDef;
 pub struct Layer {
     pub(crate) in_data_ptr: *const ae_sys::PF_InData,
     pub(crate) layer: PointerOwnership<PF_LayerDef>,
-    drop_fn: Option<fn(&mut Self)>
+    drop_fn: Option<fn(&mut Self)>,
 }
 
 impl Debug for Layer {
@@ -33,42 +33,58 @@ impl Debug for Layer {
 //pub dephault: A_long,
 
 impl Layer {
-    pub fn from_aegp_world(in_data: impl AsPtr<*const ae_sys::PF_InData>, world_handle: impl AsPtr<ae_sys::AEGP_WorldH>) -> Result<Self, crate::Error> {
+    pub fn from_aegp_world(
+        in_data: impl AsPtr<*const ae_sys::PF_InData>,
+        world_handle: impl AsPtr<ae_sys::AEGP_WorldH>,
+    ) -> Result<Self, crate::Error> {
         let mut layer: PF_LayerDef = unsafe { std::mem::zeroed() };
 
-        aegp::suites::World::new()?
-            .fill_out_pf_effect_world(world_handle.as_ptr(), &mut layer)?;
+        aegp::suites::World::new()?.fill_out_pf_effect_world(world_handle.as_ptr(), &mut layer)?;
 
-        Ok(Self { in_data_ptr: in_data.as_ptr(), layer: PointerOwnership::Rust(layer), drop_fn: None })
+        Ok(Self {
+            in_data_ptr: in_data.as_ptr(),
+            layer: PointerOwnership::Rust(layer),
+            drop_fn: None,
+        })
     }
 
-    pub fn from_owned(layer: PF_LayerDef, in_data: impl AsPtr<*const ae_sys::PF_InData>, drop_fn: fn(&mut Self)) -> Self {
-        Self { in_data_ptr: in_data.as_ptr(), layer: PointerOwnership::Rust(layer), drop_fn: Some(drop_fn) }
+    pub fn from_owned(
+        layer: PF_LayerDef,
+        in_data: impl AsPtr<*const ae_sys::PF_InData>,
+        drop_fn: fn(&mut Self),
+    ) -> Self {
+        Self {
+            in_data_ptr: in_data.as_ptr(),
+            layer: PointerOwnership::Rust(layer),
+            drop_fn: Some(drop_fn),
+        }
     }
 
-    pub fn from_raw(layer_ptr: *mut PF_LayerDef, in_data: impl AsPtr<*const ae_sys::PF_InData>, drop_fn: Option<fn(&mut Self)>) -> Self {
+    pub fn from_raw(
+        layer_ptr: *mut PF_LayerDef,
+        in_data: impl AsPtr<*const ae_sys::PF_InData>,
+        drop_fn: Option<fn(&mut Self)>,
+    ) -> Self {
         assert!(!layer_ptr.is_null());
-        Self { in_data_ptr: in_data.as_ptr(), layer: PointerOwnership::AfterEffects(layer_ptr), drop_fn }
+        Self {
+            in_data_ptr: in_data.as_ptr(),
+            layer: PointerOwnership::AfterEffects(layer_ptr),
+            drop_fn,
+        }
     }
 
-    pub fn width(&self) -> usize {
-        self.layer.width as usize
-    }
-    pub fn height(&self) -> usize {
-        self.layer.height as usize
-    }
-    pub fn buffer_stride(&self) -> usize {
-        self.layer.rowbytes.abs() as usize
-    }
-    pub fn row_bytes(&self) -> isize {
-        self.layer.rowbytes as isize
-    }
-    pub fn extent_hint(&self) -> Rect {
-        self.layer.extent_hint.into()
-    }
-    pub fn pix_aspect_ratio(&self) -> RationalScale {
-        self.layer.pix_aspect_ratio.into()
-    }
+    pub fn width(&self) -> usize { self.layer.width as usize }
+
+    pub fn height(&self) -> usize { self.layer.height as usize }
+
+    pub fn buffer_stride(&self) -> usize { self.layer.rowbytes.abs() as usize }
+
+    pub fn row_bytes(&self) -> isize { self.layer.rowbytes as isize }
+
+    pub fn extent_hint(&self) -> Rect { self.layer.extent_hint.into() }
+
+    pub fn pix_aspect_ratio(&self) -> RationalScale { self.layer.pix_aspect_ratio.into() }
+
     pub fn origin(&self) -> Point {
         Point {
             h: self.layer.origin_x.into(),
@@ -92,6 +108,7 @@ impl Layer {
             )
         }
     }
+
     pub fn buffer_mut(&mut self) -> &mut [u8] {
         // Stride can be negative, so we need to offset the pointer to get to the real beginning of the buffer
         let offset = if self.row_bytes() < 0 {
@@ -109,20 +126,31 @@ impl Layer {
         }
     }
 
-    pub fn copy_from(&mut self, src: &Self, src_rect: Option<Rect>, dst_rect: Option<Rect>) -> Result<(), Error> {
+    pub fn copy_from(
+        &mut self,
+        src: &Self,
+        src_rect: Option<Rect>,
+        dst_rect: Option<Rect>,
+    ) -> Result<(), Error> {
         self.utils().copy(src, self, src_rect, dst_rect)
     }
 
-    pub fn utils(&self) -> UtilCallbacks {
-        UtilCallbacks::new(self.in_data_ptr)
-    }
+    pub fn utils(&self) -> UtilCallbacks { UtilCallbacks::new(self.in_data_ptr) }
 
     fn clamp_rect(&self, rect: &mut Option<Rect>) {
         if let Some(rect) = rect {
-            if rect.left < 0 { rect.left = 0; }
-            if rect.top  < 0 { rect.top  = 0; }
-            if rect.width()  > self.width()  as i32 { rect.set_width(self.width() as i32); }
-            if rect.height() > self.height() as i32 { rect.set_height(self.height() as i32); }
+            if rect.left < 0 {
+                rect.left = 0;
+            }
+            if rect.top < 0 {
+                rect.top = 0;
+            }
+            if rect.width() > self.width() as i32 {
+                rect.set_width(self.width() as i32);
+            }
+            if rect.height() > self.height() as i32 {
+                rect.set_height(self.height() as i32);
+            }
         }
     }
 
@@ -131,24 +159,46 @@ impl Layer {
         if self.bit_depth() == 16 {
             return self.fill16(color.map(pixel8_to_16), rect);
         }
-        if !self.in_data_ptr.is_null() && unsafe { (*self.in_data_ptr).appl_id != i32::from_be_bytes(*b"PrMr") } {
+        if !self.in_data_ptr.is_null()
+            && unsafe { (*self.in_data_ptr).appl_id != i32::from_be_bytes(*b"PrMr") }
+        {
             if let Ok(fill_suite) = pf::suites::FillMatte::new() {
-                return fill_suite.fill(unsafe { (*self.in_data_ptr).effect_ref }, self, color, rect);
+                return fill_suite.fill(
+                    unsafe { (*self.in_data_ptr).effect_ref },
+                    self,
+                    color,
+                    rect,
+                );
             }
         }
         self.utils().fill(self, color, rect)
     }
+
     pub fn fill16(&mut self, color: Option<Pixel16>, mut rect: Option<Rect>) -> Result<(), Error> {
         self.clamp_rect(&mut rect);
-        if !self.in_data_ptr.is_null() && unsafe { (*self.in_data_ptr).appl_id != i32::from_be_bytes(*b"PrMr") } {
+        if !self.in_data_ptr.is_null()
+            && unsafe { (*self.in_data_ptr).appl_id != i32::from_be_bytes(*b"PrMr") }
+        {
             if let Ok(fill_suite) = pf::suites::FillMatte::new() {
-                return fill_suite.fill16(unsafe { (*self.in_data_ptr).effect_ref }, self, color, rect);
+                return fill_suite.fill16(
+                    unsafe { (*self.in_data_ptr).effect_ref },
+                    self,
+                    color,
+                    rect,
+                );
             }
         }
         self.utils().fill16(self, color, rect)
     }
 
-    pub fn iterate_with<F>(&self, output: &mut Self, progress_base: i32, progress_final: i32, area: Option<Rect>, cb: F) -> Result<(), Error>
+    pub fn iterate_with<F>(
+        &self,
+        output: &mut Self,
+        progress_base: i32,
+        progress_final: i32,
+        area: Option<Rect>,
+        cb: F,
+    ) -> Result<(), Error>
     where
         F: Fn(i32, i32, GenericPixel, GenericPixelMut) -> Result<(), Error>,
     {
@@ -156,51 +206,106 @@ impl Layer {
 
         let self_ptr = Some(self.as_ptr());
         match self.bit_depth() {
-            8 => self.utils().iterate(self_ptr, output.as_mut_ptr(), progress_base, progress_final, area, move |x, y, in_pixel, out_pixel| {
-                cb(x, y, GenericPixel::Pixel8(in_pixel), GenericPixelMut::Pixel8(out_pixel))
-            }),
-            16 => self.utils().iterate16(self_ptr, output.as_mut_ptr(), progress_base, progress_final, area, move |x, y, in_pixel, out_pixel| {
-                cb(x, y, GenericPixel::Pixel16(in_pixel), GenericPixelMut::Pixel16(out_pixel))
-            }),
+            8 => self.utils().iterate(
+                self_ptr,
+                output.as_mut_ptr(),
+                progress_base,
+                progress_final,
+                area,
+                move |x, y, in_pixel, out_pixel| {
+                    cb(
+                        x,
+                        y,
+                        GenericPixel::Pixel8(in_pixel),
+                        GenericPixelMut::Pixel8(out_pixel),
+                    )
+                },
+            ),
+            16 => self.utils().iterate16(
+                self_ptr,
+                output.as_mut_ptr(),
+                progress_base,
+                progress_final,
+                area,
+                move |x, y, in_pixel, out_pixel| {
+                    cb(
+                        x,
+                        y,
+                        GenericPixel::Pixel16(in_pixel),
+                        GenericPixelMut::Pixel16(out_pixel),
+                    )
+                },
+            ),
             32 => {
                 let suite = pf::suites::IterateFloat::new()?;
-                suite.iterate(self.in_data_ptr, self_ptr, output.as_mut_ptr(), progress_base, progress_final, area, move |x, y, in_pixel, out_pixel| {
-                    cb(x, y, GenericPixel::PixelF32(in_pixel), GenericPixelMut::PixelF32(out_pixel))
-                })
-            },
+                suite.iterate(
+                    self.in_data_ptr,
+                    self_ptr,
+                    output.as_mut_ptr(),
+                    progress_base,
+                    progress_final,
+                    area,
+                    move |x, y, in_pixel, out_pixel| {
+                        cb(
+                            x,
+                            y,
+                            GenericPixel::PixelF32(in_pixel),
+                            GenericPixelMut::PixelF32(out_pixel),
+                        )
+                    },
+                )
+            }
             _ => Err(Error::BadCallbackParameter),
         }
     }
 
-    pub fn iterate<F>(&mut self, progress_base: i32, progress_final: i32, area: Option<Rect>, cb: F) -> Result<(), Error>
+    pub fn iterate<F>(
+        &mut self,
+        progress_base: i32,
+        progress_final: i32,
+        area: Option<Rect>,
+        cb: F,
+    ) -> Result<(), Error>
     where
         F: Fn(i32, i32, GenericPixelMut) -> Result<(), Error>,
     {
         let self_ptr = self.as_mut_ptr();
         match self.bit_depth() {
-            8 => self.utils().iterate(None, self_ptr, progress_base, progress_final, area, move |x, y, _, out_pixel| {
-                cb(x, y, GenericPixelMut::Pixel8(out_pixel))
-            }),
-            16 => self.utils().iterate16(None, self_ptr, progress_base, progress_final, area, move |x, y, _, out_pixel| {
-                cb(x, y, GenericPixelMut::Pixel16(out_pixel))
-            }),
+            8 => self.utils().iterate(
+                None,
+                self_ptr,
+                progress_base,
+                progress_final,
+                area,
+                move |x, y, _, out_pixel| cb(x, y, GenericPixelMut::Pixel8(out_pixel)),
+            ),
+            16 => self.utils().iterate16(
+                None,
+                self_ptr,
+                progress_base,
+                progress_final,
+                area,
+                move |x, y, _, out_pixel| cb(x, y, GenericPixelMut::Pixel16(out_pixel)),
+            ),
             32 => {
                 let suite = pf::suites::IterateFloat::new()?;
-                suite.iterate(self.in_data_ptr, None, self_ptr, progress_base, progress_final, area, move |x, y, _, out_pixel| {
-                    cb(x, y, GenericPixelMut::PixelF32(out_pixel))
-                })
-            },
+                suite.iterate(
+                    self.in_data_ptr,
+                    None,
+                    self_ptr,
+                    progress_base,
+                    progress_final,
+                    area,
+                    move |x, y, _, out_pixel| cb(x, y, GenericPixelMut::PixelF32(out_pixel)),
+                )
+            }
             _ => Err(Error::BadCallbackParameter),
         }
     }
 
-    pub unsafe fn data_ptr(&self) -> *const u8 {
-        self.layer.data as *const u8
-    }
+    pub unsafe fn data_ptr(&self) -> *const u8 { self.layer.data as *const u8 }
 
-    pub unsafe fn data_ptr_mut(&self) -> *mut u8 {
-        self.layer.data as *mut u8
-    }
+    pub unsafe fn data_ptr_mut(&self) -> *mut u8 { self.layer.data as *mut u8 }
 
     pub fn row_padding_bytes(&self) -> usize {
         self.buffer_stride()
@@ -219,39 +324,51 @@ impl Layer {
     // `self`, so handing it out from a shared borrow aliases no Rust-owned data.
     #[allow(clippy::mut_from_ref)]
     pub fn as_pixel8_mut(&self, x: usize, y: usize) -> &mut Pixel8 {
-        debug_assert!(x < self.width() && y < self.height(), "Coordinate is outside EffectWorld bounds.");
-        unsafe { &mut *(self.data_ptr_mut().offset(y as isize * self.row_bytes()) as *mut Pixel8).offset(x as isize) }
+        debug_assert!(
+            x < self.width() && y < self.height(),
+            "Coordinate is outside EffectWorld bounds."
+        );
+        unsafe {
+            &mut *(self.data_ptr_mut().offset(y as isize * self.row_bytes()) as *mut Pixel8)
+                .offset(x as isize)
+        }
     }
 
-    pub fn as_pixel8(&self, x: usize, y: usize) -> &Pixel8 {
-        self.as_pixel8_mut(x, y)
-    }
+    pub fn as_pixel8(&self, x: usize, y: usize) -> &Pixel8 { self.as_pixel8_mut(x, y) }
 
     // `mut_from_ref` is expected: the returned `&mut` points into the host-owned
     // `PF_EffectWorld` pixel buffer reached through a raw data pointer, not into
     // `self`, so handing it out from a shared borrow aliases no Rust-owned data.
     #[allow(clippy::mut_from_ref)]
     pub fn as_pixel16_mut(&self, x: usize, y: usize) -> &mut Pixel16 {
-        debug_assert!(x < self.width() && y < self.height(), "Coordinate is outside EffectWorld bounds.");
-        unsafe { &mut *(self.data_ptr_mut().offset(y as isize * self.row_bytes()) as *mut Pixel16).offset(x as isize) }
+        debug_assert!(
+            x < self.width() && y < self.height(),
+            "Coordinate is outside EffectWorld bounds."
+        );
+        unsafe {
+            &mut *(self.data_ptr_mut().offset(y as isize * self.row_bytes()) as *mut Pixel16)
+                .offset(x as isize)
+        }
     }
 
-    pub fn as_pixel16(&self, x: usize, y: usize) -> &Pixel16 {
-        self.as_pixel16_mut(x, y)
-    }
+    pub fn as_pixel16(&self, x: usize, y: usize) -> &Pixel16 { self.as_pixel16_mut(x, y) }
 
     // `mut_from_ref` is expected: the returned `&mut` points into the host-owned
     // `PF_EffectWorld` pixel buffer reached through a raw data pointer, not into
     // `self`, so handing it out from a shared borrow aliases no Rust-owned data.
     #[allow(clippy::mut_from_ref)]
     pub fn as_pixel32_mut(&self, x: usize, y: usize) -> &mut PixelF32 {
-        debug_assert!(x < self.width() && y < self.height(), "Coordinate is outside EffectWorld bounds.");
-        unsafe { &mut *(self.data_ptr_mut().offset(y as isize * self.row_bytes()) as *mut PixelF32).add(x) }
+        debug_assert!(
+            x < self.width() && y < self.height(),
+            "Coordinate is outside EffectWorld bounds."
+        );
+        unsafe {
+            &mut *(self.data_ptr_mut().offset(y as isize * self.row_bytes()) as *mut PixelF32)
+                .add(x)
+        }
     }
 
-    pub fn as_pixel32(&self, x: usize, y: usize) -> &PixelF32 {
-        self.as_pixel32_mut(x, y)
-    }
+    pub fn as_pixel32(&self, x: usize, y: usize) -> &PixelF32 { self.as_pixel32_mut(x, y) }
 
     pub fn world_type(&self) -> aegp::WorldType {
         let flags = WorldFlags::from_bits(self.layer.world_flags as _).unwrap();
@@ -274,47 +391,46 @@ impl Layer {
         } else {
             if InData::from_raw(self.in_data_ptr).is_premiere() {
                 match self.pr_pixel_format() {
-                    Ok(pr::PixelFormat::Rgb444_10u) |
-                    Ok(pr::PixelFormat::V210422_10u601) |
-                    Ok(pr::PixelFormat::V210422_10u709) => { 10 }
-                    Ok(pr::PixelFormat::Rgb444_12uPq709) |
-                    Ok(pr::PixelFormat::Rgb444_12uPqP3) |
-                    Ok(pr::PixelFormat::Rgb444_12uPq2020) => { 12 }
-                    Ok(pr::PixelFormat::Bgra4444_16u) |
-                    Ok(pr::PixelFormat::Vuya4444_16u) |
-                    Ok(pr::PixelFormat::Argb4444_16u) |
-                    Ok(pr::PixelFormat::Bgrx4444_16u) |
-                    Ok(pr::PixelFormat::Xrgb4444_16u) |
-                    Ok(pr::PixelFormat::Bgrp4444_16u) |
-                    Ok(pr::PixelFormat::Prgb4444_16u) => { 16 }
-                    Ok(pr::PixelFormat::Bgra4444_32f) |
-                    Ok(pr::PixelFormat::Vuya4444_32f) |
-                    Ok(pr::PixelFormat::Vuya4444_32f709) |
-                    Ok(pr::PixelFormat::Argb4444_32f) |
-                    Ok(pr::PixelFormat::Bgrx4444_32f) |
-                    Ok(pr::PixelFormat::Vuyx4444_32f) |
-                    Ok(pr::PixelFormat::Vuyx4444_32f709) |
-                    Ok(pr::PixelFormat::Xrgb4444_32f) |
-                    Ok(pr::PixelFormat::Bgrp4444_32f) |
-                    Ok(pr::PixelFormat::Vuyp4444_32f) |
-                    Ok(pr::PixelFormat::Vuyp4444_32f709) |
-                    Ok(pr::PixelFormat::Prgb4444_32f) |
-                    Ok(pr::PixelFormat::Uyvy422_32f601) |
-                    Ok(pr::PixelFormat::Uyvy422_32f709) |
-                    Ok(pr::PixelFormat::Bgra4444_32fLinear) |
-                    Ok(pr::PixelFormat::Bgrp4444_32fLinear) |
-                    Ok(pr::PixelFormat::Bgrx4444_32fLinear) |
-                    Ok(pr::PixelFormat::Argb4444_32fLinear) |
-                    Ok(pr::PixelFormat::Prgb4444_32fLinear) |
-                    Ok(pr::PixelFormat::Xrgb4444_32fLinear) => { 32 }
-                    _ => { 8 }
+                    Ok(pr::PixelFormat::Rgb444_10u)
+                    | Ok(pr::PixelFormat::V210422_10u601)
+                    | Ok(pr::PixelFormat::V210422_10u709) => 10,
+                    Ok(pr::PixelFormat::Rgb444_12uPq709)
+                    | Ok(pr::PixelFormat::Rgb444_12uPqP3)
+                    | Ok(pr::PixelFormat::Rgb444_12uPq2020) => 12,
+                    Ok(pr::PixelFormat::Bgra4444_16u)
+                    | Ok(pr::PixelFormat::Vuya4444_16u)
+                    | Ok(pr::PixelFormat::Argb4444_16u)
+                    | Ok(pr::PixelFormat::Bgrx4444_16u)
+                    | Ok(pr::PixelFormat::Xrgb4444_16u)
+                    | Ok(pr::PixelFormat::Bgrp4444_16u)
+                    | Ok(pr::PixelFormat::Prgb4444_16u) => 16,
+                    Ok(pr::PixelFormat::Bgra4444_32f)
+                    | Ok(pr::PixelFormat::Vuya4444_32f)
+                    | Ok(pr::PixelFormat::Vuya4444_32f709)
+                    | Ok(pr::PixelFormat::Argb4444_32f)
+                    | Ok(pr::PixelFormat::Bgrx4444_32f)
+                    | Ok(pr::PixelFormat::Vuyx4444_32f)
+                    | Ok(pr::PixelFormat::Vuyx4444_32f709)
+                    | Ok(pr::PixelFormat::Xrgb4444_32f)
+                    | Ok(pr::PixelFormat::Bgrp4444_32f)
+                    | Ok(pr::PixelFormat::Vuyp4444_32f)
+                    | Ok(pr::PixelFormat::Vuyp4444_32f709)
+                    | Ok(pr::PixelFormat::Prgb4444_32f)
+                    | Ok(pr::PixelFormat::Uyvy422_32f601)
+                    | Ok(pr::PixelFormat::Uyvy422_32f709)
+                    | Ok(pr::PixelFormat::Bgra4444_32fLinear)
+                    | Ok(pr::PixelFormat::Bgrp4444_32fLinear)
+                    | Ok(pr::PixelFormat::Bgrx4444_32fLinear)
+                    | Ok(pr::PixelFormat::Argb4444_32fLinear)
+                    | Ok(pr::PixelFormat::Prgb4444_32fLinear)
+                    | Ok(pr::PixelFormat::Xrgb4444_32fLinear) => 32,
+                    _ => 8,
                 }
             } else {
                 match self.pixel_format() {
-                    Ok(PixelFormat::Argb64) => { 16 }
-                    Ok(PixelFormat::Argb128) |
-                    Ok(PixelFormat::GpuBgra128) => { 32 }
-                    _ => { 8 }
+                    Ok(PixelFormat::Argb64) => 16,
+                    Ok(PixelFormat::Argb128) | Ok(PixelFormat::GpuBgra128) => 32,
+                    _ => 8,
                 }
             }
         }
@@ -338,29 +454,18 @@ impl Drop for Layer {
 }
 
 impl AsPtr<*const ae_sys::PF_EffectWorld> for Layer {
-    fn as_ptr(&self) -> *const ae_sys::PF_EffectWorld {
-        &*self.layer
-    }
+    fn as_ptr(&self) -> *const ae_sys::PF_EffectWorld { &*self.layer }
 }
 impl AsPtr<*const ae_sys::PF_EffectWorld> for &Layer {
-    fn as_ptr(&self) -> *const ae_sys::PF_EffectWorld {
-        &*self.layer
-    }
+    fn as_ptr(&self) -> *const ae_sys::PF_EffectWorld { &*self.layer }
 }
 impl AsPtr<*const ae_sys::PF_EffectWorld> for *const ae_sys::PF_EffectWorld {
-    fn as_ptr(&self) -> *const ae_sys::PF_EffectWorld {
-        *self
-    }
+    fn as_ptr(&self) -> *const ae_sys::PF_EffectWorld { *self }
 }
 
 impl AsMutPtr<*mut ae_sys::PF_EffectWorld> for Layer {
-    fn as_mut_ptr(&mut self) -> *mut ae_sys::PF_EffectWorld {
-        &mut *self.layer
-    }
+    fn as_mut_ptr(&mut self) -> *mut ae_sys::PF_EffectWorld { &mut *self.layer }
 }
 impl AsMutPtr<*mut ae_sys::PF_EffectWorld> for &mut Layer {
-    fn as_mut_ptr(&mut self) -> *mut ae_sys::PF_EffectWorld {
-        &mut *self.layer
-    }
+    fn as_mut_ptr(&mut self) -> *mut ae_sys::PF_EffectWorld { &mut *self.layer }
 }
-

--- a/after-effects/src/pf/mod.rs
+++ b/after-effects/src/pf/mod.rs
@@ -1,96 +1,110 @@
 use crate::*;
 use bitflags::bitflags;
-use std::{
-    fmt::Debug,
-    marker::PhantomData,
-};
+use std::{fmt::Debug, marker::PhantomData};
 
-mod command;    pub use command::*;
-mod events;     pub use events::*;
-mod gpu;        pub use gpu::*;
-mod handles;    pub use handles::*;
-mod in_data;    pub use in_data::*;
-mod layer;      pub use layer::*;
-mod out_data;   pub use out_data::*;
-mod parameters; pub use parameters::*;
-mod pixel;      pub use pixel::*;
-mod render;     pub use render::*;
-mod effect;     pub use effect::*;
-mod interact_callbacks;    pub use interact_callbacks::*;
-mod util_callbacks;        pub use util_callbacks::*;
-mod external_dependencies; pub use external_dependencies::*;
+mod command;
+pub use command::*;
+mod events;
+pub use events::*;
+mod gpu;
+pub use gpu::*;
+mod handles;
+pub use handles::*;
+mod in_data;
+pub use in_data::*;
+mod layer;
+pub use layer::*;
+mod out_data;
+pub use out_data::*;
+mod parameters;
+pub use parameters::*;
+mod pixel;
+pub use pixel::*;
+mod render;
+pub use render::*;
+mod effect;
+pub use effect::*;
+mod interact_callbacks;
+pub use interact_callbacks::*;
+mod util_callbacks;
+pub use util_callbacks::*;
+mod external_dependencies;
+pub use external_dependencies::*;
 
 pub mod suites {
-    pub(crate) mod adv_item;              pub use adv_item            ::AdvItemSuite               as AdvItem;
-    pub(crate) mod background_frame;      pub use background_frame    ::BackgroundFrameSuite       as BackgroundFrame;
-    pub(crate) mod cache_on_load;         pub use cache_on_load       ::CacheOnLoadSuite           as CacheOnLoad;
-    pub(crate) mod channel;               pub use channel             ::ChannelSuite               as Channel;
-    pub(crate) mod color_callbacks;       pub use color_callbacks     ::{ ColorCallbacksSuite      as ColorCallbacks,
-                                                                          ColorCallbacks16Suite    as ColorCallbacks16,
-                                                                          ColorCallbacksFloatSuite as ColorCallbacksFloat };
-    pub(crate) mod effect_sequence_data;  pub use effect_sequence_data::EffectSequenceDataSuite    as EffectSequenceData;
-    pub(crate) mod effect_ui;             pub use effect_ui           ::EffectUISuite              as EffectUI;
-    pub(crate) mod app;                   pub use app                 ::{ AppSuite                 as App,
-                                                                          AdvAppSuite              as AdvApp };
-    pub(crate) mod custom_ui;             pub use custom_ui           ::{ EffectCustomUISuite      as EffectCustomUI,
-                                                                          EffectCustomUIOverlayThemeSuite as EffectCustomUIOverlayTheme };
-    pub(crate) mod iterate;               pub use iterate             ::{ Iterate8Suite            as Iterate8,
-                                                                          Iterate16Suite           as Iterate16,
-                                                                          IterateFloatSuite        as IterateFloat };
-    pub(crate) mod pixel_data;            pub use pixel_data          ::PixelDataSuite             as PixelData;
-    pub(crate) mod pixel_format;          pub use pixel_format        ::PixelFormatSuite           as PixelFormat;
-    pub(crate) mod source_settings;       pub use source_settings     ::SourceSettingsSuite        as SourceSettings;
-    pub(crate) mod transition;            pub use transition          ::TransitionSuite            as Transition;
-    pub(crate) mod utility;               pub use utility             ::UtilitySuite               as Utility;
-    pub(crate) mod world;                 pub use world               ::WorldSuite                 as World;
-    pub(crate) mod world_transform;       pub use world_transform     ::WorldTransformSuite        as WorldTransform;
-    pub(crate) mod handle;                pub use handle              ::HandleSuite                as Handle;
-    pub(crate) mod helper;                pub use helper              ::{ HelperSuite              as Helper,
-                                                                          HelperSuite2             as Helper2 };
-    pub(crate) mod param_utils;           pub use param_utils         ::{ ParamUtilsSuite          as ParamUtils,
-                                                                          AngleParamSuite          as AngleParam,
-                                                                          ColorParamSuite          as ColorParam,
-                                                                          PointParamSuite          as PointParam };
-    pub(crate) mod gpu_device;            pub use gpu_device          ::GPUDeviceSuite             as GPUDevice;
-    pub(crate) mod fill_matte;            pub use fill_matte          ::FillMatteSuite             as FillMatte;
-    pub(crate) mod path;                  pub use path                ::{ PathQuerySuite           as PathQuery,
-                                                                          PathDataSuite            as PathData };
+    pub(crate) mod adv_item;
+    pub use adv_item::AdvItemSuite as AdvItem;
+    pub(crate) mod background_frame;
+    pub use background_frame::BackgroundFrameSuite as BackgroundFrame;
+    pub(crate) mod cache_on_load;
+    pub use cache_on_load::CacheOnLoadSuite as CacheOnLoad;
+    pub(crate) mod channel;
+    pub use channel::ChannelSuite as Channel;
+    pub(crate) mod color_callbacks;
+    pub use color_callbacks::{
+        ColorCallbacks16Suite as ColorCallbacks16, ColorCallbacksFloatSuite as ColorCallbacksFloat,
+        ColorCallbacksSuite as ColorCallbacks,
+    };
+    pub(crate) mod effect_sequence_data;
+    pub use effect_sequence_data::EffectSequenceDataSuite as EffectSequenceData;
+    pub(crate) mod effect_ui;
+    pub use effect_ui::EffectUISuite as EffectUI;
+    pub(crate) mod app;
+    pub use app::{AdvAppSuite as AdvApp, AppSuite as App};
+    pub(crate) mod custom_ui;
+    pub use custom_ui::{
+        EffectCustomUIOverlayThemeSuite as EffectCustomUIOverlayTheme,
+        EffectCustomUISuite as EffectCustomUI,
+    };
+    pub(crate) mod iterate;
+    pub use iterate::{
+        Iterate8Suite as Iterate8, Iterate16Suite as Iterate16, IterateFloatSuite as IterateFloat,
+    };
+    pub(crate) mod pixel_data;
+    pub use pixel_data::PixelDataSuite as PixelData;
+    pub(crate) mod pixel_format;
+    pub use pixel_format::PixelFormatSuite as PixelFormat;
+    pub(crate) mod source_settings;
+    pub use source_settings::SourceSettingsSuite as SourceSettings;
+    pub(crate) mod transition;
+    pub use transition::TransitionSuite as Transition;
+    pub(crate) mod utility;
+    pub use utility::UtilitySuite as Utility;
+    pub(crate) mod world;
+    pub use world::WorldSuite as World;
+    pub(crate) mod world_transform;
+    pub use world_transform::WorldTransformSuite as WorldTransform;
+    pub(crate) mod handle;
+    pub use handle::HandleSuite as Handle;
+    pub(crate) mod helper;
+    pub use helper::{HelperSuite as Helper, HelperSuite2 as Helper2};
+    pub(crate) mod param_utils;
+    pub use param_utils::{
+        AngleParamSuite as AngleParam, ColorParamSuite as ColorParam,
+        ParamUtilsSuite as ParamUtils, PointParamSuite as PointParam,
+    };
+    pub(crate) mod gpu_device;
+    pub use gpu_device::GPUDeviceSuite as GPUDevice;
+    pub(crate) mod fill_matte;
+    pub use fill_matte::FillMatteSuite as FillMatte;
+    pub(crate) mod path;
+    pub use path::{PathDataSuite as PathData, PathQuerySuite as PathQuery};
 }
 
 pub use suites::adv_item::Step;
 pub use suites::app::{
-    AppColorType,
-    AppPersonalTextInfo,
-    AppProgressDialog,
-    CursorType,
-    EyeDropperSampleMode,
+    AppColorType, AppPersonalTextInfo, AppProgressDialog, CursorType, EyeDropperSampleMode,
     FontStyleSheet,
 };
-pub use suites::custom_ui::{
-    ContextHandle,
-    CustomUIInfo,
-};
-pub use suites::channel::{
-    DataType,
-    ChannelType,
-};
-pub use suites::helper::{
-    SuiteTool,
-    ExtendedSuiteTool
-};
+pub use suites::channel::{ChannelType, DataType};
+pub use suites::custom_ui::{ContextHandle, CustomUIInfo};
+pub use suites::helper::{ExtendedSuiteTool, SuiteTool};
 pub use suites::param_utils::{
-    PARAM_INDEX_NONE,
-    PARAM_INDEX_CHECK_ALL,
-    PARAM_INDEX_CHECK_ALL_EXCEPT_LAYER_PARAMS,
-    PARAM_INDEX_CHECK_ALL_HONOR_EXCLUDE,
-    TimeDir,
+    PARAM_INDEX_CHECK_ALL, PARAM_INDEX_CHECK_ALL_EXCEPT_LAYER_PARAMS,
+    PARAM_INDEX_CHECK_ALL_HONOR_EXCLUDE, PARAM_INDEX_NONE, TimeDir,
 };
+pub use suites::path::{MaskMode, PathOutline, PathSegPrep};
 pub use suites::pixel_format::PixelFormat;
-pub use suites::path::{
-    MaskMode,
-    PathOutline,
-    PathSegPrep,
-};
 
 define_enum! {
     ae_sys::PF_XferMode,
@@ -200,9 +214,7 @@ define_struct! {
     }
 }
 impl Point {
-    pub fn empty() -> Self {
-        Self { h: 0, v: 0 }
-    }
+    pub fn empty() -> Self { Self { h: 0, v: 0 } }
 }
 
 define_struct! {
@@ -215,7 +227,10 @@ define_struct! {
 }
 impl RationalScale {
     pub fn inv(&self) -> RationalScale {
-        RationalScale { num: self.den as _, den: self.num as _ }
+        RationalScale {
+            num: self.den as _,
+            den: self.num as _,
+        }
     }
 }
 
@@ -392,28 +407,20 @@ bitflags! {
 #[repr(transparent)]
 pub struct Fixed(ae_sys::PF_Fixed);
 impl Fixed {
-    pub const ONE: Self = Self(0x00010000);
     pub const HALF: Self = Self(0x00008000);
+    pub const ONE: Self = Self(0x00010000);
 
-    pub fn to_int(self) -> i32 {
-        self.0 as ae_sys::A_long >> 16
-    }
-    pub fn to_int_rounded(self) -> i32 {
-        (self.0 as ae_sys::A_long + 32768) >> 16
-    }
-    pub fn from_int(value: i32) -> Self {
-        Self(value << 16)
-    }
-    pub fn as_f32(&self) -> f32 {
-        self.0 as f32 / 65536.0
-    }
+    pub fn to_int(self) -> i32 { self.0 as ae_sys::A_long >> 16 }
 
-    pub fn as_fixed(&self) -> ae_sys::PF_Fixed {
-        self.0
-    }
-    pub fn from_fixed(value: ae_sys::PF_Fixed) -> Self {
-        Self(value)
-    }
+    pub fn to_int_rounded(self) -> i32 { (self.0 as ae_sys::A_long + 32768) >> 16 }
+
+    pub fn from_int(value: i32) -> Self { Self(value << 16) }
+
+    pub fn as_f32(&self) -> f32 { self.0 as f32 / 65536.0 }
+
+    pub fn as_fixed(&self) -> ae_sys::PF_Fixed { self.0 }
+
+    pub fn from_fixed(value: ae_sys::PF_Fixed) -> Self { Self(value) }
 }
 impl From<f32> for Fixed {
     fn from(value: f32) -> Self {
@@ -421,12 +428,8 @@ impl From<f32> for Fixed {
     }
 }
 impl From<Fixed> for f32 {
-    fn from(val: Fixed) -> Self {
-        val.0 as f32 / 65536.0
-    }
+    fn from(val: Fixed) -> Self { val.0 as f32 / 65536.0 }
 }
 impl From<Fixed> for f64 {
-    fn from(val: Fixed) -> Self {
-        val.0 as f64 / 65536.0
-    }
+    fn from(val: Fixed) -> Self { val.0 as f64 / 65536.0 }
 }

--- a/after-effects/src/pf/out_data.rs
+++ b/after-effects/src/pf/out_data.rs
@@ -14,14 +14,10 @@ pub struct OutData {
 }
 
 impl AsRef<ae_sys::PF_OutData> for OutData {
-    fn as_ref(&self) -> &ae_sys::PF_OutData {
-        unsafe { &*self.ptr }
-    }
+    fn as_ref(&self) -> &ae_sys::PF_OutData { unsafe { &*self.ptr } }
 }
 impl AsMut<ae_sys::PF_OutData> for OutData {
-    fn as_mut(&mut self) -> &mut ae_sys::PF_OutData {
-        unsafe { &mut *self.ptr }
-    }
+    fn as_mut(&mut self) -> &mut ae_sys::PF_OutData { unsafe { &mut *self.ptr } }
 }
 
 impl OutData {
@@ -30,39 +26,25 @@ impl OutData {
         Self { ptr }
     }
 
-    pub fn as_ptr(&self) -> *const ae_sys::PF_OutData {
-        self.ptr
-    }
+    pub fn as_ptr(&self) -> *const ae_sys::PF_OutData { self.ptr }
 
-    pub fn width(&self) -> u32 {
-        self.as_ref().width as u32
-    }
+    pub fn width(&self) -> u32 { self.as_ref().width as u32 }
 
     /// Set during [`Command::FrameSetup`] if the output image size differs from the input. width and height are the size of the output buffer, and origin is the point the input should map to in the output.
     /// To create a 5-pixel drop shadow up and left, set origin to (5, 5).
-    pub fn set_width(&mut self, width: u32) {
-        self.as_mut().width = width as ae_sys::A_long;
-    }
+    pub fn set_width(&mut self, width: u32) { self.as_mut().width = width as ae_sys::A_long; }
 
-    pub fn height(&self) -> u32 {
-        self.as_ref().height as u32
-    }
+    pub fn height(&self) -> u32 { self.as_ref().height as u32 }
 
     /// Set during [`Command::FrameSetup`] if the output image size differs from the input. width and height are the size of the output buffer, and origin is the point the input should map to in the output.
     /// To create a 5-pixel drop shadow up and left, set origin to (5, 5).
-    pub fn set_height(&mut self, height: u32) {
-        self.as_mut().height = height as ae_sys::A_long;
-    }
+    pub fn set_height(&mut self, height: u32) { self.as_mut().height = height as ae_sys::A_long; }
 
-    pub fn origin(&self) -> Point {
-        self.as_ref().origin.into()
-    }
+    pub fn origin(&self) -> Point { self.as_ref().origin.into() }
 
     /// Set during [`Command::FrameSetup`] if the output image size differs from the input. width and height are the size of the output buffer, and origin is the point the input should map to in the output.
     /// To create a 5-pixel drop shadow up and left, set origin to (5, 5).
-    pub fn set_origin(&mut self, origin: Point) {
-        self.as_mut().origin = origin.into();
-    }
+    pub fn set_origin(&mut self, origin: Point) { self.as_mut().origin = origin.into(); }
 
     /// After Effects displays any string you put here (checked and cleared after every command selector).
     pub fn set_return_msg(&mut self, msg: &str) {
@@ -74,9 +56,7 @@ impl OutData {
     }
 
     /// Whether the plug-in already supplied a message for the current command.
-    pub fn has_return_msg(&self) -> bool {
-        self.as_ref().return_msg[0] != 0
-    }
+    pub fn has_return_msg(&self) -> bool { self.as_ref().return_msg[0] != 0 }
 
     /// After Effects displays any string you put here as an error (checked and cleared after every command selector).
     pub fn set_error_msg(&mut self, msg: &str) {
@@ -85,19 +65,13 @@ impl OutData {
     }
 
     /// Set this flag to the version of your plug-in code. After Effects uses this data to decide which of duplicate effects to load.
-    pub fn set_version(&mut self, v: u32) {
-        self.as_mut().my_version = v as ae_sys::A_u_long;
-    }
+    pub fn set_version(&mut self, v: u32) { self.as_mut().my_version = v as ae_sys::A_u_long; }
 
     /// Send messages to After Effects. OR together multiple values.
-    pub fn set_out_flags(&mut self, v: OutFlags) {
-        self.as_mut().out_flags = v.into();
-    }
+    pub fn set_out_flags(&mut self, v: OutFlags) { self.as_mut().out_flags = v.into(); }
 
     /// Send messages to After Effects. OR together multiple values.
-    pub fn set_out_flags2(&mut self, v: OutFlags2) {
-        self.as_mut().out_flags2 = v.into();
-    }
+    pub fn set_out_flags2(&mut self, v: OutFlags2) { self.as_mut().out_flags2 = v.into(); }
 
     /// Send messages to After Effects. OR together multiple values.
     pub fn set_out_flag(&mut self, flag: OutFlags, enabled: bool) {
@@ -118,9 +92,7 @@ impl OutData {
     }
 
     /// Set the [`OutFlags::ForceRerender`] flag
-    pub fn set_force_rerender(&mut self) {
-        self.set_out_flag(OutFlags::ForceRerender, true);
-    }
+    pub fn set_force_rerender(&mut self) { self.set_out_flag(OutFlags::ForceRerender, true); }
 
     /// Data you (might have) allocated during [`Command::FrameSetup`].
     /// This is never written to disk; it was used to pass information from your [`Command::FrameSetup`] response to your [`Command::Render`] or [`Command::FrameSetdown`]
@@ -191,7 +163,6 @@ define_enum! {
         AudioEffectOnly              = ae_sys::PF_OutFlag_AUDIO_EFFECT_ONLY,
     }
 }
-
 
 define_enum! {
     ae_sys::PF_OutFlags2,

--- a/after-effects/src/pf/parameters.rs
+++ b/after-effects/src/pf/parameters.rs
@@ -1,9 +1,9 @@
 use super::*;
-use std::ffi::{ CStr, CString };
 use ae_sys::PF_PathID;
-use serde::{de::DeserializeOwned, Serialize};
 #[cfg(target_os = "macos")]
 use objc2_core_foundation::{CFRange, CFString};
+use serde::{Serialize, de::DeserializeOwned};
+use std::ffi::{CStr, CString};
 
 const MAX_NAME_LEN: usize = 32;
 
@@ -144,15 +144,19 @@ impl AngleDef<'_> {
         self.def.dephault = Fixed::from(v).as_fixed();
         self
     }
-    pub fn default(&self) -> f32 {
-        Fixed::from_fixed(self.def.dephault).into()
-    }
+
+    pub fn default(&self) -> f32 { Fixed::from_fixed(self.def.dephault).into() }
+
     pub fn float_value(&self) -> Result<f64, Error> {
         if self._in_data.is_null() || self._parent_ptr.is_none() {
             return Err(Error::InvalidParms);
         }
-        Ok(pf::suites::AngleParam::new()?
-            .floating_point_value_from_angle_def(unsafe { (*self._in_data).effect_ref }, self._parent_ptr.unwrap())?)
+        Ok(
+            pf::suites::AngleParam::new()?.floating_point_value_from_angle_def(
+                unsafe { (*self._in_data).effect_ref },
+                self._parent_ptr.unwrap(),
+            )?,
+        )
     }
 }
 // ―――――――――――――――――――――――――――――――――――― Angle ―――――――――――――――――――――――――――――――――――――
@@ -185,17 +189,16 @@ impl<'a> CheckBoxDef<'_> {
         self.def.dephault = if v { 1 } else { 0 };
         self
     }
-    pub fn default(&self) -> bool {
-        self.def.dephault != 0
-    }
+
+    pub fn default(&self) -> bool { self.def.dephault != 0 }
+
     pub fn set_label(&mut self, v: &str) -> &mut Self {
         self.label = CString::new(v).unwrap();
         self.def.u.nameptr = self.label.as_ptr();
         self
     }
-    pub fn label(&self) -> &str {
-        unsafe { CStr::from_ptr(self.def.u.nameptr).to_str().unwrap() }
-    }
+
+    pub fn label(&self) -> &str { unsafe { CStr::from_ptr(self.def.u.nameptr).to_str().unwrap() } }
 }
 // ――――――――――――――――――――――――――――――――――― Checkbox ――――――――――――――――――――――――――――――――――――
 
@@ -212,8 +215,12 @@ impl ColorDef<'_> {
         if self._in_data.is_null() || self._parent_ptr.is_none() {
             return Err(Error::InvalidParms);
         }
-        Ok(pf::suites::ColorParam::new()?
-            .floating_point_value_from_color_def(unsafe { (*self._in_data).effect_ref }, self._parent_ptr.unwrap())?)
+        Ok(
+            pf::suites::ColorParam::new()?.floating_point_value_from_color_def(
+                unsafe { (*self._in_data).effect_ref },
+                self._parent_ptr.unwrap(),
+            )?,
+        )
     }
 }
 // ―――――――――――――――――――――――――――――――――――― Color ――――――――――――――――――――――――――――――――――――――
@@ -258,21 +265,24 @@ impl FloatSliderDef<'_> {
         self.def.display_flags = flags.bits() as _;
         self
     }
+
     pub fn display_flags(&self) -> ValueDisplayFlag {
         ValueDisplayFlag::from_bits_truncate(self.def.display_flags as _)
     }
+
     pub fn set_flags(&mut self, flags: FSliderFlag) -> &mut Self {
         self.def.fs_flags = flags.bits() as _;
         self
     }
-    pub fn flags(&self) -> FSliderFlag {
-        FSliderFlag::from_bits_truncate(self.def.fs_flags as _)
-    }
+
+    pub fn flags(&self) -> FSliderFlag { FSliderFlag::from_bits_truncate(self.def.fs_flags as _) }
+
     pub fn set_exponent(&mut self, v: f32) -> &mut Self {
         self.def.exponent = v;
         self.def.useExponent = 1;
         self
     }
+
     pub fn exponent(&self) -> Option<f32> {
         if self.def.useExponent == 1 {
             Some(self.def.exponent)
@@ -327,9 +337,18 @@ define_param_wrapper! {
     impl y_value: Fixed,
 }
 impl PointDef<'_> {
-    pub fn set_default_x(&mut self, v: f32) -> &mut Self { self.def.x_dephault = Fixed::from(v).as_fixed(); self }
-    pub fn set_default_y(&mut self, v: f32) -> &mut Self { self.def.y_dephault = Fixed::from(v).as_fixed(); self }
+    pub fn set_default_x(&mut self, v: f32) -> &mut Self {
+        self.def.x_dephault = Fixed::from(v).as_fixed();
+        self
+    }
+
+    pub fn set_default_y(&mut self, v: f32) -> &mut Self {
+        self.def.y_dephault = Fixed::from(v).as_fixed();
+        self
+    }
+
     pub fn default_x(&self) -> f32 { Fixed::from_fixed(self.def.x_dephault).into() }
+
     pub fn default_y(&self) -> f32 { Fixed::from_fixed(self.def.y_dephault).into() }
 
     pub fn set_default(&mut self, v: (f32, f32)) -> &mut Self {
@@ -337,8 +356,12 @@ impl PointDef<'_> {
         self.def.y_dephault = Fixed::from(v.1).as_fixed();
         self
     }
+
     pub fn default(&self) -> (f32, f32) {
-        (Fixed::from_fixed(self.def.x_dephault).into(), Fixed::from_fixed(self.def.y_dephault).into())
+        (
+            Fixed::from_fixed(self.def.x_dephault).into(),
+            Fixed::from_fixed(self.def.y_dephault).into(),
+        )
     }
 
     pub fn set_value(&mut self, v: (f32, f32)) -> &mut Self {
@@ -346,15 +369,24 @@ impl PointDef<'_> {
         self.def.y_value = Fixed::from(v.1).as_fixed();
         self
     }
+
     pub fn value(&self) -> (f32, f32) {
-        (Fixed::from_fixed(self.def.x_value).into(), Fixed::from_fixed(self.def.y_value).into())
+        (
+            Fixed::from_fixed(self.def.x_value).into(),
+            Fixed::from_fixed(self.def.y_value).into(),
+        )
     }
+
     pub fn float_value(&self) -> Result<ae_sys::A_FloatPoint, Error> {
         if self._in_data.is_null() || self._parent_ptr.is_none() {
             return Err(Error::InvalidParms);
         }
-        Ok(pf::suites::PointParam::new()?
-            .floating_point_value_from_point_def(unsafe { (*self._in_data).effect_ref }, self._parent_ptr.unwrap())?)
+        Ok(
+            pf::suites::PointParam::new()?.floating_point_value_from_point_def(
+                unsafe { (*self._in_data).effect_ref },
+                self._parent_ptr.unwrap(),
+            )?,
+        )
     }
 }
 
@@ -371,11 +403,25 @@ define_param_wrapper! {
     impl z_value: f64,
 }
 impl Point3DDef<'_> {
-    pub fn set_default_x(&mut self, v: f64) -> &mut Self { self.def.x_dephault = v; self }
-    pub fn set_default_y(&mut self, v: f64) -> &mut Self { self.def.y_dephault = v; self }
-    pub fn set_default_z(&mut self, v: f64) -> &mut Self { self.def.z_dephault = v; self }
+    pub fn set_default_x(&mut self, v: f64) -> &mut Self {
+        self.def.x_dephault = v;
+        self
+    }
+
+    pub fn set_default_y(&mut self, v: f64) -> &mut Self {
+        self.def.y_dephault = v;
+        self
+    }
+
+    pub fn set_default_z(&mut self, v: f64) -> &mut Self {
+        self.def.z_dephault = v;
+        self
+    }
+
     pub fn default_x(&self) -> f64 { self.def.x_dephault }
+
     pub fn default_y(&self) -> f64 { self.def.y_dephault }
+
     pub fn default_z(&self) -> f64 { self.def.z_dephault }
 
     pub fn set_default(&mut self, v: (f64, f64, f64)) -> &mut Self {
@@ -384,8 +430,13 @@ impl Point3DDef<'_> {
         self.def.z_dephault = v.2;
         self
     }
+
     pub fn default(&self) -> (f64, f64, f64) {
-        (self.def.x_dephault, self.def.y_dephault, self.def.z_dephault)
+        (
+            self.def.x_dephault,
+            self.def.y_dephault,
+            self.def.z_dephault,
+        )
     }
 
     pub fn set_value(&mut self, v: (f64, f64, f64)) -> &mut Self {
@@ -394,6 +445,7 @@ impl Point3DDef<'_> {
         self.def.z_value = v.2;
         self
     }
+
     pub fn value(&self) -> (f64, f64, f64) {
         (self.def.x_value, self.def.y_value, self.def.z_value)
     }
@@ -417,6 +469,7 @@ impl<'a> PopupDef<'a> {
         self.def.u.namesptr = self.options.as_ptr();
         self.def.num_choices = options.len().try_into().unwrap();
     }
+
     pub fn options(&self) -> Vec<&str> {
         let options = unsafe { CStr::from_ptr(self.def.u.namesptr).to_str().unwrap() };
         options.split('|').collect()
@@ -434,11 +487,16 @@ impl<'a> LayerDef<'a> {
     pub fn set_default_to_this_layer(&mut self) {
         self.def.dephault = ae_sys::PF_LayerDefault_MYSELF;
     }
+
     pub fn value(&self) -> Option<Layer> {
         if self.def.data.is_null() {
             None
         } else {
-            Some(Layer::from_raw(&*self.def as *const _ as _, self._in_data, None))
+            Some(Layer::from_raw(
+                &*self.def as *const _ as _,
+                self._in_data,
+                None,
+            ))
         }
     }
 }
@@ -448,14 +506,10 @@ impl<'a> LayerDef<'a> {
 #[allow(dead_code)]
 pub struct NullDef<'a>(&'a ());
 impl<'a> NullDef<'a> {
-    pub fn new() -> Self {
-        Self(&())
-    }
+    pub fn new() -> Self { Self(&()) }
 }
 impl<'p> Into<Param<'p>> for NullDef<'p> {
-    fn into(self) -> Param<'p> {
-        Param::Null(self)
-    }
+    fn into(self) -> Param<'p> { Param::Null(self) }
 }
 // ―――――――――――――――――――――――――――――――――――― Null ―――――――――――――――――――――――――――――――――――――
 
@@ -480,6 +534,7 @@ impl ArbitraryDef<'_> {
         self.set_value_changed();
         Ok(self)
     }
+
     pub fn value<T>(&self) -> Result<BorrowedHandleLock<T>, Error> {
         if self.def.value.is_null() {
             return Err(Error::InvalidParms);
@@ -511,21 +566,18 @@ impl std::fmt::Debug for ArbParamsExtra {
 }
 
 impl ArbParamsExtra {
-    pub fn id(&self) -> i16 {
-        self.as_ref().id as _
-    }
+    pub fn id(&self) -> i16 { self.as_ref().id as _ }
 
     pub fn refcon(&self) -> *mut std::ffi::c_void {
         unsafe { self.as_ref().u.new_func_params.refconPV }
     }
 
-    pub fn which_function(&self) -> u32 {
-        self.as_ref().which_function as _
-    }
+    pub fn which_function(&self) -> u32 { self.as_ref().which_function as _ }
 
     pub fn dispatch<T, P>(&mut self, param: P) -> Result<(), Error>
-    where T: ArbitraryData<T> + Default + DeserializeOwned + Serialize + PartialEq + PartialOrd,
-          P: Eq + PartialEq + Hash + Copy + Debug
+    where
+        T: ArbitraryData<T> + Default + DeserializeOwned + Serialize + PartialEq + PartialOrd,
+        P: Eq + PartialEq + Hash + Copy + Debug,
     {
         let param_id = Parameters::param_id(param) as i16;
         if self.id() != param_id {
@@ -554,7 +606,10 @@ impl ArbParamsExtra {
                 // disposes then handle when it goes out of scope
                 // and is dropped just after.
                 if unsafe { !self.as_ref().u.dispose_func_params.arbH.is_null() } {
-                    Handle::<T>::from_raw(unsafe { self.as_ref().u.dispose_func_params.arbH }, true)?;
+                    Handle::<T>::from_raw(
+                        unsafe { self.as_ref().u.dispose_func_params.arbH },
+                        true,
+                    )?;
                 }
             }
 
@@ -575,11 +630,20 @@ impl ArbParamsExtra {
                     return Ok(());
                 }
 
-                let mut src_handle = Handle::<T>::from_raw(self.as_ref().u.copy_func_params.src_arbH, false)?;
+                let mut src_handle =
+                    Handle::<T>::from_raw(self.as_ref().u.copy_func_params.src_arbH, false)?;
                 let lock = src_handle.lock()?;
 
-                let serialized = bincode::serde::encode_to_vec::<&T, _>(lock.as_ref()?, bincode::config::legacy()).map_err(|_| Error::InternalStructDamaged)?;
-                let deserialized = bincode::serde::decode_from_slice::<T, _>(&serialized, bincode::config::legacy()).map_err(|_| Error::InternalStructDamaged)?;
+                let serialized = bincode::serde::encode_to_vec::<&T, _>(
+                    lock.as_ref()?,
+                    bincode::config::legacy(),
+                )
+                .map_err(|_| Error::InternalStructDamaged)?;
+                let deserialized = bincode::serde::decode_from_slice::<T, _>(
+                    &serialized,
+                    bincode::config::legacy(),
+                )
+                .map_err(|_| Error::InternalStructDamaged)?;
                 let new_handle = Handle::<T>::new(deserialized.0)?;
 
                 self.as_ref()
@@ -592,10 +656,15 @@ impl ArbParamsExtra {
             ae_sys::PF_Arbitrary_FLAT_SIZE_FUNC => unsafe {
                 // log::info!("FLAT_SIZE_FUNC");
 
-                let mut handle = Handle::<T>::from_raw(self.as_ref().u.flat_size_func_params.arbH, false)?;
+                let mut handle =
+                    Handle::<T>::from_raw(self.as_ref().u.flat_size_func_params.arbH, false)?;
                 let lock = handle.lock()?;
 
-                let serialized = bincode::serde::encode_to_vec::<&T, _>(lock.as_ref()?, bincode::config::legacy()).map_err(|_| Error::InternalStructDamaged)?;
+                let serialized = bincode::serde::encode_to_vec::<&T, _>(
+                    lock.as_ref()?,
+                    bincode::config::legacy(),
+                )
+                .map_err(|_| Error::InternalStructDamaged)?;
 
                 self.as_ref()
                     .u
@@ -608,21 +677,24 @@ impl ArbParamsExtra {
                 // log::info!("FLATTEN_FUNC");
                 assert!(!self.as_ref().u.unflatten_func_params.flat_dataPV.is_null());
 
-                let mut handle = Handle::<T>::from_raw(self.as_ref().u.flatten_func_params.arbH, false)?;
+                let mut handle =
+                    Handle::<T>::from_raw(self.as_ref().u.flatten_func_params.arbH, false)?;
                 let lock = handle.lock()?;
 
-                let serialized = bincode::serde::encode_to_vec::<&T, _>(lock.as_ref()?, bincode::config::legacy()).map_err(|_| Error::InternalStructDamaged)?;
+                let serialized = bincode::serde::encode_to_vec::<&T, _>(
+                    lock.as_ref()?,
+                    bincode::config::legacy(),
+                )
+                .map_err(|_| Error::InternalStructDamaged)?;
 
-                assert!(
-                    serialized.len() <= self.as_ref().u.flatten_func_params.buf_sizeLu as _
-                );
+                assert!(serialized.len() <= self.as_ref().u.flatten_func_params.buf_sizeLu as _);
 
                 std::ptr::copy_nonoverlapping(
                     serialized.as_ptr(),
                     self.as_ref().u.flatten_func_params.flat_dataPV as _,
                     serialized.len(),
                 );
-            }
+            },
 
             ae_sys::PF_Arbitrary_UNFLATTEN_FUNC => unsafe {
                 // log::info!("UNFLATTEN_FUNC");
@@ -630,9 +702,13 @@ impl ArbParamsExtra {
 
                 let serialized = std::slice::from_raw_parts(
                     self.as_ref().u.unflatten_func_params.flat_dataPV as *mut u8,
-                    self.as_ref().u.unflatten_func_params.buf_sizeLu as _
+                    self.as_ref().u.unflatten_func_params.buf_sizeLu as _,
                 );
-                let t = bincode::serde::decode_from_slice::<T, _>(serialized, bincode::config::legacy()).map_err(|_| Error::InternalStructDamaged)?;
+                let t = bincode::serde::decode_from_slice::<T, _>(
+                    serialized,
+                    bincode::config::legacy(),
+                )
+                .map_err(|_| Error::InternalStructDamaged)?;
                 let handle = Handle::<T>::new(t.0)?;
 
                 self.as_ref()
@@ -645,14 +721,18 @@ impl ArbParamsExtra {
             ae_sys::PF_Arbitrary_INTERP_FUNC => unsafe {
                 // log::info!("INTERP_FUNC");
 
-                let mut left = Handle::<T>::from_raw(self.as_ref().u.interp_func_params.left_arbH, false)?;
+                let mut left =
+                    Handle::<T>::from_raw(self.as_ref().u.interp_func_params.left_arbH, false)?;
                 let left_lock = left.lock()?;
 
-                let mut right = Handle::<T>::from_raw(self.as_ref().u.interp_func_params.right_arbH, false)?;
+                let mut right =
+                    Handle::<T>::from_raw(self.as_ref().u.interp_func_params.right_arbH, false)?;
                 let right_lock = right.lock()?;
 
                 let interpolated = Handle::<T>::new(
-                    left_lock.as_ref()?.interpolate(right_lock.as_ref()?, self.as_ref().u.interp_func_params.tF)
+                    left_lock
+                        .as_ref()?
+                        .interpolate(right_lock.as_ref()?, self.as_ref().u.interp_func_params.tF),
                 )?;
 
                 self.as_ref()
@@ -665,11 +745,17 @@ impl ArbParamsExtra {
             ae_sys::PF_Arbitrary_COMPARE_FUNC => {
                 // log::info!("COMPARE_FUNC");
 
-                let mut handle_a = Handle::<T>::from_raw(unsafe { self.as_ref().u.compare_func_params.a_arbH }, false)?;
+                let mut handle_a = Handle::<T>::from_raw(
+                    unsafe { self.as_ref().u.compare_func_params.a_arbH },
+                    false,
+                )?;
                 let handle_a_lock = handle_a.lock()?;
                 let a = handle_a_lock.as_ref()?;
 
-                let mut handle_b = Handle::<T>::from_raw(unsafe { self.as_ref().u.compare_func_params.b_arbH }, false)?;
+                let mut handle_b = Handle::<T>::from_raw(
+                    unsafe { self.as_ref().u.compare_func_params.b_arbH },
+                    false,
+                )?;
                 let handle_b_lock = handle_b.lock()?;
                 let b = handle_b_lock.as_ref()?;
 
@@ -711,15 +797,20 @@ impl ArbParamsExtra {
             ae_sys::PF_Arbitrary_PRINT_SIZE_FUNC => unsafe {
                 // log::info!("PRINT_SIZE_FUNC");
 
-                let mut handle = Handle::<T>::from_raw(self.as_ref().u.print_size_func_params.arbH, false)?;
+                let mut handle =
+                    Handle::<T>::from_raw(self.as_ref().u.print_size_func_params.arbH, false)?;
                 let lock = handle.lock()?;
 
-                let serialized = serde_json::to_string::<T>(lock.as_ref()?).map_err(|_| Error::InternalStructDamaged)?;
-                let cstr = std::ffi::CString::new(serialized).map_err(|_| Error::InternalStructDamaged)?;
+                let serialized = serde_json::to_string::<T>(lock.as_ref()?)
+                    .map_err(|_| Error::InternalStructDamaged)?;
+                let cstr =
+                    std::ffi::CString::new(serialized).map_err(|_| Error::InternalStructDamaged)?;
 
-                self.as_ref().u.print_size_func_params.print_sizePLu.write(
-                    cstr.as_bytes_with_nul().len() as _,
-                );
+                self.as_ref()
+                    .u
+                    .print_size_func_params
+                    .print_sizePLu
+                    .write(cstr.as_bytes_with_nul().len() as _);
             },
 
             // Print arbitrary data into a string as JSON.
@@ -727,27 +818,35 @@ impl ArbParamsExtra {
             ae_sys::PF_Arbitrary_PRINT_FUNC => unsafe {
                 // log::info!("PRINT_FUNC");
 
-                let mut handle = Handle::<T>::from_raw(self.as_ref().u.print_func_params.arbH, false)?;
+                let mut handle =
+                    Handle::<T>::from_raw(self.as_ref().u.print_func_params.arbH, false)?;
                 let lock = handle.lock()?;
 
-                let serialized = serde_json::to_string::<T>(lock.as_ref()?).map_err(|_| Error::InternalStructDamaged)?;
-                let cstr = std::ffi::CString::new(serialized).map_err(|_| Error::InternalStructDamaged)?;
+                let serialized = serde_json::to_string::<T>(lock.as_ref()?)
+                    .map_err(|_| Error::InternalStructDamaged)?;
+                let cstr =
+                    std::ffi::CString::new(serialized).map_err(|_| Error::InternalStructDamaged)?;
                 let cstr = cstr.as_bytes_with_nul();
 
-                if cstr.len() <= self.as_ref().u.print_func_params.print_sizeLu as _ && self.as_ref().u.print_func_params.print_flags == 0 {
+                if cstr.len() <= self.as_ref().u.print_func_params.print_sizeLu as _
+                    && self.as_ref().u.print_func_params.print_flags == 0
+                {
                     std::ptr::copy_nonoverlapping(
                         cstr.as_ptr(),
                         self.as_ref().u.print_func_params.print_bufferPC as _,
                         cstr.len(),
                     );
                 }
-            }
+            },
             ae_sys::PF_Arbitrary_SCAN_FUNC => unsafe {
                 // log::info!("SCAN_FUNC");
 
-                let cstr = CStr::from_ptr(self.as_ref().u.scan_func_params.bufPC).to_str().map_err(|_| Error::InternalStructDamaged)?;
+                let cstr = CStr::from_ptr(self.as_ref().u.scan_func_params.bufPC)
+                    .to_str()
+                    .map_err(|_| Error::InternalStructDamaged)?;
 
-                let t = serde_json::from_str::<T>(cstr).map_err(|_| Error::InternalStructDamaged)?;
+                let t =
+                    serde_json::from_str::<T>(cstr).map_err(|_| Error::InternalStructDamaged)?;
                 let handle = Handle::<T>::new(t)?;
 
                 self.as_ref()
@@ -808,19 +907,19 @@ pub enum Param<'p> {
 impl Debug for Param<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Param::Angle(_)       => write!(f, "Angle"),
-            Param::Arbitrary(_)   => write!(f, "Arbitrary"),
-            Param::Button(_)      => write!(f, "Button"),
-            Param::CheckBox(_)    => write!(f, "CheckBox"),
-            Param::Color(_)       => write!(f, "Color"),
+            Param::Angle(_) => write!(f, "Angle"),
+            Param::Arbitrary(_) => write!(f, "Arbitrary"),
+            Param::Button(_) => write!(f, "Button"),
+            Param::CheckBox(_) => write!(f, "CheckBox"),
+            Param::Color(_) => write!(f, "Color"),
             Param::FloatSlider(_) => write!(f, "FloatSlider"),
-            Param::Path(_)        => write!(f, "Path"),
-            Param::Point(_)       => write!(f, "Point"),
-            Param::Point3D(_)     => write!(f, "Point3D"),
-            Param::Popup(_)       => write!(f, "Popup"),
-            Param::Slider(_)      => write!(f, "Slider"),
-            Param::Layer(_)       => write!(f, "Layer"),
-            Param::Null(_)        => write!(f, "Null"),
+            Param::Path(_) => write!(f, "Path"),
+            Param::Point(_) => write!(f, "Point"),
+            Param::Point3D(_) => write!(f, "Point3D"),
+            Param::Popup(_) => write!(f, "Popup"),
+            Param::Slider(_) => write!(f, "Slider"),
+            Param::Layer(_) => write!(f, "Layer"),
+            Param::Null(_) => write!(f, "Null"),
         }
     }
 }
@@ -834,6 +933,32 @@ pub struct ParamDef<'p> {
 }
 
 impl<'p> ParamDef<'p> {
+    define_param_cast!("popup", Popup, PopupDef);
+
+    define_param_cast!("angle", Angle, AngleDef);
+
+    define_param_cast!("checkbox", CheckBox, CheckBoxDef);
+
+    define_param_cast!("color", Color, ColorDef);
+
+    define_param_cast!("slider", Slider, SliderDef);
+
+    define_param_cast!("float_slider", FloatSlider, FloatSliderDef);
+
+    define_param_cast!("button", Button, ButtonDef);
+
+    define_param_cast!("arbitrary", Arbitrary, ArbitraryDef);
+
+    define_param_cast!("point", Point, PointDef);
+
+    define_param_cast!("point3d", Point3D, Point3DDef);
+
+    define_param_cast!("path", Path, PathDef);
+
+    define_param_cast!("layer", Layer, LayerDef);
+
+    define_param_cast!("null", Null, NullDef);
+
     pub fn new(in_data: InData) -> Self {
         Self {
             param_def: Ownership::Rust(unsafe { std::mem::zeroed() }),
@@ -843,16 +968,11 @@ impl<'p> ParamDef<'p> {
         }
     }
 
-    pub fn as_ref(&self) -> &ae_sys::PF_ParamDef {
-        &*self.param_def
-    }
-    pub fn as_mut(&mut self) -> &mut ae_sys::PF_ParamDef {
-        &mut *self.param_def
-    }
+    pub fn as_ref(&self) -> &ae_sys::PF_ParamDef { &*self.param_def }
 
-    pub fn index(&self) -> Option<i32> {
-        self.index
-    }
+    pub fn as_mut(&mut self) -> &mut ae_sys::PF_ParamDef { &mut *self.param_def }
+
+    pub fn index(&self) -> Option<i32> { self.index }
 
     pub fn update_param_ui(&self) -> Result<(), Error> {
         if let Some(index) = self.index {
@@ -861,16 +981,20 @@ impl<'p> ParamDef<'p> {
             Err(Error::InvalidIndex)
         }
     }
+
     pub fn keyframe_count(&self) -> Result<i32, Error> {
         if let Some(index) = self.index {
-            pf::suites::ParamUtils::new()?
-                .keyframe_count(self.in_data.effect_ref(), index)
+            pf::suites::ParamUtils::new()?.keyframe_count(self.in_data.effect_ref(), index)
         } else {
             Err(Error::InvalidIndex)
         }
     }
 
-    pub fn from_raw(in_data: InData, param_def: &'p mut ae_sys::PF_ParamDef, index: Option<i32>) -> Self {
+    pub fn from_raw(
+        in_data: InData,
+        param_def: &'p mut ae_sys::PF_ParamDef,
+        index: Option<i32>,
+    ) -> Self {
         Self {
             param_def: Ownership::AfterEffectsMut(param_def),
             checkin_on_drop: false,
@@ -887,8 +1011,17 @@ impl<'p> ParamDef<'p> {
         Ok(())
     }
 
-    pub fn checkout(in_data: InData, index: i32, what_time: i32, time_step: i32, time_scale: u32, expected_type: Option<ParamType>) -> Result<Self, Error> {
-        let mut param_def = in_data.interact().checkout_param(index, what_time, time_step, time_scale)?;
+    pub fn checkout(
+        in_data: InData,
+        index: i32,
+        what_time: i32,
+        time_step: i32,
+        time_scale: u32,
+        expected_type: Option<ParamType>,
+    ) -> Result<Self, Error> {
+        let mut param_def = in_data
+            .interact()
+            .checkout_param(index, what_time, time_step, time_scale)?;
         if param_def.param_type == ae_sys::PF_Param_RESERVED {
             return Err(Error::InvalidIndex);
         }
@@ -962,38 +1095,75 @@ impl<'p> ParamDef<'p> {
         }
     }
 
-    define_param_cast!("popup",        Popup,       PopupDef);
-    define_param_cast!("angle",        Angle,       AngleDef);
-    define_param_cast!("checkbox",     CheckBox,    CheckBoxDef);
-    define_param_cast!("color",        Color,       ColorDef);
-    define_param_cast!("slider",       Slider,      SliderDef);
-    define_param_cast!("float_slider", FloatSlider, FloatSliderDef);
-    define_param_cast!("button",       Button,      ButtonDef);
-    define_param_cast!("arbitrary",    Arbitrary,   ArbitraryDef);
-    define_param_cast!("point",        Point,       PointDef);
-    define_param_cast!("point3d",      Point3D,     Point3DDef);
-    define_param_cast!("path",         Path,        PathDef);
-    define_param_cast!("layer",        Layer,       LayerDef);
-    define_param_cast!("null",         Null,        NullDef);
-
-    pub fn as_param<'a>(&'a self) -> Result<Param<'a>, Error> where 'p: 'a {
+    pub fn as_param<'a>(&'a self) -> Result<Param<'a>, Error>
+    where
+        'p: 'a,
+    {
         let param_def = &*self.param_def;
         let parent_ptr = param_def as *const _;
         unsafe {
             match param_def.param_type {
-                ae_sys::PF_Param_ANGLE          => Ok(Param::Angle      (AngleDef      ::from_ref(&param_def.u.ad,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_ARBITRARY_DATA => Ok(Param::Arbitrary  (ArbitraryDef  ::from_ref(&param_def.u.arb_d,     self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_BUTTON         => Ok(Param::Button     (ButtonDef     ::from_ref(&param_def.u.button_d,  self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_CHECKBOX       => Ok(Param::CheckBox   (CheckBoxDef   ::from_ref(&param_def.u.bd,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_COLOR          => Ok(Param::Color      (ColorDef      ::from_ref(&param_def.u.cd,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_FLOAT_SLIDER   => Ok(Param::FloatSlider(FloatSliderDef::from_ref(&param_def.u.fs_d,      self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_POPUP          => Ok(Param::Popup      (PopupDef      ::from_ref(&param_def.u.pd,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_SLIDER         => Ok(Param::Slider     (SliderDef     ::from_ref(&param_def.u.sd,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_POINT          => Ok(Param::Point      (PointDef      ::from_ref(&param_def.u.td,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_POINT_3D       => Ok(Param::Point3D    (Point3DDef    ::from_ref(&param_def.u.point3d_d, self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_PATH           => Ok(Param::Path       (PathDef       ::from_ref(&param_def.u.path_d,    self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_LAYER          => Ok(Param::Layer      (LayerDef      ::from_ref(&param_def.u.ld,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_NO_DATA        => Ok(Param::Null       (NullDef       ::new())),
+                ae_sys::PF_Param_ANGLE => Ok(Param::Angle(AngleDef::from_ref(
+                    &param_def.u.ad,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_ARBITRARY_DATA => Ok(Param::Arbitrary(ArbitraryDef::from_ref(
+                    &param_def.u.arb_d,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_BUTTON => Ok(Param::Button(ButtonDef::from_ref(
+                    &param_def.u.button_d,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_CHECKBOX => Ok(Param::CheckBox(CheckBoxDef::from_ref(
+                    &param_def.u.bd,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_COLOR => Ok(Param::Color(ColorDef::from_ref(
+                    &param_def.u.cd,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_FLOAT_SLIDER => Ok(Param::FloatSlider(FloatSliderDef::from_ref(
+                    &param_def.u.fs_d,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_POPUP => Ok(Param::Popup(PopupDef::from_ref(
+                    &param_def.u.pd,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_SLIDER => Ok(Param::Slider(SliderDef::from_ref(
+                    &param_def.u.sd,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_POINT => Ok(Param::Point(PointDef::from_ref(
+                    &param_def.u.td,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_POINT_3D => Ok(Param::Point3D(Point3DDef::from_ref(
+                    &param_def.u.point3d_d,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_PATH => Ok(Param::Path(PathDef::from_ref(
+                    &param_def.u.path_d,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_LAYER => Ok(Param::Layer(LayerDef::from_ref(
+                    &param_def.u.ld,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_NO_DATA => Ok(Param::Null(NullDef::new())),
                 _ => {
                     log::error!("Invalid parameter type: {}", param_def.param_type);
                     Err(Error::InvalidParms)
@@ -1002,24 +1172,75 @@ impl<'p> ParamDef<'p> {
         }
     }
 
-    pub fn as_param_mut<'a>(&'a mut self) -> Result<Param<'a>, Error> where 'p: 'a {
+    pub fn as_param_mut<'a>(&'a mut self) -> Result<Param<'a>, Error>
+    where
+        'p: 'a,
+    {
         let param_def = &mut *self.param_def;
         let parent_ptr = param_def as *const _;
         unsafe {
             match param_def.param_type {
-                ae_sys::PF_Param_ANGLE          => Ok(Param::Angle      (AngleDef      ::from_mut(&mut param_def.u.ad,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_ARBITRARY_DATA => Ok(Param::Arbitrary  (ArbitraryDef  ::from_mut(&mut param_def.u.arb_d,     self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_BUTTON         => Ok(Param::Button     (ButtonDef     ::from_mut(&mut param_def.u.button_d,  self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_CHECKBOX       => Ok(Param::CheckBox   (CheckBoxDef   ::from_mut(&mut param_def.u.bd,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_COLOR          => Ok(Param::Color      (ColorDef      ::from_mut(&mut param_def.u.cd,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_FLOAT_SLIDER   => Ok(Param::FloatSlider(FloatSliderDef::from_mut(&mut param_def.u.fs_d,      self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_POPUP          => Ok(Param::Popup      (PopupDef      ::from_mut(&mut param_def.u.pd,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_SLIDER         => Ok(Param::Slider     (SliderDef     ::from_mut(&mut param_def.u.sd,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_POINT          => Ok(Param::Point      (PointDef      ::from_mut(&mut param_def.u.td,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_POINT_3D       => Ok(Param::Point3D    (Point3DDef    ::from_mut(&mut param_def.u.point3d_d, self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_PATH           => Ok(Param::Path       (PathDef       ::from_mut(&mut param_def.u.path_d,    self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_LAYER          => Ok(Param::Layer      (LayerDef      ::from_mut(&mut param_def.u.ld,        self.in_data.as_ptr(), parent_ptr))),
-                ae_sys::PF_Param_NO_DATA        => Ok(Param::Null       (NullDef       ::new())),
+                ae_sys::PF_Param_ANGLE => Ok(Param::Angle(AngleDef::from_mut(
+                    &mut param_def.u.ad,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_ARBITRARY_DATA => Ok(Param::Arbitrary(ArbitraryDef::from_mut(
+                    &mut param_def.u.arb_d,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_BUTTON => Ok(Param::Button(ButtonDef::from_mut(
+                    &mut param_def.u.button_d,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_CHECKBOX => Ok(Param::CheckBox(CheckBoxDef::from_mut(
+                    &mut param_def.u.bd,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_COLOR => Ok(Param::Color(ColorDef::from_mut(
+                    &mut param_def.u.cd,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_FLOAT_SLIDER => Ok(Param::FloatSlider(FloatSliderDef::from_mut(
+                    &mut param_def.u.fs_d,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_POPUP => Ok(Param::Popup(PopupDef::from_mut(
+                    &mut param_def.u.pd,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_SLIDER => Ok(Param::Slider(SliderDef::from_mut(
+                    &mut param_def.u.sd,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_POINT => Ok(Param::Point(PointDef::from_mut(
+                    &mut param_def.u.td,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_POINT_3D => Ok(Param::Point3D(Point3DDef::from_mut(
+                    &mut param_def.u.point3d_d,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_PATH => Ok(Param::Path(PathDef::from_mut(
+                    &mut param_def.u.path_d,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_LAYER => Ok(Param::Layer(LayerDef::from_mut(
+                    &mut param_def.u.ld,
+                    self.in_data.as_ptr(),
+                    parent_ptr,
+                ))),
+                ae_sys::PF_Param_NO_DATA => Ok(Param::Null(NullDef::new())),
                 _ => {
                     log::error!("Invalid parameter type: {}", param_def.param_type);
                     Err(Error::InvalidParms)
@@ -1049,9 +1270,8 @@ impl<'p> ParamDef<'p> {
                 | ae_sys::PF_Param_NO_DATA
         )
     }
-    pub fn param_type(&self) -> ParamType {
-        self.param_def.param_type.into()
-    }
+
+    pub fn param_type(&self) -> ParamType { self.param_def.param_type.into() }
 
     pub unsafe fn layer_def(&mut self) -> *mut ae_sys::PF_LayerDef {
         unsafe { &mut self.param_def.u.ld }
@@ -1068,24 +1288,24 @@ impl<'p> ParamDef<'p> {
             #[cfg(target_os = "macos")]
             unsafe {
                 let cfstr = CFString::from_str(name);
-                let encoding = CFString::system_encoding(); 
+                let encoding = CFString::system_encoding();
                 let length = cfstr.length();
                 let max_size = CFString::maximum_size_for_encoding(length, encoding);
-                
+
                 let mut buffer = vec![0u8; max_size as usize];
                 let mut used_len = 0;
-                
-                 CFString::bytes(
+
+                CFString::bytes(
                     &cfstr,
                     CFRange::new(0, length),
                     encoding,
-                    b'?',  // replacement for unconvertible characters
+                    b'?', // replacement for unconvertible characters
                     false,
                     buffer.as_mut_ptr(),
                     max_size,
                     &mut used_len,
                 );
-                
+
                 buffer.truncate(used_len as usize);
                 buffer
             }
@@ -1093,14 +1313,32 @@ impl<'p> ParamDef<'p> {
             unsafe {
                 use std::ffi::OsStr;
                 use std::os::windows::ffi::OsStrExt;
-                use windows_sys::Win32::Globalization::{WideCharToMultiByte, CP_OEMCP};
+                use windows_sys::Win32::Globalization::{CP_OEMCP, WideCharToMultiByte};
                 let mut wstr: Vec<u16> = OsStr::new(name).encode_wide().collect();
                 if !wstr.is_empty() {
                     wstr.push(0); // Null-terminate
-                    let len = WideCharToMultiByte(CP_OEMCP, 0, wstr.as_ptr(), wstr.len() as i32, std::ptr::null_mut(), 0, std::ptr::null(), std::ptr::null_mut());
+                    let len = WideCharToMultiByte(
+                        CP_OEMCP,
+                        0,
+                        wstr.as_ptr(),
+                        wstr.len() as i32,
+                        std::ptr::null_mut(),
+                        0,
+                        std::ptr::null(),
+                        std::ptr::null_mut(),
+                    );
                     if len > 0 {
                         let mut bytes: Vec<u8> = Vec::with_capacity(len as usize);
-                        let len = WideCharToMultiByte(CP_OEMCP, 0, wstr.as_ptr(), wstr.len() as i32, bytes.as_mut_ptr() as _, len, std::ptr::null(), std::ptr::null_mut());
+                        let len = WideCharToMultiByte(
+                            CP_OEMCP,
+                            0,
+                            wstr.as_ptr(),
+                            wstr.len() as i32,
+                            bytes.as_mut_ptr() as _,
+                            len,
+                            std::ptr::null(),
+                            std::ptr::null_mut(),
+                        );
                         if len > 0 {
                             bytes.set_len(len as usize);
                             bytes
@@ -1122,32 +1360,56 @@ impl<'p> ParamDef<'p> {
             if let Some(last_elem) = bytes.get_mut(MAX_NAME_LEN - 1) {
                 *last_elem = 0;
             }
-            self.param_def.name_do_not_use_directly[0..bytes.len()].copy_from_slice(unsafe { std::mem::transmute(bytes.as_slice()) });
+            self.param_def.name_do_not_use_directly[0..bytes.len()]
+                .copy_from_slice(unsafe { std::mem::transmute(bytes.as_slice()) });
             return Ok(());
         }
 
-        log::error!("Failed to set the parameter name, \"{name}\" is too long or contains invalid characters for the system encoding.");
+        log::error!(
+            "Failed to set the parameter name, \"{name}\" is too long or contains invalid characters for the system encoding."
+        );
         Err(Error::InvalidParms)
     }
 
-    pub fn set_flags       (&mut self, f: ParamFlag)    { self.param_def.flags           = f.bits() as _; }
-    pub fn set_change_flags(&mut self, f: ChangeFlag)   { self.param_def.uu.change_flags = f.bits() as _; }
-    pub fn set_ui_flags    (&mut self, f: ParamUIFlags) { self.param_def.ui_flags        = f.bits() as _; }
+    pub fn set_flags(&mut self, f: ParamFlag) { self.param_def.flags = f.bits() as _; }
 
-    pub fn set_flag       (&mut self, f: ParamFlag,    set: bool) { let mut v = self.flags();        v.set(f, set); self.set_flags(v);        }
-    pub fn set_change_flag(&mut self, f: ChangeFlag,   set: bool) { let mut v = self.change_flags(); v.set(f, set); self.set_change_flags(v); }
-    pub fn set_ui_flag    (&mut self, f: ParamUIFlags, set: bool) { let mut v = self.ui_flags();     v.set(f, set); self.set_ui_flags(v);     }
-
-    pub fn flags       (&self) -> ParamFlag    {    ParamFlag::from_bits_truncate(self.param_def.flags) }
-    pub fn change_flags(&self) -> ChangeFlag   {   ChangeFlag::from_bits_truncate(unsafe { self.param_def.uu.change_flags }) }
-    pub fn ui_flags    (&self) -> ParamUIFlags { ParamUIFlags::from_bits_truncate(self.param_def.ui_flags) }
-
-    pub fn set_ui_width(&mut self, width: u16) {
-        self.param_def.ui_width = width as _;
+    pub fn set_change_flags(&mut self, f: ChangeFlag) {
+        self.param_def.uu.change_flags = f.bits() as _;
     }
-    pub fn set_ui_height(&mut self, height: u16) {
-        self.param_def.ui_height = height as _;
+
+    pub fn set_ui_flags(&mut self, f: ParamUIFlags) { self.param_def.ui_flags = f.bits() as _; }
+
+    pub fn set_flag(&mut self, f: ParamFlag, set: bool) {
+        let mut v = self.flags();
+        v.set(f, set);
+        self.set_flags(v);
     }
+
+    pub fn set_change_flag(&mut self, f: ChangeFlag, set: bool) {
+        let mut v = self.change_flags();
+        v.set(f, set);
+        self.set_change_flags(v);
+    }
+
+    pub fn set_ui_flag(&mut self, f: ParamUIFlags, set: bool) {
+        let mut v = self.ui_flags();
+        v.set(f, set);
+        self.set_ui_flags(v);
+    }
+
+    pub fn flags(&self) -> ParamFlag { ParamFlag::from_bits_truncate(self.param_def.flags) }
+
+    pub fn change_flags(&self) -> ChangeFlag {
+        ChangeFlag::from_bits_truncate(unsafe { self.param_def.uu.change_flags })
+    }
+
+    pub fn ui_flags(&self) -> ParamUIFlags {
+        ParamUIFlags::from_bits_truncate(self.param_def.ui_flags)
+    }
+
+    pub fn set_ui_width(&mut self, width: u16) { self.param_def.ui_width = width as _; }
+
+    pub fn set_ui_height(&mut self, height: u16) { self.param_def.ui_height = height as _; }
 
     pub fn set_id(&mut self, id: i32) {
         self.param_def.uu.id = id;
@@ -1164,7 +1426,10 @@ impl<'p> ParamDef<'p> {
 impl Drop for ParamDef<'_> {
     fn drop(&mut self) {
         if self.checkin_on_drop {
-            self.in_data.interact().checkin_param(&*self.param_def).unwrap()
+            self.in_data
+                .interact()
+                .checkin_param(&*self.param_def)
+                .unwrap()
         }
     }
 }
@@ -1188,9 +1453,7 @@ pub struct ParamMapInfo {
     pub type_: ParamType,
 }
 impl ParamMapInfo {
-    fn new(index: usize, type_: ParamType) -> Self {
-        Self { index, type_ }
-    }
+    fn new(index: usize, type_: ParamType) -> Self { Self { index, type_ } }
 }
 
 #[derive(Clone)]
@@ -1201,20 +1464,15 @@ pub struct Parameters<'p, P: Eq + PartialEq + Hash + Copy + Debug> {
     params: Vec<ParamDef<'p>>,
 }
 impl<P: Eq + PartialEq + Hash + Copy + Debug> Default for Parameters<'_, P> {
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { Self::new() }
 }
 impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
-    pub fn len(&self) -> usize {
-        self.map.len()
-    }
-    pub fn set_in_data(&mut self, in_data: *const ae_sys::PF_InData) {
-        self.in_data = in_data;
-    }
-    pub fn in_data(&self) -> InData {
-        InData::from_raw(self.in_data)
-    }
+    pub fn len(&self) -> usize { self.map.len() }
+
+    pub fn set_in_data(&mut self, in_data: *const ae_sys::PF_InData) { self.in_data = in_data; }
+
+    pub fn in_data(&self) -> InData { InData::from_raw(self.in_data) }
+
     pub fn new() -> Self {
         Self {
             in_data: std::ptr::null(),
@@ -1223,7 +1481,13 @@ impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
             params: Vec::new(),
         }
     }
-    pub fn with_params(in_data: *const ae_sys::PF_InData, params: &'p [*mut ae_sys::PF_ParamDef], map: Option<&'p HashMap<P, ParamMapInfo>>, num_params: usize) -> Self {
+
+    pub fn with_params(
+        in_data: *const ae_sys::PF_InData,
+        params: &'p [*mut ae_sys::PF_ParamDef],
+        map: Option<&'p HashMap<P, ParamMapInfo>>,
+        num_params: usize,
+    ) -> Self {
         let in_data_obj = InData::from_raw(in_data);
         Self {
             in_data,
@@ -1233,7 +1497,10 @@ impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
                 params
                     .iter()
                     .enumerate()
-                    .map(|(i, p)| { debug_assert!(!p.is_null()); ParamDef::from_raw(in_data_obj, unsafe { &mut **p }, Some(i as i32)) })
+                    .map(|(i, p)| {
+                        debug_assert!(!p.is_null());
+                        ParamDef::from_raw(in_data_obj, unsafe { &mut **p }, Some(i as i32))
+                    })
                     .collect::<Vec<_>>()
             },
             num_params,
@@ -1249,7 +1516,14 @@ impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
         hasher.finish() as i32
     }
 
-    pub fn add_group<F: FnOnce(&mut Self) -> Result<(), Error>>(&mut self, type_start: P, type_end: P, name: &str, start_collapsed: bool, inner_cb: F) -> Result<(), Error> {
+    pub fn add_group<F: FnOnce(&mut Self) -> Result<(), Error>>(
+        &mut self,
+        type_start: P,
+        type_end: P,
+        name: &str,
+        start_collapsed: bool,
+        inner_cb: F,
+    ) -> Result<(), Error> {
         assert!(!self.in_data.is_null());
 
         let mut param_def = ParamDef::new(InData::from_raw(self.in_data));
@@ -1260,7 +1534,10 @@ impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
             param_def.set_flags(ParamFlag::START_COLLAPSED);
         }
         param_def.add(-1)?;
-        self.map.insert(type_start, ParamMapInfo::new(self.num_params, ParamType::GroupStart));
+        self.map.insert(
+            type_start,
+            ParamMapInfo::new(self.num_params, ParamType::GroupStart),
+        );
         self.num_params += 1;
 
         inner_cb(self)?;
@@ -1269,12 +1546,20 @@ impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
         param_def.as_mut().param_type = ParamType::GroupEnd.into();
         param_def.set_id(Self::param_id(type_end));
         param_def.add(-1)?;
-        self.map.insert(type_end, ParamMapInfo::new(self.num_params, ParamType::GroupEnd));
+        self.map.insert(
+            type_end,
+            ParamMapInfo::new(self.num_params, ParamType::GroupEnd),
+        );
         self.num_params += 1;
         Ok(())
     }
 
-    pub fn add<'a>(&mut self, type_: P, name: &str, def: impl Into<Param<'a>>) -> Result<(), Error> {
+    pub fn add<'a>(
+        &mut self,
+        type_: P,
+        name: &str,
+        def: impl Into<Param<'a>>,
+    ) -> Result<(), Error> {
         assert!(!self.in_data.is_null());
 
         let param = def.into(); // This must outlive the call to .add()
@@ -1288,12 +1573,20 @@ impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
             param_def.set_flags(ParamFlag::SUPERVISE);
         }
         param_def.add(-1)?;
-        self.map.insert(type_, ParamMapInfo::new(self.num_params, param_type));
+        self.map
+            .insert(type_, ParamMapInfo::new(self.num_params, param_type));
         self.num_params += 1;
         Ok(())
     }
 
-    pub fn add_with_flags<'a>(&mut self, type_: P, name: &str, def: impl Into<Param<'a>>, flags: ParamFlag, ui_flags: ParamUIFlags) -> Result<(), Error> {
+    pub fn add_with_flags<'a>(
+        &mut self,
+        type_: P,
+        name: &str,
+        def: impl Into<Param<'a>>,
+        flags: ParamFlag,
+        ui_flags: ParamUIFlags,
+    ) -> Result<(), Error> {
         assert!(!self.in_data.is_null());
 
         let param = def.into(); // This must outlive the call to .add()
@@ -1306,12 +1599,19 @@ impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
         param_def.set_flags(flags);
         param_def.set_ui_flags(ui_flags);
         param_def.add(-1)?;
-        self.map.insert(type_, ParamMapInfo::new(self.num_params, param_type));
+        self.map
+            .insert(type_, ParamMapInfo::new(self.num_params, param_type));
         self.num_params += 1;
         Ok(())
     }
 
-    pub fn add_customized<'a, F: FnOnce(&mut ParamDef) -> i32>(&mut self, type_: P, name: &str, def: impl Into<Param<'a>>, cb: F) -> Result<(), Error> {
+    pub fn add_customized<'a, F: FnOnce(&mut ParamDef) -> i32>(
+        &mut self,
+        type_: P,
+        name: &str,
+        def: impl Into<Param<'a>>,
+        cb: F,
+    ) -> Result<(), Error> {
         assert!(!self.in_data.is_null());
 
         let param = def.into(); // This must outlive the call to .add()
@@ -1326,7 +1626,8 @@ impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
         if index == -1 {
             index = self.num_params as i32;
         }
-        self.map.insert(type_, ParamMapInfo::new(index as usize, param_type));
+        self.map
+            .insert(type_, ParamMapInfo::new(index as usize, param_type));
         self.num_params += 1;
         Ok(())
     }
@@ -1346,29 +1647,51 @@ impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
         self.checkout_at(type_, None, None, None)
     }
 
-    pub fn get_at(&self, type_: P, time: Option<i32>, time_step: Option<i32>, time_scale: Option<u32>) -> Result<ReadOnlyOwnership<'_, ParamDef<'p>>, Error> {
+    pub fn get_at(
+        &self,
+        type_: P,
+        time: Option<i32>,
+        time_step: Option<i32>,
+        time_scale: Option<u32>,
+    ) -> Result<ReadOnlyOwnership<'_, ParamDef<'p>>, Error> {
         if self.params.is_empty() || time.is_some() {
             match self.checkout_at(type_, time, time_step, time_scale) {
                 Ok(Ownership::Rust(param)) => Ok(ReadOnlyOwnership::Rust(param)),
                 Ok(_) => unreachable!(),
-                Err(e) => Err(e)
+                Err(e) => Err(e),
             }
         } else {
             let index = self.index(type_).ok_or(Error::InvalidIndex)?;
-            Ok(ReadOnlyOwnership::AfterEffects(self.params.get(index).ok_or(Error::InvalidIndex)?))
+            Ok(ReadOnlyOwnership::AfterEffects(
+                self.params.get(index).ok_or(Error::InvalidIndex)?,
+            ))
         }
     }
 
-    pub fn get_mut_at(&mut self, type_: P, time: Option<i32>, time_step: Option<i32>, time_scale: Option<u32>) -> Result<Ownership<'_, ParamDef<'p>>, Error> {
+    pub fn get_mut_at(
+        &mut self,
+        type_: P,
+        time: Option<i32>,
+        time_step: Option<i32>,
+        time_scale: Option<u32>,
+    ) -> Result<Ownership<'_, ParamDef<'p>>, Error> {
         if self.params.is_empty() || time.is_some() {
             self.checkout_at(type_, time, time_step, time_scale)
         } else {
             let index = self.index(type_).ok_or(Error::InvalidIndex)?;
-            Ok(Ownership::AfterEffectsMut(self.params.get_mut(index).ok_or(Error::InvalidIndex)?))
+            Ok(Ownership::AfterEffectsMut(
+                self.params.get_mut(index).ok_or(Error::InvalidIndex)?,
+            ))
         }
     }
 
-    pub fn checkout_at(&self, type_: P, time: Option<i32>, time_step: Option<i32>, time_scale: Option<u32>) -> Result<Ownership<'_, ParamDef<'p>>, Error> {
+    pub fn checkout_at(
+        &self,
+        type_: P,
+        time: Option<i32>,
+        time_step: Option<i32>,
+        time_scale: Option<u32>,
+    ) -> Result<Ownership<'_, ParamDef<'p>>, Error> {
         let index = self.index(type_).ok_or(Error::InvalidIndex)?;
         let type_ = self.raw_param_type(type_).ok_or(Error::InvalidIndex)?;
         let in_data = self.in_data();
@@ -1378,7 +1701,7 @@ impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
             time.unwrap_or(in_data.current_time()),
             time_step.unwrap_or(in_data.time_step()),
             time_scale.unwrap_or(in_data.time_scale()),
-            Some(type_)
+            Some(type_),
         )?;
         if !param.is_valid() {
             return Err(Error::InvalidParms);
@@ -1386,20 +1709,16 @@ impl<'p, P: Eq + PartialEq + Hash + Copy + Debug> Parameters<'p, P> {
         Ok(Ownership::Rust(param))
     }
 
-    pub fn num_params(&self) -> usize {
-        self.num_params
-    }
+    pub fn num_params(&self) -> usize { self.num_params }
 
-    pub fn index(&self, type_: P) -> Option<usize> {
-        self.map.get(&type_).map(|x| x.index)
-    }
+    pub fn index(&self, type_: P) -> Option<usize> { self.map.get(&type_).map(|x| x.index) }
+
     pub fn type_at(&self, index: usize) -> P {
         *self.map.iter().find(|(_, v)| v.index == index).unwrap().0
     }
 
-    pub fn raw_params(&self) -> &[ParamDef<'p>] {
-        &self.params
-    }
+    pub fn raw_params(&self) -> &[ParamDef<'p>] { &self.params }
+
     pub fn raw_param_type(&self, type_: P) -> Option<ParamType> {
         self.map.get(&type_).map(|x| x.type_)
     }

--- a/after-effects/src/pf/pixel.rs
+++ b/after-effects/src/pf/pixel.rs
@@ -8,10 +8,10 @@ pub type Pixel16 = ae_sys::PF_Pixel16;
 pub type PixelF32 = ae_sys::PF_Pixel32;
 pub type PixelF64 = ae_sys::AEGP_ColorVal;
 
-pub use ae_sys::PF_MAX_CHAN8 as MAX_CHANNEL8;
 pub use ae_sys::PF_HALF_CHAN8 as HALF_CHANNEL8;
-pub use ae_sys::PF_MAX_CHAN16 as MAX_CHANNEL16;
 pub use ae_sys::PF_HALF_CHAN16 as HALF_CHANNEL16;
+pub use ae_sys::PF_MAX_CHAN8 as MAX_CHANNEL8;
+pub use ae_sys::PF_MAX_CHAN16 as MAX_CHANNEL16;
 
 pub fn pixel8_to_16(p: Pixel8) -> Pixel16 {
     fn convert_8_to_16(x: u8) -> u16 {
@@ -20,9 +20,9 @@ pub fn pixel8_to_16(p: Pixel8) -> Pixel16 {
 
     Pixel16 {
         alpha: convert_8_to_16(p.alpha),
-        red:   convert_8_to_16(p.red),
+        red: convert_8_to_16(p.red),
         green: convert_8_to_16(p.green),
-        blue:  convert_8_to_16(p.blue),
+        blue: convert_8_to_16(p.blue),
     }
 }
 
@@ -33,12 +33,11 @@ pub fn pixel16_to_8(p: Pixel16) -> Pixel8 {
 
     Pixel8 {
         alpha: convert_16_to_8(p.alpha),
-        red:   convert_16_to_8(p.red),
+        red: convert_16_to_8(p.red),
         green: convert_16_to_8(p.green),
-        blue:  convert_16_to_8(p.blue),
+        blue: convert_16_to_8(p.blue),
     }
 }
-
 
 pub enum GenericPixel<'a> {
     Pixel8(&'a Pixel8),
@@ -57,26 +56,73 @@ pub enum GenericPixelMut<'a> {
 impl<'a> GenericPixel<'a> {
     pub fn as_u8(&self) -> Pixel8 {
         match self {
-            Self::Pixel8 (p)  => **p,
-            Self::Pixel16(p)  => Pixel8 { alpha: p.alpha as _, red: p.red as _, green: p.green as _, blue: p.blue as _ },
-            Self::PixelF32(p) => Pixel8 { alpha: p.alpha as _, red: p.red as _, green: p.green as _, blue: p.blue as _ },
-            Self::PixelF64(p) => Pixel8 { alpha: p.alphaF as _, red: p.redF as _, green: p.greenF as _, blue: p.blueF as _ },
+            Self::Pixel8(p) => **p,
+            Self::Pixel16(p) => Pixel8 {
+                alpha: p.alpha as _,
+                red: p.red as _,
+                green: p.green as _,
+                blue: p.blue as _,
+            },
+            Self::PixelF32(p) => Pixel8 {
+                alpha: p.alpha as _,
+                red: p.red as _,
+                green: p.green as _,
+                blue: p.blue as _,
+            },
+            Self::PixelF64(p) => Pixel8 {
+                alpha: p.alphaF as _,
+                red: p.redF as _,
+                green: p.greenF as _,
+                blue: p.blueF as _,
+            },
         }
     }
+
     pub fn as_u16(&self) -> Pixel16 {
         match self {
-            Self::Pixel8 (p)  => Pixel16 { alpha: p.alpha as _, red: p.red as _, green: p.green as _, blue: p.blue as _ },
-            Self::Pixel16(p)  => **p,
-            Self::PixelF32(p) => Pixel16 { alpha: p.alpha as _, red: p.red as _, green: p.green as _, blue: p.blue as _ },
-            Self::PixelF64(p) => Pixel16 { alpha: p.alphaF as _, red: p.redF as _, green: p.greenF as _, blue: p.blueF as _ },
+            Self::Pixel8(p) => Pixel16 {
+                alpha: p.alpha as _,
+                red: p.red as _,
+                green: p.green as _,
+                blue: p.blue as _,
+            },
+            Self::Pixel16(p) => **p,
+            Self::PixelF32(p) => Pixel16 {
+                alpha: p.alpha as _,
+                red: p.red as _,
+                green: p.green as _,
+                blue: p.blue as _,
+            },
+            Self::PixelF64(p) => Pixel16 {
+                alpha: p.alphaF as _,
+                red: p.redF as _,
+                green: p.greenF as _,
+                blue: p.blueF as _,
+            },
         }
     }
+
     pub fn as_f32(&self) -> PixelF32 {
         match self {
-            Self::Pixel8 (p)  => PixelF32 { alpha: p.alpha as _, red: p.red as _, green: p.green as _, blue: p.blue as _ },
-            Self::Pixel16(p)  => PixelF32 { alpha: p.alpha as _, red: p.red as _, green: p.green as _, blue: p.blue as _ },
+            Self::Pixel8(p) => PixelF32 {
+                alpha: p.alpha as _,
+                red: p.red as _,
+                green: p.green as _,
+                blue: p.blue as _,
+            },
+            Self::Pixel16(p) => PixelF32 {
+                alpha: p.alpha as _,
+                red: p.red as _,
+                green: p.green as _,
+                blue: p.blue as _,
+            },
             Self::PixelF32(p) => **p,
-            Self::PixelF64(p) => PixelF32 { alpha: p.alphaF as _, red: p.redF as _, green: p.greenF as _, blue: p.blueF as _ },
+            Self::PixelF64(p) => PixelF32 {
+                alpha: p.alphaF as _,
+                red: p.redF as _,
+                green: p.greenF as _,
+                blue: p.blueF as _,
+            },
         }
     }
 }
@@ -84,26 +130,79 @@ impl<'a> GenericPixel<'a> {
 impl<'a> GenericPixelMut<'a> {
     pub fn set_from_u8(&mut self, px: Pixel8) {
         match self {
-            Self::Pixel8 (s)  => { **s = px; },
-            Self::Pixel16(s)  => { s.alpha = px.alpha as _; s.red = px.red as _; s.green = px.green as _; s.blue = px.blue as _; },
-            Self::PixelF32(s) => { s.alpha = px.alpha as _; s.red = px.red as _; s.green = px.green as _; s.blue = px.blue as _; },
-            Self::PixelF64(s) => { s.alphaF = px.alpha as _; s.redF = px.red as _; s.greenF = px.green as _; s.blueF = px.blue as _; },
+            Self::Pixel8(s) => {
+                **s = px;
+            }
+            Self::Pixel16(s) => {
+                s.alpha = px.alpha as _;
+                s.red = px.red as _;
+                s.green = px.green as _;
+                s.blue = px.blue as _;
+            }
+            Self::PixelF32(s) => {
+                s.alpha = px.alpha as _;
+                s.red = px.red as _;
+                s.green = px.green as _;
+                s.blue = px.blue as _;
+            }
+            Self::PixelF64(s) => {
+                s.alphaF = px.alpha as _;
+                s.redF = px.red as _;
+                s.greenF = px.green as _;
+                s.blueF = px.blue as _;
+            }
         }
     }
+
     pub fn set_from_u16(&mut self, px: Pixel16) {
         match self {
-            Self::Pixel8 (s)  => { s.alpha = px.alpha as _; s.red = px.red as _; s.green = px.green as _; s.blue = px.blue as _; },
-            Self::Pixel16(s)  => { **s = px; },
-            Self::PixelF32(s) => { s.alpha = px.alpha as _; s.red = px.red as _; s.green = px.green as _; s.blue = px.blue as _; },
-            Self::PixelF64(s) => { s.alphaF = px.alpha as _; s.redF = px.red as _; s.greenF = px.green as _; s.blueF = px.blue as _; },
+            Self::Pixel8(s) => {
+                s.alpha = px.alpha as _;
+                s.red = px.red as _;
+                s.green = px.green as _;
+                s.blue = px.blue as _;
+            }
+            Self::Pixel16(s) => {
+                **s = px;
+            }
+            Self::PixelF32(s) => {
+                s.alpha = px.alpha as _;
+                s.red = px.red as _;
+                s.green = px.green as _;
+                s.blue = px.blue as _;
+            }
+            Self::PixelF64(s) => {
+                s.alphaF = px.alpha as _;
+                s.redF = px.red as _;
+                s.greenF = px.green as _;
+                s.blueF = px.blue as _;
+            }
         }
     }
+
     pub fn set_from_f32(&mut self, px: PixelF32) {
         match self {
-            Self::Pixel8 (s)  => { s.alpha = px.alpha as _; s.red = px.red as _; s.green = px.green as _; s.blue = px.blue as _; },
-            Self::Pixel16(s)  => { s.alpha = px.alpha as _; s.red = px.red as _; s.green = px.green as _; s.blue = px.blue as _; },
-            Self::PixelF32(s) => { **s = px; },
-            Self::PixelF64(s) => { s.alphaF = px.alpha as _; s.redF = px.red as _; s.greenF = px.green as _; s.blueF = px.blue as _; },
+            Self::Pixel8(s) => {
+                s.alpha = px.alpha as _;
+                s.red = px.red as _;
+                s.green = px.green as _;
+                s.blue = px.blue as _;
+            }
+            Self::Pixel16(s) => {
+                s.alpha = px.alpha as _;
+                s.red = px.red as _;
+                s.green = px.green as _;
+                s.blue = px.blue as _;
+            }
+            Self::PixelF32(s) => {
+                **s = px;
+            }
+            Self::PixelF64(s) => {
+                s.alphaF = px.alpha as _;
+                s.redF = px.red as _;
+                s.greenF = px.green as _;
+                s.blueF = px.blue as _;
+            }
         }
     }
 }

--- a/after-effects/src/pf/render.rs
+++ b/after-effects/src/pf/render.rs
@@ -39,14 +39,10 @@ pub struct PreRenderExtra {
     pub(crate) ptr: *mut ae_sys::PF_PreRenderExtra,
 }
 impl AsRef<ae_sys::PF_PreRenderExtra> for PreRenderExtra {
-    fn as_ref(&self) -> &ae_sys::PF_PreRenderExtra {
-        unsafe { &*self.ptr }
-    }
+    fn as_ref(&self) -> &ae_sys::PF_PreRenderExtra { unsafe { &*self.ptr } }
 }
 impl AsMut<ae_sys::PF_PreRenderExtra> for PreRenderExtra {
-    fn as_mut(&mut self) -> &mut ae_sys::PF_PreRenderExtra {
-        unsafe { &mut *self.ptr }
-    }
+    fn as_mut(&mut self) -> &mut ae_sys::PF_PreRenderExtra { unsafe { &mut *self.ptr } }
 }
 impl PreRenderExtra {
     pub fn from_raw(
@@ -57,21 +53,24 @@ impl PreRenderExtra {
         assert!(!ptr.is_null());
         Self { in_data_ptr, ptr }
     }
-    pub fn as_ptr(&self) -> *mut ae_sys::PF_PreRenderExtra {
-        self.ptr
-    }
+
+    pub fn as_ptr(&self) -> *mut ae_sys::PF_PreRenderExtra { self.ptr }
+
     pub fn what_gpu(&self) -> GpuFramework {
         assert!(!self.as_ref().input.is_null());
         unsafe { (*self.as_ref().input).what_gpu.into() }
     }
+
     pub fn bit_depth(&self) -> i16 {
         assert!(!self.as_ref().input.is_null());
         unsafe { (*self.as_ref().input).bitdepth as i16 }
     }
+
     pub fn device_index(&self) -> usize {
         assert!(!self.as_ref().input.is_null());
         unsafe { (*self.as_ref().input).device_index as usize }
     }
+
     pub fn set_pre_render_data<T: Any>(&mut self, val: T) {
         let boxed: Box<Box<dyn Any>> = Box::new(Box::new(val));
         unsafe {
@@ -82,6 +81,7 @@ impl PreRenderExtra {
             (*self.as_mut().output).delete_pre_render_data_func = Some(delete_pre_render_data);
         }
     }
+
     pub fn callbacks(&self) -> PreRenderCallbacks {
         unsafe { PreRenderCallbacks::from_raw(self.in_data_ptr, (*self.ptr).cb) }
     }
@@ -90,6 +90,7 @@ impl PreRenderExtra {
         assert!(!self.as_ref().input.is_null());
         unsafe { (*self.as_ref().input).output_request }
     }
+
     pub fn set_gpu_render_possible(&mut self, val: bool) {
         assert!(!self.as_mut().output.is_null());
         unsafe {
@@ -102,6 +103,7 @@ impl PreRenderExtra {
             }
         }
     }
+
     pub fn set_returns_extra_pixels(&mut self, val: bool) {
         assert!(!self.as_mut().output.is_null());
         unsafe {
@@ -119,27 +121,32 @@ impl PreRenderExtra {
         assert!(!self.as_ref().output.is_null());
         unsafe { (*self.as_ref().output).result_rect.into() }
     }
+
     pub fn max_result_rect(&self) -> Rect {
         assert!(!self.as_ref().output.is_null());
         unsafe { (*self.as_ref().output).max_result_rect.into() }
     }
+
     pub fn set_result_rect(&mut self, rect: Rect) {
         assert!(!self.as_mut().output.is_null());
         unsafe {
             (*self.as_mut().output).result_rect = rect.into();
         }
     }
+
     pub fn set_max_result_rect(&mut self, rect: Rect) {
         assert!(!self.as_mut().output.is_null());
         unsafe {
             (*self.as_mut().output).max_result_rect = rect.into();
         }
     }
+
     pub fn union_result_rect(&mut self, rect: Rect) -> Rect {
         let rect = *self.result_rect().union(&rect);
         self.set_result_rect(rect);
         rect
     }
+
     pub fn union_max_result_rect(&mut self, rect: Rect) -> Rect {
         let rect = *self.max_result_rect().union(&rect);
         self.set_max_result_rect(rect);
@@ -158,9 +165,7 @@ pub struct SmartRenderExtra {
     pub(crate) ptr: *mut ae_sys::PF_SmartRenderExtra,
 }
 impl AsRef<ae_sys::PF_SmartRenderExtra> for SmartRenderExtra {
-    fn as_ref(&self) -> &ae_sys::PF_SmartRenderExtra {
-        unsafe { &*self.ptr }
-    }
+    fn as_ref(&self) -> &ae_sys::PF_SmartRenderExtra { unsafe { &*self.ptr } }
 }
 impl SmartRenderExtra {
     pub fn from_raw(
@@ -170,24 +175,28 @@ impl SmartRenderExtra {
         assert!(!ptr.is_null());
         Self { in_data_ptr, ptr }
     }
-    pub fn as_ptr(&self) -> *mut ae_sys::PF_SmartRenderExtra {
-        self.ptr
-    }
+
+    pub fn as_ptr(&self) -> *mut ae_sys::PF_SmartRenderExtra { self.ptr }
+
     pub fn callbacks(&self) -> SmartRenderCallbacks {
         unsafe { SmartRenderCallbacks::from_raw(self.in_data_ptr, (*self.ptr).cb) }
     }
+
     pub fn what_gpu(&self) -> GpuFramework {
         assert!(!self.as_ref().input.is_null());
         unsafe { (*self.as_ref().input).what_gpu.into() }
     }
+
     pub fn device_index(&self) -> usize {
         assert!(!self.as_ref().input.is_null());
         unsafe { (*self.as_ref().input).device_index as usize }
     }
+
     pub fn bit_depth(&self) -> i16 {
         assert!(!self.as_ref().input.is_null());
         unsafe { (*self.as_ref().input).bitdepth }
     }
+
     /// # Panics
     /// Panics if the stored GPU data is not of type `T` (a plugin bug).
     pub fn gpu_data<T: Any>(&self) -> Option<&T> {
@@ -203,6 +212,7 @@ impl SmartRenderExtra {
             None => panic!("Invalid type for gpu_data"),
         }
     }
+
     /// # Panics
     /// Panics if the stored pre-render data is not of type `T` (a plugin bug).
     pub fn pre_render_data<T: Any>(&self) -> Option<&T> {
@@ -219,6 +229,7 @@ impl SmartRenderExtra {
             None => panic!("Invalid type for pre_render_data"),
         }
     }
+
     /// # Panics
     /// Panics if the stored pre-render data is not of type `T` (a plugin bug).
     pub fn pre_render_data_mut<T: Any>(&mut self) -> Option<&mut T> {
@@ -254,14 +265,9 @@ impl PreRenderCallbacks {
         }
     }
 
-    pub fn as_ptr(&self) -> *const ae_sys::PF_PreRenderCallbacks {
-        self.rc_ptr
-    }
+    pub fn as_ptr(&self) -> *const ae_sys::PF_PreRenderCallbacks { self.rc_ptr }
 
-    pub fn guid_mix_in_ptr<T>(
-        &self,
-        buf: &T,
-    ) -> Result<(), Error> {
+    pub fn guid_mix_in_ptr<T>(&self, buf: &T) -> Result<(), Error> {
         let buf_ptr: *const std::ffi::c_void = buf as *const _ as *const std::ffi::c_void;
         if buf_ptr.is_null() {
             return Err(Error::InvalidCallback);
@@ -273,7 +279,9 @@ impl PreRenderCallbacks {
         }
 
         if let Some(guid_mix_in_ptr) = unsafe { *self.rc_ptr }.GuidMixInPtr {
-            match unsafe { guid_mix_in_ptr((*self.in_data_ptr).effect_ref, buf_size as u32, buf_ptr) } {
+            match unsafe {
+                guid_mix_in_ptr((*self.in_data_ptr).effect_ref, buf_size as u32, buf_ptr)
+            } {
                 0 => Ok(()),
                 e => Err(Error::from(e)),
             }
@@ -333,9 +341,7 @@ impl SmartRenderCallbacks {
         }
     }
 
-    pub fn as_ptr(&self) -> *const ae_sys::PF_SmartRenderCallbacks {
-        self.rc_ptr
-    }
+    pub fn as_ptr(&self) -> *const ae_sys::PF_SmartRenderCallbacks { self.rc_ptr }
 
     /// Check out a layer corresponding to the ID you checked it out with in SmartPreRender.
     /// Note that the resulting layer may be None even if the ID is valid--for example, if the target layer is an
@@ -344,13 +350,16 @@ impl SmartRenderCallbacks {
         if let Some(checkout_layer_pixels) = unsafe { *self.rc_ptr }.checkout_layer_pixels {
             let mut effect_world_ptr = std::ptr::null_mut();
 
-            match (unsafe {
-                checkout_layer_pixels(
-                    (*self.in_data_ptr).effect_ref,
-                    checkout_id as i32,
-                    &mut effect_world_ptr,
-                )
-            }, effect_world_ptr.is_null()) {
+            match (
+                unsafe {
+                    checkout_layer_pixels(
+                        (*self.in_data_ptr).effect_ref,
+                        checkout_id as i32,
+                        &mut effect_world_ptr,
+                    )
+                },
+                effect_world_ptr.is_null(),
+            ) {
                 (0, false) => Ok(Some(Layer::from_raw(
                     effect_world_ptr,
                     self.in_data_ptr,
@@ -383,12 +392,10 @@ impl SmartRenderCallbacks {
         if let Some(checkout_output) = unsafe { *self.rc_ptr }.checkout_output {
             let mut effect_world_ptr = std::ptr::null_mut();
 
-            match (unsafe {
-                checkout_output(
-                    (*self.in_data_ptr).effect_ref,
-                    &mut effect_world_ptr,
-                )
-            }, effect_world_ptr.is_null()) {
+            match (
+                unsafe { checkout_output((*self.in_data_ptr).effect_ref, &mut effect_world_ptr) },
+                effect_world_ptr.is_null(),
+            ) {
                 (0, false) => Ok(Some(Layer::from_raw(
                     effect_world_ptr,
                     self.in_data_ptr,

--- a/after-effects/src/pf/suites/adv_item.rs
+++ b/after-effects/src/pf/suites/adv_item.rs
@@ -1,5 +1,3 @@
-
-
 use crate::*;
 use ae_sys::*;
 
@@ -19,33 +17,59 @@ define_suite!(
 impl AdvItemSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Moves current time `num_steps` in the specified direction.
-    pub fn move_time_step(&self, in_data: impl AsPtr<*mut PF_InData>, world: impl AsPtr<*mut PF_EffectWorld>, time_dir: Step, num_steps: i32) -> Result<(), Error> {
-        call_suite_fn!(self, PF_MoveTimeStep, in_data.as_ptr(), world.as_ptr(), time_dir.into(), num_steps as _)
+    pub fn move_time_step(
+        &self,
+        in_data: impl AsPtr<*mut PF_InData>,
+        world: impl AsPtr<*mut PF_EffectWorld>,
+        time_dir: Step,
+        num_steps: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PF_MoveTimeStep,
+            in_data.as_ptr(),
+            world.as_ptr(),
+            time_dir.into(),
+            num_steps as _
+        )
     }
 
     /// Moves `num_steps` in the specified direction, for the active item.
     pub fn move_time_step_active_item(&self, time_dir: Step, num_steps: i32) -> Result<(), Error> {
-        call_suite_fn!(self, PF_MoveTimeStepActiveItem, time_dir.into(), num_steps as _)
+        call_suite_fn!(
+            self,
+            PF_MoveTimeStepActiveItem,
+            time_dir.into(),
+            num_steps as _
+        )
     }
 
     /// Tells After Effects that the active item must be updated.
     pub fn touch_active_item(&self) -> Result<(), Error> {
-        call_suite_fn!(self, PF_TouchActiveItem, )
+        call_suite_fn!(self, PF_TouchActiveItem,)
     }
 
     /// Forces After Effects to rerender the current frame.
-    pub fn force_rerender(&self, in_data: impl AsPtr<*mut PF_InData>, world: impl AsPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
+    pub fn force_rerender(
+        &self,
+        in_data: impl AsPtr<*mut PF_InData>,
+        world: impl AsPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, PF_ForceRerender, in_data.as_ptr(), world.as_ptr())
     }
 
     /// Returns whether the effect which owns the `PF_ContextH` is currently active or enabled (if it isn't, After Effects won't be listening for function calls from it).
-    pub fn effect_is_active_or_enabled(&self, context: impl AsPtr<PF_ContextH>) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, PF_EffectIsActiveOrEnabled -> PF_Boolean, context.as_ptr())? != 0)
+    pub fn effect_is_active_or_enabled(
+        &self,
+        context: impl AsPtr<PF_ContextH>,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, PF_EffectIsActiveOrEnabled -> PF_Boolean, context.as_ptr())?
+                != 0,
+        )
     }
 }
 

--- a/after-effects/src/pf/suites/app.rs
+++ b/after-effects/src/pf/suites/app.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use std::ffi::{ CStr, CString };
+use std::ffi::{CStr, CString};
 
 define_suite!(
     /// Roughly 437 years ago, when we released After Effects 5.0, we published some useful utility callbacks in PF_AppSuite. They're as useful today as they were then. After Effects has user-controllable UI brightness.
@@ -13,24 +13,21 @@ define_suite!(
     kPFAppSuiteVersion4
 );
 
-define_suite!(
-    AppSuite6,
-    PFAppSuite6,
-    kPFAppSuite,
-    kPFAppSuiteVersion6
-);
+define_suite!(AppSuite6, PFAppSuite6, kPFAppSuite, kPFAppSuiteVersion6);
 
 fn str_from_c(slice: &[i8]) -> Result<String, Error> {
-    let slice: &[u8] = unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u8, slice.len()) };
-    Ok(CStr::from_bytes_until_nul(slice).map_err(|_| Error::InvalidParms)?.to_string_lossy().into_owned())
+    let slice: &[u8] =
+        unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u8, slice.len()) };
+    Ok(CStr::from_bytes_until_nul(slice)
+        .map_err(|_| Error::InvalidParms)?
+        .to_string_lossy()
+        .into_owned())
 }
 
 impl AppSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Retrieves the current background color.
     pub fn bg_color(&self) -> Result<ae_sys::PF_App_Color, Error> {
@@ -63,10 +60,11 @@ impl AppSuite {
 
     /// Retrieves the user's registration information.
     pub fn personal_info(&self) -> Result<AppPersonalTextInfo, Error> {
-        let info = call_suite_fn_single!(self, PF_GetPersonalInfo -> ae_sys::PF_AppPersonalTextInfo)?;
+        let info =
+            call_suite_fn_single!(self, PF_GetPersonalInfo -> ae_sys::PF_AppPersonalTextInfo)?;
         Ok(AppPersonalTextInfo {
-            name:       str_from_c(&info.name)?,
-            org:        str_from_c(&info.org)?,
+            name: str_from_c(&info.name)?,
+            org: str_from_c(&info.org)?,
             serial_str: str_from_c(&info.serial_str)?,
         })
     }
@@ -76,18 +74,24 @@ impl AppSuite {
     /// Trivia: The font used in After Effects' UI starting in 15.0 is Adobe Clean. Before that, it was Tahoma on Windows and Lucida Grande on macOS X.
     ///
     /// Returns a tuple containing: (font name, font number, size, style),
-    pub fn font_style_sheet(&self, sheet: FontStyleSheet) -> Result<(String, i16, i16, i16), Error> {
+    pub fn font_style_sheet(
+        &self,
+        sheet: FontStyleSheet,
+    ) -> Result<(String, i16, i16, i16), Error> {
         let mut font_name: ae_sys::PF_FontName = unsafe { std::mem::zeroed() };
         let mut font_num = 0;
         let mut size = 0;
         let mut style = 0;
-        call_suite_fn!(self, PF_GetFontStyleSheet, sheet.into(), &mut font_name as *mut _, &mut font_num, &mut size, &mut style)?;
-        Ok((
-            str_from_c(&font_name.font_nameAC)?,
-            font_num,
-            size,
-            style,
-        ))
+        call_suite_fn!(
+            self,
+            PF_GetFontStyleSheet,
+            sheet.into(),
+            &mut font_name as *mut _,
+            &mut font_num,
+            &mut size,
+            &mut style
+        )?;
+        Ok((str_from_c(&font_name.font_nameAC)?, font_num, size, style))
     }
 
     /// Sets the cursor to any of After Effects' cursors. See [`CursorType`]` for a complete enumeration.
@@ -107,8 +111,16 @@ impl AppSuite {
     /// Displays the After Effects color picker dialog (which may be the system color picker, depending on the user's preferences).
     ///
     /// Will return `Error::InterruptCancel` if user cancels dialog. Returned color is in the project's working color space.
-    pub fn color_picker_dialog(&self, dialog_title: Option<&str>, sample_color: &pf::PixelF32, use_ws_to_monitor_xform: bool) -> Result<pf::PixelF32, Error> {
-        let dialog_title = dialog_title.map(CString::new).transpose().map_err(|_| Error::InvalidParms)?;
+    pub fn color_picker_dialog(
+        &self,
+        dialog_title: Option<&str>,
+        sample_color: &pf::PixelF32,
+        use_ws_to_monitor_xform: bool,
+    ) -> Result<pf::PixelF32, Error> {
+        let dialog_title = dialog_title
+            .map(CString::new)
+            .transpose()
+            .map_err(|_| Error::InvalidParms)?;
         call_suite_fn_single!(self, PF_AppColorPickerDialog -> ae_sys::PF_PixelFloat, dialog_title.as_ref().map_or(std::ptr::null(), |x| x.as_ptr()), sample_color, use_ws_to_monitor_xform as _)
     }
 
@@ -124,16 +136,35 @@ impl AppSuite {
     /// Specify `None` to invalidate the entire window. The redraw will happen at the next available idle moment after returning from the event.
     ///
     /// Set the `PF_EO_UPDATE_NOW` event outflag to update the window immediately after the event returns.
-    pub fn invalidate_rect(&self, context: impl AsPtr<ae_sys::PF_ContextH>, rect: Option<pf::Rect>) -> Result<(), Error> {
-        call_suite_fn!(self, PF_InvalidateRect, context.as_ptr(), rect.map(Into::into).as_ref().map_or(std::ptr::null(), |x| x))
+    pub fn invalidate_rect(
+        &self,
+        context: impl AsPtr<ae_sys::PF_ContextH>,
+        rect: Option<pf::Rect>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PF_InvalidateRect,
+            context.as_ptr(),
+            rect.map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null(), |x| x)
+        )
     }
 
     /// Converts from the custom UI coordinate system to global screen coordinates. Use only during custom UI event handling.
-    pub fn convert_local_to_global(&self, local: &ae_sys::PF_Point) -> Result<ae_sys::PF_Point, Error> {
+    pub fn convert_local_to_global(
+        &self,
+        local: &ae_sys::PF_Point,
+    ) -> Result<ae_sys::PF_Point, Error> {
         call_suite_fn_single!(self, PF_ConvertLocalToGlobal -> ae_sys::PF_Point, local)
     }
 
-    pub fn color_at_global_point(&self, global: &ae_sys::PF_Point, eye_size: i16, mode: EyeDropperSampleMode) -> Result<pf::PixelF32, Error> {
+    pub fn color_at_global_point(
+        &self,
+        global: &ae_sys::PF_Point,
+        eye_size: i16,
+        mode: EyeDropperSampleMode,
+    ) -> Result<pf::PixelF32, Error> {
         call_suite_fn_single!(self, PF_GetColorAtGlobalPoint -> ae_sys::PF_PixelFloat, global, eye_size, mode.into())
     }
 
@@ -142,15 +173,30 @@ impl AppSuite {
     /// If `cancel_str` is `None`, the dialog will not have a cancel button.
     ///
     /// It won't open the dialog unless it detects a slow render. (2 seconds timeout).
-    pub fn create_progress_dialog(&self, title: &str, cancel_str: Option<&str>, indeterminate: bool) -> Result<AppProgressDialog, Error> {
+    pub fn create_progress_dialog(
+        &self,
+        title: &str,
+        cancel_str: Option<&str>,
+        indeterminate: bool,
+    ) -> Result<AppProgressDialog, Error> {
         let v6 = AppSuite6::new()?;
         let title = widestring::U16CString::from_str(title).map_err(|_| Error::InvalidParms)?;
-        let cancel_str = cancel_str.map(widestring::U16CString::from_str).transpose().map_err(|_| Error::InvalidParms)?;
+        let cancel_str = cancel_str
+            .map(widestring::U16CString::from_str)
+            .transpose()
+            .map_err(|_| Error::InvalidParms)?;
         let mut ptr = std::ptr::null_mut();
-        call_suite_fn!(v6, PF_CreateNewAppProgressDialog, title.as_ptr(), cancel_str.map_or(std::ptr::null(), |x| x.as_ptr()), indeterminate as _, &mut ptr)?;
+        call_suite_fn!(
+            v6,
+            PF_CreateNewAppProgressDialog,
+            title.as_ptr(),
+            cancel_str.map_or(std::ptr::null(), |x| x.as_ptr()),
+            indeterminate as _,
+            &mut ptr
+        )?;
         Ok(AppProgressDialog {
             suite_ptr: v6.suite_ptr,
-            ptr
+            ptr,
         })
     }
 }
@@ -166,9 +212,7 @@ define_suite!(
 impl AdvAppSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Tells After Effects that the project has been changed since it was last saved.
     pub fn set_project_dirty(&self) -> Result<(), Error> {
@@ -176,9 +220,7 @@ impl AdvAppSuite {
     }
 
     /// Saves the project to the current path. To save the project elsewhere, use [`aegp::suites::Project::save_project_to_path`].
-    pub fn save_project(&self) -> Result<(), Error> {
-        call_suite_fn!(self, PF_SaveProject,)
-    }
+    pub fn save_project(&self) -> Result<(), Error> { call_suite_fn!(self, PF_SaveProject,) }
 
     /// Stores the background state (After Effects' position in the stacking order of open applications and windows).
     pub fn save_background_state(&self) -> Result<(), Error> {
@@ -219,17 +261,38 @@ impl AdvAppSuite {
         let line1 = CString::new(line1).map_err(|_| Error::InvalidParms)?;
         let line2 = CString::new(line2).map_err(|_| Error::InvalidParms)?;
         let line3 = CString::new(line3).map_err(|_| Error::InvalidParms)?;
-        call_suite_fn!(self, PF_InfoDrawText3, line1.as_ptr(), line2.as_ptr(), line3.as_ptr())
+        call_suite_fn!(
+            self,
+            PF_InfoDrawText3,
+            line1.as_ptr(),
+            line2.as_ptr(),
+            line3.as_ptr()
+        )
     }
 
     /// Writes three lines of text into the After Effects info palette, with portions of the second and third lines left and right justified.
-    pub fn info_draw_text3_plus(&self, line1: &str, line2_jr: &str, line2_jl: &str, line3_jr: &str, line3_jl: &str) -> Result<(), Error> {
+    pub fn info_draw_text3_plus(
+        &self,
+        line1: &str,
+        line2_jr: &str,
+        line2_jl: &str,
+        line3_jr: &str,
+        line3_jl: &str,
+    ) -> Result<(), Error> {
         let line1 = CString::new(line1).map_err(|_| Error::InvalidParms)?;
         let line2_jr = CString::new(line2_jr).map_err(|_| Error::InvalidParms)?;
         let line2_jl = CString::new(line2_jl).map_err(|_| Error::InvalidParms)?;
         let line3_jr = CString::new(line3_jr).map_err(|_| Error::InvalidParms)?;
         let line3_jl = CString::new(line3_jl).map_err(|_| Error::InvalidParms)?;
-        call_suite_fn!(self, PF_InfoDrawText3Plus, line1.as_ptr(), line2_jr.as_ptr(), line2_jl.as_ptr(), line3_jr.as_ptr(), line3_jl.as_ptr())
+        call_suite_fn!(
+            self,
+            PF_InfoDrawText3Plus,
+            line1.as_ptr(),
+            line2_jr.as_ptr(),
+            line2_jl.as_ptr(),
+            line3_jr.as_ptr(),
+            line3_jl.as_ptr()
+        )
     }
 
     /// Appends characters to the currently-displayed info text.
@@ -492,7 +555,7 @@ define_enum! {
 pub struct AppPersonalTextInfo {
     pub name: String,
     pub org: String,
-    pub serial_str: String
+    pub serial_str: String,
 }
 
 pub struct AppProgressDialog {
@@ -502,7 +565,13 @@ pub struct AppProgressDialog {
 impl AppProgressDialog {
     /// Updates the progress dialog.
     pub fn update(&self, count: i32, total: i32) -> Result<(), Error> {
-        call_suite_fn!(self, PF_AppProgressDialogUpdate, self.ptr, count as _, total as _)
+        call_suite_fn!(
+            self,
+            PF_AppProgressDialogUpdate,
+            self.ptr,
+            count as _,
+            total as _
+        )
     }
 }
 impl Drop for AppProgressDialog {

--- a/after-effects/src/pf/suites/background_frame.rs
+++ b/after-effects/src/pf/suites/background_frame.rs
@@ -1,4 +1,3 @@
-
 use crate::*;
 use ae_sys::*;
 
@@ -12,21 +11,39 @@ define_suite!(
 impl BackgroundFrameSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
+    pub fn add_supported_background_transfer_mode(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        supported_transfer_mode: TransferMode,
+        supported_pixel_format: pr::PixelFormat,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AddSupportedBackgroundTransferMode,
+            effect_ref.as_ptr(),
+            supported_transfer_mode.into(),
+            supported_pixel_format.into()
+        )
     }
 
-    pub fn add_supported_background_transfer_mode(&self, effect_ref: impl AsPtr<PF_ProgPtr>, supported_transfer_mode: TransferMode, supported_pixel_format: pr::PixelFormat) -> Result<(), Error> {
-        call_suite_fn!(self, AddSupportedBackgroundTransferMode, effect_ref.as_ptr(), supported_transfer_mode.into(), supported_pixel_format.into())
-    }
-
-    pub fn background_frame(&self, in_data: impl AsPtr<*const PF_InData>) -> Result<(Layer, TransferMode), Error> {
+    pub fn background_frame(
+        &self,
+        in_data: impl AsPtr<*const PF_InData>,
+    ) -> Result<(Layer, TransferMode), Error> {
         let mut background_frame = std::ptr::null_mut();
         let mut background_transfer_mode: ae_sys::PF_TransferMode = 0;
-        call_suite_fn!(self, GetBackgroundFrame, (*in_data.as_ptr()).effect_ref, &mut background_frame, &mut background_transfer_mode)?;
+        call_suite_fn!(
+            self,
+            GetBackgroundFrame,
+            (*in_data.as_ptr()).effect_ref,
+            &mut background_frame,
+            &mut background_transfer_mode
+        )?;
         Ok((
             Layer::from_raw(background_frame, in_data.as_ptr(), None),
-            background_transfer_mode.into()
+            background_transfer_mode.into(),
         ))
     }
 }

--- a/after-effects/src/pf/suites/cache_on_load.rs
+++ b/after-effects/src/pf/suites/cache_on_load.rs
@@ -1,4 +1,3 @@
-
 use crate::*;
 use ae_sys::*;
 
@@ -19,13 +18,20 @@ define_suite!(
 impl CacheOnLoadSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Pass a non-zero value if you want your effect to show up in the UI.
     /// Pass zero if loading failed, but you still want Premiere Pro to attempt to load it again on the next relaunch.
-    pub fn set_no_cache_on_load(&self, effect_ref: impl AsPtr<PF_ProgPtr>, effect_available: bool) -> Result<(), Error> {
-        call_suite_fn!(self, PF_SetNoCacheOnLoad, effect_ref.as_ptr(), effect_available as _)
+    pub fn set_no_cache_on_load(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        effect_available: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PF_SetNoCacheOnLoad,
+            effect_ref.as_ptr(),
+            effect_available as _
+        )
     }
 }

--- a/after-effects/src/pf/suites/channel.rs
+++ b/after-effects/src/pf/suites/channel.rs
@@ -1,4 +1,3 @@
-
 use crate::*;
 use ae_sys::*;
 
@@ -13,25 +12,44 @@ define_suite!(
 impl ChannelSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Retrieves the number of auxiliary channels associated with the indexed layer.
     /// - `param_index` is the parameter index of the layer whose source you wish to interrogate
-    pub fn layer_channel_count(&self, effect_ref: impl AsPtr<PF_ProgPtr>, param_index: i32) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, PF_GetLayerChannelCount -> ae_sys::A_long, effect_ref.as_ptr(), param_index)? as _)
+    pub fn layer_channel_count(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        param_index: i32,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, PF_GetLayerChannelCount -> ae_sys::A_long, effect_ref.as_ptr(), param_index)?
+                as _,
+        )
     }
 
     /// Retrieves (by index) a reference to, and description of, the specified channel.
     /// Given a channel index return the opaque channelRef and a channel description.
     /// Channel index must lie between 0 and num_channels-1.
     /// You will use the channelRef in all subsequent calls
-    pub fn layer_channel_indexed_ref_and_desc(&self, effect_ref: impl AsPtr<PF_ProgPtr>, param_index: i32, channel_index: i32) -> Result<Option<(PF_ChannelRef, PF_ChannelDesc)>, Error> {
-        let mut found: PF_Boolean  = 0;
+    pub fn layer_channel_indexed_ref_and_desc(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        param_index: i32,
+        channel_index: i32,
+    ) -> Result<Option<(PF_ChannelRef, PF_ChannelDesc)>, Error> {
+        let mut found: PF_Boolean = 0;
         let mut channel_ref = unsafe { std::mem::zeroed() };
         let mut channel_desc = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, PF_GetLayerChannelIndexedRefAndDesc, effect_ref.as_ptr(), param_index, channel_index, &mut found, &mut channel_ref, &mut channel_desc)?;
+        call_suite_fn!(
+            self,
+            PF_GetLayerChannelIndexedRefAndDesc,
+            effect_ref.as_ptr(),
+            param_index,
+            channel_index,
+            &mut found,
+            &mut channel_ref,
+            &mut channel_desc
+        )?;
         if found == 1 {
             Ok(Some((channel_ref, channel_desc)))
         } else {
@@ -40,11 +58,25 @@ impl ChannelSuite {
     }
 
     /// Retrieves an auxiliary channel by type.
-    pub fn layer_channel_typed_ref_and_desc(&self, effect_ref: impl AsPtr<PF_ProgPtr>, param_index: i32, channel_type: ChannelType) -> Result<Option<(PF_ChannelRef, PF_ChannelDesc)>, Error> {
-        let mut found: PF_Boolean  = 0;
+    pub fn layer_channel_typed_ref_and_desc(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        param_index: i32,
+        channel_type: ChannelType,
+    ) -> Result<Option<(PF_ChannelRef, PF_ChannelDesc)>, Error> {
+        let mut found: PF_Boolean = 0;
         let mut channel_ref = unsafe { std::mem::zeroed() };
         let mut channel_desc = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, PF_GetLayerChannelTypedRefAndDesc, effect_ref.as_ptr(), param_index, channel_type.into(), &mut found, &mut channel_ref, &mut channel_desc)?;
+        call_suite_fn!(
+            self,
+            PF_GetLayerChannelTypedRefAndDesc,
+            effect_ref.as_ptr(),
+            param_index,
+            channel_type.into(),
+            &mut found,
+            &mut channel_ref,
+            &mut channel_desc
+        )?;
         if found == 1 {
             Ok(Some((channel_ref, channel_desc)))
         } else {
@@ -55,13 +87,34 @@ impl ChannelSuite {
     /// Retrieves the ``PF_ChannelChunk`` containing the data associated with the given ``PF_ChannelRefPtr``.
     /// The data chunk is allocated is of the type requested.
     /// The data is in chunky format.
-    pub fn checkout_layer_channel(&self, effect_ref: impl AsPtr<PF_ProgPtr>, channel_ref: &PF_ChannelRef, what_time: i32, duration: i32, time_scale: u32, data_type: DataType) -> Result<ChannelChunk, Error> {
-        Ok(ChannelChunk(call_suite_fn_single!(self, PF_CheckoutLayerChannel -> PF_ChannelChunk, effect_ref.as_ptr(), channel_ref as *const _ as _, what_time, duration, time_scale, data_type.into())?))
+    pub fn checkout_layer_channel(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        channel_ref: &PF_ChannelRef,
+        what_time: i32,
+        duration: i32,
+        time_scale: u32,
+        data_type: DataType,
+    ) -> Result<ChannelChunk, Error> {
+        Ok(ChannelChunk(
+            call_suite_fn_single!(self, PF_CheckoutLayerChannel -> PF_ChannelChunk, effect_ref.as_ptr(), channel_ref as *const _ as _, what_time, duration, time_scale, data_type.into())?,
+        ))
     }
 
     /// The checked out channel must be checked in to avoid memory leaks.
-    pub fn checkin_layer_channel(&self, effect_ref: impl AsPtr<PF_ProgPtr>, channel_ref: &PF_ChannelRef, channel_chunk: &ChannelChunk) -> Result<(), Error> {
-        call_suite_fn!(self, PF_CheckinLayerChannel, effect_ref.as_ptr(), channel_ref as *const _ as _, channel_chunk as *const _ as _)
+    pub fn checkin_layer_channel(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        channel_ref: &PF_ChannelRef,
+        channel_chunk: &ChannelChunk,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PF_CheckinLayerChannel,
+            effect_ref.as_ptr(),
+            channel_ref as *const _ as _,
+            channel_chunk as *const _ as _
+        )
     }
 }
 
@@ -114,29 +167,29 @@ define_enum! {
     }
 }
 
-const PF_CHANNELTYPE_DEPTH:        i32 = i32::from_be_bytes(*b"DPTH");
-const PF_CHANNELTYPE_DEPTHAA:      i32 = i32::from_be_bytes(*b"DPAA"); // since 16.0 for 3D Precomp in some Artisans
-const PF_CHANNELTYPE_NORMALS:      i32 = i32::from_be_bytes(*b"NRML");
-const PF_CHANNELTYPE_OBJECTID:     i32 = i32::from_be_bytes(*b"OBID");
+const PF_CHANNELTYPE_DEPTH: i32 = i32::from_be_bytes(*b"DPTH");
+const PF_CHANNELTYPE_DEPTHAA: i32 = i32::from_be_bytes(*b"DPAA"); // since 16.0 for 3D Precomp in some Artisans
+const PF_CHANNELTYPE_NORMALS: i32 = i32::from_be_bytes(*b"NRML");
+const PF_CHANNELTYPE_OBJECTID: i32 = i32::from_be_bytes(*b"OBID");
 const PF_CHANNELTYPE_MOTIONVECTOR: i32 = i32::from_be_bytes(*b"MTVR");
-const PF_CHANNELTYPE_BK_COLOR:     i32 = i32::from_be_bytes(*b"BKCR");
-const PF_CHANNELTYPE_TEXTURE:      i32 = i32::from_be_bytes(*b"TEXR");
-const PF_CHANNELTYPE_COVERAGE:     i32 = i32::from_be_bytes(*b"COVR");
-const PF_CHANNELTYPE_NODE:         i32 = i32::from_be_bytes(*b"NODE");
-const PF_CHANNELTYPE_MATERIAL:     i32 = i32::from_be_bytes(*b"MATR");
-const PF_CHANNELTYPE_UNCLAMPED:    i32 = i32::from_be_bytes(*b"UNCP");
-const PF_CHANNELTYPE_UNKNOWN:      i32 = i32::from_be_bytes(*b"UNKN");
+const PF_CHANNELTYPE_BK_COLOR: i32 = i32::from_be_bytes(*b"BKCR");
+const PF_CHANNELTYPE_TEXTURE: i32 = i32::from_be_bytes(*b"TEXR");
+const PF_CHANNELTYPE_COVERAGE: i32 = i32::from_be_bytes(*b"COVR");
+const PF_CHANNELTYPE_NODE: i32 = i32::from_be_bytes(*b"NODE");
+const PF_CHANNELTYPE_MATERIAL: i32 = i32::from_be_bytes(*b"MATR");
+const PF_CHANNELTYPE_UNCLAMPED: i32 = i32::from_be_bytes(*b"UNCP");
+const PF_CHANNELTYPE_UNKNOWN: i32 = i32::from_be_bytes(*b"UNKN");
 
-const PF_DATATYPE_FLOAT:         i32 = i32::from_be_bytes(*b"FLT4"); // 4 byte
-const PF_DATATYPE_DOUBLE:        i32 = i32::from_be_bytes(*b"DBL8"); // 8 byte
-const PF_DATATYPE_LONG:          i32 = i32::from_be_bytes(*b"LON4"); // 4 bytes
-const PF_DATATYPE_SHORT:         i32 = i32::from_be_bytes(*b"SHT2"); // 2 bytes
-const PF_DATATYPE_FIXED_16_16:   i32 = i32::from_be_bytes(*b"FIX4"); // 4 bytes
-const PF_DATATYPE_CHAR:          i32 = i32::from_be_bytes(*b"CHR1"); // 1 byte
-const PF_DATATYPE_U_BYTE:        i32 = i32::from_be_bytes(*b"UBT1"); // 1 byte
-const PF_DATATYPE_U_SHORT:       i32 = i32::from_be_bytes(*b"UST2"); // 2 bytes
+const PF_DATATYPE_FLOAT: i32 = i32::from_be_bytes(*b"FLT4"); // 4 byte
+const PF_DATATYPE_DOUBLE: i32 = i32::from_be_bytes(*b"DBL8"); // 8 byte
+const PF_DATATYPE_LONG: i32 = i32::from_be_bytes(*b"LON4"); // 4 bytes
+const PF_DATATYPE_SHORT: i32 = i32::from_be_bytes(*b"SHT2"); // 2 bytes
+const PF_DATATYPE_FIXED_16_16: i32 = i32::from_be_bytes(*b"FIX4"); // 4 bytes
+const PF_DATATYPE_CHAR: i32 = i32::from_be_bytes(*b"CHR1"); // 1 byte
+const PF_DATATYPE_U_BYTE: i32 = i32::from_be_bytes(*b"UBT1"); // 1 byte
+const PF_DATATYPE_U_SHORT: i32 = i32::from_be_bytes(*b"UST2"); // 2 bytes
 const PF_DATATYPE_U_FIXED_16_16: i32 = i32::from_be_bytes(*b"UFX4"); // 4 bytes
-const PF_DATATYPE_RGB:           i32 = i32::from_be_bytes(*b"RBG "); // 3 bytes
+const PF_DATATYPE_RGB: i32 = i32::from_be_bytes(*b"RBG "); // 3 bytes
 
 /// the channel data parallels the image data in size and shape.
 /// the width is the number of pixels, the height is the number of scanlines
@@ -152,6 +205,7 @@ const PF_DATATYPE_RGB:           i32 = i32::from_be_bytes(*b"RBG "); // 3 bytes
 pub struct ChannelChunk(ae_sys::PF_ChannelChunk);
 impl std::ops::Deref for ChannelChunk {
     type Target = ae_sys::PF_ChannelChunk;
+
     fn deref(&self) -> &Self::Target { &self.0 }
 }
 
@@ -172,19 +226,20 @@ pub enum ChannelDataType {
 impl ChannelChunk {
     pub fn channel_data(&self) -> ChannelDataType {
         match self.0.data_type {
-            PF_DATATYPE_FLOAT         => ChannelDataType::Float(      self.0.dataPV as *mut _),
-            PF_DATATYPE_DOUBLE        => ChannelDataType::Double(     self.0.dataPV as *mut _),
-            PF_DATATYPE_LONG          => ChannelDataType::Long(       self.0.dataPV as *mut _),
-            PF_DATATYPE_SHORT         => ChannelDataType::Short(      self.0.dataPV as *mut _),
-            PF_DATATYPE_FIXED_16_16   => ChannelDataType::Fixed16_16( self.0.dataPV as *mut _),
-            PF_DATATYPE_CHAR          => ChannelDataType::Char(       self.0.dataPV as *mut _),
-            PF_DATATYPE_U_BYTE        => ChannelDataType::UByte(      self.0.dataPV as *mut _),
-            PF_DATATYPE_U_SHORT       => ChannelDataType::UShort(     self.0.dataPV as *mut _),
+            PF_DATATYPE_FLOAT => ChannelDataType::Float(self.0.dataPV as *mut _),
+            PF_DATATYPE_DOUBLE => ChannelDataType::Double(self.0.dataPV as *mut _),
+            PF_DATATYPE_LONG => ChannelDataType::Long(self.0.dataPV as *mut _),
+            PF_DATATYPE_SHORT => ChannelDataType::Short(self.0.dataPV as *mut _),
+            PF_DATATYPE_FIXED_16_16 => ChannelDataType::Fixed16_16(self.0.dataPV as *mut _),
+            PF_DATATYPE_CHAR => ChannelDataType::Char(self.0.dataPV as *mut _),
+            PF_DATATYPE_U_BYTE => ChannelDataType::UByte(self.0.dataPV as *mut _),
+            PF_DATATYPE_U_SHORT => ChannelDataType::UShort(self.0.dataPV as *mut _),
             PF_DATATYPE_U_FIXED_16_16 => ChannelDataType::UFixed16_16(self.0.dataPV as *mut _),
-            PF_DATATYPE_RGB           => ChannelDataType::Rgb(        self.0.dataPV as *mut _),
+            PF_DATATYPE_RGB => ChannelDataType::Rgb(self.0.dataPV as *mut _),
             _ => unreachable!(),
         }
     }
+
     /// # Panics
     /// Panics if `row` is out of range (`0..height`).
     pub fn channel_row_data(&self, row: i32) -> ChannelDataType {
@@ -193,16 +248,36 @@ impl ChannelChunk {
         }
         let offset = row as isize * self.0.row_bytesL as isize;
         match self.0.data_type {
-            PF_DATATYPE_FLOAT         => ChannelDataType::Float(      unsafe { (self.0.dataPV as *mut f32).byte_offset(offset) }),
-            PF_DATATYPE_DOUBLE        => ChannelDataType::Double(     unsafe { (self.0.dataPV as *mut f64).byte_offset(offset) }),
-            PF_DATATYPE_LONG          => ChannelDataType::Long(       unsafe { (self.0.dataPV as *mut i32).byte_offset(offset) }),
-            PF_DATATYPE_SHORT         => ChannelDataType::Short(      unsafe { (self.0.dataPV as *mut i16).byte_offset(offset) }),
-            PF_DATATYPE_FIXED_16_16   => ChannelDataType::Fixed16_16( unsafe { (self.0.dataPV as *mut i32).byte_offset(offset) }),
-            PF_DATATYPE_CHAR          => ChannelDataType::Char(       unsafe { (self.0.dataPV as *mut i8 ).byte_offset(offset) }),
-            PF_DATATYPE_U_BYTE        => ChannelDataType::UByte(      unsafe { (self.0.dataPV as *mut u8 ).byte_offset(offset) }),
-            PF_DATATYPE_U_SHORT       => ChannelDataType::UShort(     unsafe { (self.0.dataPV as *mut u16).byte_offset(offset) }),
-            PF_DATATYPE_U_FIXED_16_16 => ChannelDataType::UFixed16_16(unsafe { (self.0.dataPV as *mut u32).byte_offset(offset) }),
-            PF_DATATYPE_RGB           => ChannelDataType::Rgb(        unsafe { (self.0.dataPV as *mut u8 ).byte_offset(offset) }),
+            PF_DATATYPE_FLOAT => {
+                ChannelDataType::Float(unsafe { (self.0.dataPV as *mut f32).byte_offset(offset) })
+            }
+            PF_DATATYPE_DOUBLE => {
+                ChannelDataType::Double(unsafe { (self.0.dataPV as *mut f64).byte_offset(offset) })
+            }
+            PF_DATATYPE_LONG => {
+                ChannelDataType::Long(unsafe { (self.0.dataPV as *mut i32).byte_offset(offset) })
+            }
+            PF_DATATYPE_SHORT => {
+                ChannelDataType::Short(unsafe { (self.0.dataPV as *mut i16).byte_offset(offset) })
+            }
+            PF_DATATYPE_FIXED_16_16 => ChannelDataType::Fixed16_16(unsafe {
+                (self.0.dataPV as *mut i32).byte_offset(offset)
+            }),
+            PF_DATATYPE_CHAR => {
+                ChannelDataType::Char(unsafe { (self.0.dataPV as *mut i8).byte_offset(offset) })
+            }
+            PF_DATATYPE_U_BYTE => {
+                ChannelDataType::UByte(unsafe { (self.0.dataPV as *mut u8).byte_offset(offset) })
+            }
+            PF_DATATYPE_U_SHORT => {
+                ChannelDataType::UShort(unsafe { (self.0.dataPV as *mut u16).byte_offset(offset) })
+            }
+            PF_DATATYPE_U_FIXED_16_16 => ChannelDataType::UFixed16_16(unsafe {
+                (self.0.dataPV as *mut u32).byte_offset(offset)
+            }),
+            PF_DATATYPE_RGB => {
+                ChannelDataType::Rgb(unsafe { (self.0.dataPV as *mut u8).byte_offset(offset) })
+            }
             _ => unreachable!(),
         }
     }
@@ -219,16 +294,56 @@ impl ChannelChunk {
         let row_offset = row as isize * self.0.row_bytesL as isize;
         let col_offset = col as isize * self.0.dimensionL as isize;
         match self.0.data_type {
-            PF_DATATYPE_FLOAT         => ChannelDataType::Float(      unsafe { (self.0.dataPV as *mut f32).byte_offset(row_offset).offset(col_offset) }),
-            PF_DATATYPE_DOUBLE        => ChannelDataType::Double(     unsafe { (self.0.dataPV as *mut f64).byte_offset(row_offset).offset(col_offset) }),
-            PF_DATATYPE_LONG          => ChannelDataType::Long(       unsafe { (self.0.dataPV as *mut i32).byte_offset(row_offset).offset(col_offset) }),
-            PF_DATATYPE_SHORT         => ChannelDataType::Short(      unsafe { (self.0.dataPV as *mut i16).byte_offset(row_offset).offset(col_offset) }),
-            PF_DATATYPE_FIXED_16_16   => ChannelDataType::Fixed16_16( unsafe { (self.0.dataPV as *mut i32).byte_offset(row_offset).offset(col_offset) }),
-            PF_DATATYPE_CHAR          => ChannelDataType::Char(       unsafe { (self.0.dataPV as *mut i8 ).byte_offset(row_offset).offset(col_offset) }),
-            PF_DATATYPE_U_BYTE        => ChannelDataType::UByte(      unsafe { (self.0.dataPV as *mut u8 ).byte_offset(row_offset).offset(col_offset) }),
-            PF_DATATYPE_U_SHORT       => ChannelDataType::UShort(     unsafe { (self.0.dataPV as *mut u16).byte_offset(row_offset).offset(col_offset) }),
-            PF_DATATYPE_U_FIXED_16_16 => ChannelDataType::UFixed16_16(unsafe { (self.0.dataPV as *mut u32).byte_offset(row_offset).offset(col_offset) }),
-            PF_DATATYPE_RGB           => ChannelDataType::Rgb(        unsafe { (self.0.dataPV as *mut u8 ).byte_offset(row_offset).offset(col_offset) }),
+            PF_DATATYPE_FLOAT => ChannelDataType::Float(unsafe {
+                (self.0.dataPV as *mut f32)
+                    .byte_offset(row_offset)
+                    .offset(col_offset)
+            }),
+            PF_DATATYPE_DOUBLE => ChannelDataType::Double(unsafe {
+                (self.0.dataPV as *mut f64)
+                    .byte_offset(row_offset)
+                    .offset(col_offset)
+            }),
+            PF_DATATYPE_LONG => ChannelDataType::Long(unsafe {
+                (self.0.dataPV as *mut i32)
+                    .byte_offset(row_offset)
+                    .offset(col_offset)
+            }),
+            PF_DATATYPE_SHORT => ChannelDataType::Short(unsafe {
+                (self.0.dataPV as *mut i16)
+                    .byte_offset(row_offset)
+                    .offset(col_offset)
+            }),
+            PF_DATATYPE_FIXED_16_16 => ChannelDataType::Fixed16_16(unsafe {
+                (self.0.dataPV as *mut i32)
+                    .byte_offset(row_offset)
+                    .offset(col_offset)
+            }),
+            PF_DATATYPE_CHAR => ChannelDataType::Char(unsafe {
+                (self.0.dataPV as *mut i8)
+                    .byte_offset(row_offset)
+                    .offset(col_offset)
+            }),
+            PF_DATATYPE_U_BYTE => ChannelDataType::UByte(unsafe {
+                (self.0.dataPV as *mut u8)
+                    .byte_offset(row_offset)
+                    .offset(col_offset)
+            }),
+            PF_DATATYPE_U_SHORT => ChannelDataType::UShort(unsafe {
+                (self.0.dataPV as *mut u16)
+                    .byte_offset(row_offset)
+                    .offset(col_offset)
+            }),
+            PF_DATATYPE_U_FIXED_16_16 => ChannelDataType::UFixed16_16(unsafe {
+                (self.0.dataPV as *mut u32)
+                    .byte_offset(row_offset)
+                    .offset(col_offset)
+            }),
+            PF_DATATYPE_RGB => ChannelDataType::Rgb(unsafe {
+                (self.0.dataPV as *mut u8)
+                    .byte_offset(row_offset)
+                    .offset(col_offset)
+            }),
             _ => unreachable!(),
         }
     }

--- a/after-effects/src/pf/suites/color_callbacks.rs
+++ b/after-effects/src/pf/suites/color_callbacks.rs
@@ -1,4 +1,3 @@
-
 use crate::*;
 use ae_sys::*;
 
@@ -13,41 +12,83 @@ define_suite!(
 impl ColorCallbacksSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Given an RGB pixel, returns an HLS (hue, lightness, saturation) pixel. HLS values are scaled from 0 to 1 in fixed point.
-    pub fn rgb_to_hls(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &Pixel8) -> Result<HLSPixel, Error> {
+    pub fn rgb_to_hls(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &Pixel8,
+    ) -> Result<HLSPixel, Error> {
         let mut hls = HLSPixel::default();
-        call_suite_fn!(self, RGBtoHLS, effect_ref.as_ptr(), rgb as *const _ as *mut _, &mut hls as *mut _ as *mut _)?;
+        call_suite_fn!(
+            self,
+            RGBtoHLS,
+            effect_ref.as_ptr(),
+            rgb as *const _ as *mut _,
+            &mut hls as *mut _ as *mut _
+        )?;
         Ok(hls)
     }
 
     /// Given an HLS pixel, returns an RGB pixel.
-    pub fn hls_to_rgb(&self, effect_ref: impl AsPtr<PF_ProgPtr>, hls: &HLSPixel) -> Result<Pixel8, Error> {
+    pub fn hls_to_rgb(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        hls: &HLSPixel,
+    ) -> Result<Pixel8, Error> {
         let mut rgb = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, HLStoRGB, effect_ref.as_ptr(), hls as *const _ as *mut _, &mut rgb)?;
+        call_suite_fn!(
+            self,
+            HLStoRGB,
+            effect_ref.as_ptr(),
+            hls as *const _ as *mut _,
+            &mut rgb
+        )?;
         Ok(rgb)
     }
 
     /// Given an RGB pixel, returns a YIQ (luminance, inphase chrominance, quadrature chrominance) pixel.
     /// Y is 0 to 1 in fixed point, I is -0.5959 to 0.5959 in fixed point, and Q is -0.5227 to 0.5227 in fixed point.
-    pub fn rgb_to_yiq(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &Pixel8) -> Result<YIQPixel, Error> {
+    pub fn rgb_to_yiq(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &Pixel8,
+    ) -> Result<YIQPixel, Error> {
         let mut yiq = YIQPixel::default();
-        call_suite_fn!(self, RGBtoYIQ, effect_ref.as_ptr(), rgb as *const _ as *mut _, &mut yiq as *mut _ as *mut _)?;
+        call_suite_fn!(
+            self,
+            RGBtoYIQ,
+            effect_ref.as_ptr(),
+            rgb as *const _ as *mut _,
+            &mut yiq as *mut _ as *mut _
+        )?;
         Ok(yiq)
     }
 
     /// Given a YIQ pixel, returns an RGB pixel.
-    pub fn yiq_to_rgb(&self, effect_ref: impl AsPtr<PF_ProgPtr>, yiq: &YIQPixel) -> Result<Pixel8, Error> {
+    pub fn yiq_to_rgb(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        yiq: &YIQPixel,
+    ) -> Result<Pixel8, Error> {
         let mut rgb = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, YIQtoRGB, effect_ref.as_ptr(), yiq as *const _ as *mut _, &mut rgb)?;
+        call_suite_fn!(
+            self,
+            YIQtoRGB,
+            effect_ref.as_ptr(),
+            yiq as *const _ as *mut _,
+            &mut rgb
+        )?;
         Ok(rgb)
     }
 
     /// Given an RGB pixel, returns 100 times its luminance value (0 to 25500).
-    pub fn luminance(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &Pixel8) -> Result<i32, Error> {
+    pub fn luminance(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &Pixel8,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, Luminance -> i32, effect_ref.as_ptr(), rgb as *const _ as *mut _)
     }
 
@@ -57,12 +98,20 @@ impl ColorCallbacksSuite {
     }
 
     /// Given an RGB pixel, returns its lightness value (0 to 255).
-    pub fn lightness(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &Pixel8) -> Result<i32, Error> {
+    pub fn lightness(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &Pixel8,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, Lightness -> i32, effect_ref.as_ptr(), rgb as *const _ as *mut _)
     }
 
     /// Given an RGB pixel, returns its saturation value (0 to 255).
-    pub fn saturation(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &Pixel8) -> Result<i32, Error> {
+    pub fn saturation(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &Pixel8,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, Saturation -> i32, effect_ref.as_ptr(), rgb as *const _ as *mut _)
     }
 }
@@ -78,41 +127,83 @@ define_suite!(
 impl ColorCallbacks16Suite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Given an RGB pixel, returns an HLS (hue, lightness, saturation) pixel. HLS values are scaled from 0 to 1 in fixed point.
-    pub fn rgb_to_hls(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &Pixel16) -> Result<HLSPixel, Error> {
+    pub fn rgb_to_hls(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &Pixel16,
+    ) -> Result<HLSPixel, Error> {
         let mut hls = HLSPixel::default();
-        call_suite_fn!(self, RGBtoHLS, effect_ref.as_ptr(), rgb as *const _ as *mut _, &mut hls as *mut _ as *mut _)?;
+        call_suite_fn!(
+            self,
+            RGBtoHLS,
+            effect_ref.as_ptr(),
+            rgb as *const _ as *mut _,
+            &mut hls as *mut _ as *mut _
+        )?;
         Ok(hls)
     }
 
     /// Given an HLS pixel, returns an RGB pixel.
-    pub fn hls_to_rgb(&self, effect_ref: impl AsPtr<PF_ProgPtr>, hls: &HLSPixel) -> Result<Pixel16, Error> {
+    pub fn hls_to_rgb(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        hls: &HLSPixel,
+    ) -> Result<Pixel16, Error> {
         let mut rgb = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, HLStoRGB, effect_ref.as_ptr(), hls as *const _ as *mut _, &mut rgb)?;
+        call_suite_fn!(
+            self,
+            HLStoRGB,
+            effect_ref.as_ptr(),
+            hls as *const _ as *mut _,
+            &mut rgb
+        )?;
         Ok(rgb)
     }
 
     /// Given an RGB pixel, returns a YIQ (luminance, inphase chrominance, quadrature chrominance) pixel.
     /// Y is 0 to 1 in fixed point, I is -0.5959 to 0.5959 in fixed point, and Q is -0.5227 to 0.5227 in fixed point.
-    pub fn rgb_to_yiq(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &Pixel8) -> Result<YIQPixel, Error> {
+    pub fn rgb_to_yiq(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &Pixel8,
+    ) -> Result<YIQPixel, Error> {
         let mut yiq = YIQPixel::default();
-        call_suite_fn!(self, RGBtoYIQ, effect_ref.as_ptr(), rgb as *const _ as *mut _, &mut yiq as *mut _ as *mut _)?;
+        call_suite_fn!(
+            self,
+            RGBtoYIQ,
+            effect_ref.as_ptr(),
+            rgb as *const _ as *mut _,
+            &mut yiq as *mut _ as *mut _
+        )?;
         Ok(yiq)
     }
 
     /// Given a YIQ pixel, returns an RGB pixel.
-    pub fn yiq_to_rgb(&self, effect_ref: impl AsPtr<PF_ProgPtr>, yiq: &YIQPixel) -> Result<Pixel16, Error> {
+    pub fn yiq_to_rgb(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        yiq: &YIQPixel,
+    ) -> Result<Pixel16, Error> {
         let mut rgb = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, YIQtoRGB, effect_ref.as_ptr(), yiq as *const _ as *mut _, &mut rgb)?;
+        call_suite_fn!(
+            self,
+            YIQtoRGB,
+            effect_ref.as_ptr(),
+            yiq as *const _ as *mut _,
+            &mut rgb
+        )?;
         Ok(rgb)
     }
 
     /// Given an RGB pixel, returns 100 times its luminance value (0 to 25500).
-    pub fn luminance(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &Pixel16) -> Result<i32, Error> {
+    pub fn luminance(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &Pixel16,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, Luminance -> i32, effect_ref.as_ptr(), rgb as *const _ as *mut _)
     }
 
@@ -122,12 +213,20 @@ impl ColorCallbacks16Suite {
     }
 
     /// Given an RGB pixel, returns its lightness value (0 to 255).
-    pub fn lightness(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &Pixel16) -> Result<i32, Error> {
+    pub fn lightness(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &Pixel16,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, Lightness -> i32, effect_ref.as_ptr(), rgb as *const _ as *mut _)
     }
 
     /// Given an RGB pixel, returns its saturation value (0 to 255).
-    pub fn saturation(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &Pixel16) -> Result<i32, Error> {
+    pub fn saturation(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &Pixel16,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, Saturation -> i32, effect_ref.as_ptr(), rgb as *const _ as *mut _)
     }
 }
@@ -143,41 +242,83 @@ define_suite!(
 impl ColorCallbacksFloatSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Given an RGB pixel, returns an HLS (hue, lightness, saturation) pixel. HLS values are scaled from 0 to 1 in fixed point.
-    pub fn rgb_to_hls(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &PixelF32) -> Result<HLSPixel, Error> {
+    pub fn rgb_to_hls(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &PixelF32,
+    ) -> Result<HLSPixel, Error> {
         let mut hls = HLSPixel::default();
-        call_suite_fn!(self, RGBtoHLS, effect_ref.as_ptr(), rgb as *const _ as *mut _, &mut hls as *mut _ as *mut _)?;
+        call_suite_fn!(
+            self,
+            RGBtoHLS,
+            effect_ref.as_ptr(),
+            rgb as *const _ as *mut _,
+            &mut hls as *mut _ as *mut _
+        )?;
         Ok(hls)
     }
 
     /// Given an HLS pixel, returns an RGB pixel.
-    pub fn hls_to_rgb(&self, effect_ref: impl AsPtr<PF_ProgPtr>, hls: &HLSPixel) -> Result<PixelF32, Error> {
+    pub fn hls_to_rgb(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        hls: &HLSPixel,
+    ) -> Result<PixelF32, Error> {
         let mut rgb = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, HLStoRGB, effect_ref.as_ptr(), hls as *const _ as *mut _, &mut rgb)?;
+        call_suite_fn!(
+            self,
+            HLStoRGB,
+            effect_ref.as_ptr(),
+            hls as *const _ as *mut _,
+            &mut rgb
+        )?;
         Ok(rgb)
     }
 
     /// Given an RGB pixel, returns a YIQ (luminance, inphase chrominance, quadrature chrominance) pixel.
     /// Y is 0 to 1 in fixed point, I is -0.5959 to 0.5959 in fixed point, and Q is -0.5227 to 0.5227 in fixed point.
-    pub fn rgb_to_yiq(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &Pixel8) -> Result<YIQPixel, Error> {
+    pub fn rgb_to_yiq(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &Pixel8,
+    ) -> Result<YIQPixel, Error> {
         let mut yiq = YIQPixel::default();
-        call_suite_fn!(self, RGBtoYIQ, effect_ref.as_ptr(), rgb as *const _ as *mut _, &mut yiq as *mut _ as *mut _)?;
+        call_suite_fn!(
+            self,
+            RGBtoYIQ,
+            effect_ref.as_ptr(),
+            rgb as *const _ as *mut _,
+            &mut yiq as *mut _ as *mut _
+        )?;
         Ok(yiq)
     }
 
     /// Given a YIQ pixel, returns an RGB pixel.
-    pub fn yiq_to_rgb(&self, effect_ref: impl AsPtr<PF_ProgPtr>, yiq: &YIQPixel) -> Result<PixelF32, Error> {
+    pub fn yiq_to_rgb(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        yiq: &YIQPixel,
+    ) -> Result<PixelF32, Error> {
         let mut rgb = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, YIQtoRGB, effect_ref.as_ptr(), yiq as *const _ as *mut _, &mut rgb)?;
+        call_suite_fn!(
+            self,
+            YIQtoRGB,
+            effect_ref.as_ptr(),
+            yiq as *const _ as *mut _,
+            &mut rgb
+        )?;
         Ok(rgb)
     }
 
     /// Given an RGB pixel, returns 100 times its luminance value (0 to 25500).
-    pub fn luminance(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &PixelF32) -> Result<f32, Error> {
+    pub fn luminance(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &PixelF32,
+    ) -> Result<f32, Error> {
         call_suite_fn_single!(self, Luminance -> f32, effect_ref.as_ptr(), rgb as *const _ as *mut _)
     }
 
@@ -187,12 +328,20 @@ impl ColorCallbacksFloatSuite {
     }
 
     /// Given an RGB pixel, returns its lightness value (0 to 255).
-    pub fn lightness(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &PixelF32) -> Result<f32, Error> {
+    pub fn lightness(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &PixelF32,
+    ) -> Result<f32, Error> {
         call_suite_fn_single!(self, Lightness -> f32, effect_ref.as_ptr(), rgb as *const _ as *mut _)
     }
 
     /// Given an RGB pixel, returns its saturation value (0 to 255).
-    pub fn saturation(&self, effect_ref: impl AsPtr<PF_ProgPtr>, rgb: &PixelF32) -> Result<f32, Error> {
+    pub fn saturation(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        rgb: &PixelF32,
+    ) -> Result<f32, Error> {
         call_suite_fn_single!(self, Saturation -> f32, effect_ref.as_ptr(), rgb as *const _ as *mut _)
     }
 }

--- a/after-effects/src/pf/suites/custom_ui.rs
+++ b/after-effects/src/pf/suites/custom_ui.rs
@@ -20,23 +20,28 @@ define_suite!(
 impl EffectCustomUISuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Obtain [`Drawbot`](drawbot::Drawbot) for the provided context handle.
-    pub fn drawing_reference(&self, context_handle: impl AsPtr<ae_sys::PF_ContextH>) -> Result<drawbot::Drawbot, Error> {
+    pub fn drawing_reference(
+        &self,
+        context_handle: impl AsPtr<ae_sys::PF_ContextH>,
+    ) -> Result<drawbot::Drawbot, Error> {
         Ok(drawbot::Drawbot {
             suite: crate::Suite::new()?,
-            handle: call_suite_fn_single!(self, PF_GetDrawingReference -> ae_sys::DRAWBOT_DrawRef, context_handle.as_ptr())?
+            handle: call_suite_fn_single!(self, PF_GetDrawingReference -> ae_sys::DRAWBOT_DrawRef, context_handle.as_ptr())?,
         })
     }
 
     /// Obtain the [`aegp::AsyncManager`].
-    pub fn context_async_manager(&self, in_data: impl AsPtr<*const ae_sys::PF_InData>, extra: impl AsPtr<*mut ae_sys::PF_EventExtra>) -> Result<aegp::AsyncManager, Error> {
+    pub fn context_async_manager(
+        &self,
+        in_data: impl AsPtr<*const ae_sys::PF_InData>,
+        extra: impl AsPtr<*mut ae_sys::PF_EventExtra>,
+    ) -> Result<aegp::AsyncManager, Error> {
         let v2suite = EffectCustomUISuite2::new()?;
         Ok(aegp::AsyncManager::from_raw(
-            call_suite_fn_single!(v2suite, PF_GetContextAsyncManager -> ae_sys::PF_AsyncManagerP, in_data.as_ptr() as *mut _, extra.as_ptr())?
+            call_suite_fn_single!(v2suite, PF_GetContextAsyncManager -> ae_sys::PF_AsyncManagerP, in_data.as_ptr() as *mut _, extra.as_ptr())?,
         ))
     }
 }
@@ -56,9 +61,7 @@ define_suite!(
 impl EffectCustomUIOverlayThemeSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Get the preferred foreground color.
     pub fn preferred_foreground_color(&self) -> Result<drawbot::ColorRgba, Error> {
@@ -90,20 +93,53 @@ impl EffectCustomUIOverlayThemeSuite {
     /// Optionally draw the shadow using the overlay theme shadow color.
     ///
     /// Uses overlay theme stroke width for stroking foreground and shadow strokes.
-    pub fn stroke_path(&self, drawbot: impl AsPtr<ae_sys::DRAWBOT_DrawRef>, path: impl AsPtr<ae_sys::DRAWBOT_PathRef>, draw_shadow: bool) -> Result<(), Error> {
-        call_suite_fn!(self, PF_StrokePath, drawbot.as_ptr(), path.as_ptr(), draw_shadow as _)
+    pub fn stroke_path(
+        &self,
+        drawbot: impl AsPtr<ae_sys::DRAWBOT_DrawRef>,
+        path: impl AsPtr<ae_sys::DRAWBOT_PathRef>,
+        draw_shadow: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PF_StrokePath,
+            drawbot.as_ptr(),
+            path.as_ptr(),
+            draw_shadow as _
+        )
     }
 
     /// Fills the path with overlay theme foreground color.
     ///
     /// Optionally draw the shadow using the overlay theme shadow color.
-    pub fn fill_path(&self, drawbot: impl AsPtr<ae_sys::DRAWBOT_DrawRef>, path: impl AsPtr<ae_sys::DRAWBOT_PathRef>, draw_shadow: bool) -> Result<(), Error> {
-        call_suite_fn!(self, PF_FillPath, drawbot.as_ptr(), path.as_ptr(), draw_shadow as _)
+    pub fn fill_path(
+        &self,
+        drawbot: impl AsPtr<ae_sys::DRAWBOT_DrawRef>,
+        path: impl AsPtr<ae_sys::DRAWBOT_PathRef>,
+        draw_shadow: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PF_FillPath,
+            drawbot.as_ptr(),
+            path.as_ptr(),
+            draw_shadow as _
+        )
     }
 
     /// Fills a square vertex around the center point using the overlay theme foreground color and vertex size.
-    pub fn fill_vertex(&self, drawbot: impl AsPtr<ae_sys::DRAWBOT_DrawRef>, center_point: FloatPoint, draw_shadow: bool) -> Result<(), Error> {
-        call_suite_fn!(self, PF_FillVertex, drawbot.as_ptr(), &center_point.into(), draw_shadow as _)
+    pub fn fill_vertex(
+        &self,
+        drawbot: impl AsPtr<ae_sys::DRAWBOT_DrawRef>,
+        center_point: FloatPoint,
+        draw_shadow: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PF_FillVertex,
+            drawbot.as_ptr(),
+            &center_point.into(),
+            draw_shadow as _
+        )
     }
 }
 
@@ -131,13 +167,9 @@ impl ContextHandle {
 pub struct CustomUIInfo(ae_sys::PF_CustomUIInfo);
 
 impl CustomUIInfo {
-    pub fn new() -> Self {
-        Self(unsafe { std::mem::zeroed() })
-    }
+    pub fn new() -> Self { Self(unsafe { std::mem::zeroed() }) }
 
-    pub fn as_ptr(&self) -> *const ae_sys::PF_CustomUIInfo {
-        &self.0
-    }
+    pub fn as_ptr(&self) -> *const ae_sys::PF_CustomUIInfo { &self.0 }
 
     pub fn events(mut self, events: CustomEventFlags) -> Self {
         self.0.events = events.bits() as _;

--- a/after-effects/src/pf/suites/effect_sequence_data.rs
+++ b/after-effects/src/pf/suites/effect_sequence_data.rs
@@ -11,12 +11,13 @@ define_suite!(
 impl EffectSequenceDataSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Retrieves the read-only const sequence_data object for a rendering thread when Multi-Frame Rendering is enabled for an effect.
-    pub fn const_sequence_data(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>) -> Result<ae_sys::PF_ConstHandle, Error> {
+    pub fn const_sequence_data(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+    ) -> Result<ae_sys::PF_ConstHandle, Error> {
         call_suite_fn_single!(self, PF_GetConstSequenceData -> ae_sys::PF_ConstHandle, effect_ref.as_ptr())
     }
 }

--- a/after-effects/src/pf/suites/effect_ui.rs
+++ b/after-effects/src/pf/suites/effect_ui.rs
@@ -11,18 +11,25 @@ define_suite!(
 impl EffectUISuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Changes the text on the options button in the effect controls palette.
     ///
     /// Button name can be up to 31 characters.
     ///
     /// NOTE: This must be called during [`Command::ParamsSetup`].
-    pub fn set_options_button_name(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, name: &str) -> Result<(), Error> {
+    pub fn set_options_button_name(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        name: &str,
+    ) -> Result<(), Error> {
         assert!(name.len() < 31);
         let name = std::ffi::CString::new(name).unwrap();
-        call_suite_fn!(self, PF_SetOptionsButtonName, effect_ref.as_ptr(), name.as_ptr())
+        call_suite_fn!(
+            self,
+            PF_SetOptionsButtonName,
+            effect_ref.as_ptr(),
+            name.as_ptr()
+        )
     }
 }

--- a/after-effects/src/pf/suites/fill_matte.rs
+++ b/after-effects/src/pf/suites/fill_matte.rs
@@ -1,4 +1,3 @@
-
 use crate::*;
 use ae_sys::*;
 
@@ -13,35 +12,89 @@ define_suite!(
 impl FillMatteSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
+    /// Fills a `rect` with a `color` (or, if the color is `None`, fills with black and alpha zero).
+    ///
+    /// If the `rect` is `None`, it fills the entire image.
+    pub fn fill(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        mut world: impl AsMutPtr<*mut PF_EffectWorld>,
+        color: Option<Pixel8>,
+        rect: Option<Rect>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            fill,
+            effect_ref.as_ptr(),
+            color.as_ref().map_or(std::ptr::null(), |x| x),
+            rect.map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null(), |x| x),
+            world.as_mut_ptr()
+        )
     }
 
     /// Fills a `rect` with a `color` (or, if the color is `None`, fills with black and alpha zero).
     ///
     /// If the `rect` is `None`, it fills the entire image.
-    pub fn fill(&self, effect_ref: impl AsPtr<PF_ProgPtr>, mut world: impl AsMutPtr<*mut PF_EffectWorld>, color: Option<Pixel8>, rect: Option<Rect>) -> Result<(), Error> {
-        call_suite_fn!(self, fill, effect_ref.as_ptr(), color.as_ref().map_or(std::ptr::null(), |x| x), rect.map(Into::into).as_ref().map_or(std::ptr::null(), |x| x), world.as_mut_ptr())
+    pub fn fill16(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        mut world: impl AsMutPtr<*mut PF_EffectWorld>,
+        color: Option<Pixel16>,
+        rect: Option<Rect>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            fill16,
+            effect_ref.as_ptr(),
+            color.as_ref().map_or(std::ptr::null(), |x| x),
+            rect.map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null(), |x| x),
+            world.as_mut_ptr()
+        )
     }
 
     /// Fills a `rect` with a `color` (or, if the color is `None`, fills with black and alpha zero).
     ///
     /// If the `rect` is `None`, it fills the entire image.
-    pub fn fill16(&self, effect_ref: impl AsPtr<PF_ProgPtr>, mut world: impl AsMutPtr<*mut PF_EffectWorld>, color: Option<Pixel16>, rect: Option<Rect>) -> Result<(), Error> {
-        call_suite_fn!(self, fill16, effect_ref.as_ptr(), color.as_ref().map_or(std::ptr::null(), |x| x), rect.map(Into::into).as_ref().map_or(std::ptr::null(), |x| x), world.as_mut_ptr())
-    }
-
-    /// Fills a `rect` with a `color` (or, if the color is `None`, fills with black and alpha zero).
-    ///
-    /// If the `rect` is `None`, it fills the entire image.
-    pub fn fill_float(&self, effect_ref: impl AsPtr<PF_ProgPtr>, mut world: impl AsMutPtr<*mut PF_EffectWorld>, color: Option<PixelF32>, rect: Option<Rect>) -> Result<(), Error> {
-        call_suite_fn!(self, fill_float, effect_ref.as_ptr(), color.as_ref().map_or(std::ptr::null(), |x| x), rect.map(Into::into).as_ref().map_or(std::ptr::null(), |x| x), world.as_mut_ptr())
+    pub fn fill_float(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        mut world: impl AsMutPtr<*mut PF_EffectWorld>,
+        color: Option<PixelF32>,
+        rect: Option<Rect>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            fill_float,
+            effect_ref.as_ptr(),
+            color.as_ref().map_or(std::ptr::null(), |x| x),
+            rect.map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null(), |x| x),
+            world.as_mut_ptr()
+        )
     }
 
     /// Converts to (and from) r, g, and b color values pre-multiplied with black to represent the alpha channel.
     /// * `forward` - `true` means convert non-premultiplied to pre-multiplied; `false` means un-pre-multiply.
-    pub fn premultiply(&self, effect_ref: impl AsPtr<PF_ProgPtr>, mut world: impl AsMutPtr<*mut PF_EffectWorld>, forward: bool) -> Result<(), Error> {
-        call_suite_fn!(self, premultiply, effect_ref.as_ptr(), forward as _, world.as_mut_ptr())
+    pub fn premultiply(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        mut world: impl AsMutPtr<*mut PF_EffectWorld>,
+        forward: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            premultiply,
+            effect_ref.as_ptr(),
+            forward as _,
+            world.as_mut_ptr()
+        )
     }
 
     /// Converts to (and from) having r, g, and b color values premultiplied with any color to represent the alpha channel.
@@ -49,8 +102,23 @@ impl FillMatteSuite {
     /// * `forward` - `true` means convert non-premultiplied to pre-multiplied; `false` means un-pre-multiply.
     ///
     /// To convert between premul and straight pixel buffers where the color channels were matted with a color other than black.
-    pub fn premultiply_color(&self, effect_ref: impl AsPtr<PF_ProgPtr>, src: impl AsPtr<*const PF_EffectWorld>, color: &Pixel8, forward: bool, mut dst: impl AsMutPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
-        call_suite_fn!(self, premultiply_color, effect_ref.as_ptr(), src.as_ptr() as *mut _, color, forward as _, dst.as_mut_ptr())
+    pub fn premultiply_color(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        src: impl AsPtr<*const PF_EffectWorld>,
+        color: &Pixel8,
+        forward: bool,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            premultiply_color,
+            effect_ref.as_ptr(),
+            src.as_ptr() as *mut _,
+            color,
+            forward as _,
+            dst.as_mut_ptr()
+        )
     }
 
     /// Converts to (and from) having r, g, and b color values premultiplied with any color to represent the alpha channel.
@@ -58,8 +126,23 @@ impl FillMatteSuite {
     /// * `forward` - `true` means convert non-premultiplied to pre-multiplied; `false` means un-pre-multiply.
     ///
     /// To convert between premul and straight pixel buffers where the color channels were matted with a color other than black.
-    pub fn premultiply_color16(&self, effect_ref: impl AsPtr<PF_ProgPtr>, src: impl AsPtr<*const PF_EffectWorld>, color: &Pixel16, forward: bool, mut dst: impl AsMutPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
-        call_suite_fn!(self, premultiply_color16, effect_ref.as_ptr(), src.as_ptr() as *mut _, color, forward as _, dst.as_mut_ptr())
+    pub fn premultiply_color16(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        src: impl AsPtr<*const PF_EffectWorld>,
+        color: &Pixel16,
+        forward: bool,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            premultiply_color16,
+            effect_ref.as_ptr(),
+            src.as_ptr() as *mut _,
+            color,
+            forward as _,
+            dst.as_mut_ptr()
+        )
     }
 
     /// Converts to (and from) having r, g, and b color values premultiplied with any color to represent the alpha channel.
@@ -67,7 +150,22 @@ impl FillMatteSuite {
     /// * `forward` - `true` means convert non-premultiplied to pre-multiplied; `false` means un-pre-multiply.
     ///
     /// To convert between premul and straight pixel buffers where the color channels were matted with a color other than black.
-    pub fn premultiply_color_float(&self, effect_ref: impl AsPtr<PF_ProgPtr>, src: impl AsPtr<*const PF_EffectWorld>, color: &PixelF32, forward: bool, mut dst: impl AsMutPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
-        call_suite_fn!(self, premultiply_color_float, effect_ref.as_ptr(), src.as_ptr() as *mut _, color, forward as _, dst.as_mut_ptr())
+    pub fn premultiply_color_float(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        src: impl AsPtr<*const PF_EffectWorld>,
+        color: &PixelF32,
+        forward: bool,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            premultiply_color_float,
+            effect_ref.as_ptr(),
+            src.as_ptr() as *mut _,
+            color,
+            forward as _,
+            dst.as_mut_ptr()
+        )
     }
 }

--- a/after-effects/src/pf/suites/gpu_device.rs
+++ b/after-effects/src/pf/suites/gpu_device.rs
@@ -1,6 +1,6 @@
 use crate::*;
+use ae_sys::{A_u_long, PF_EffectWorld, PF_InData, PF_ProgPtr};
 use std::ffi::c_void;
-use ae_sys:: { A_u_long, PF_EffectWorld, PF_InData, PF_ProgPtr };
 
 define_suite!(
     GPUDeviceSuite,
@@ -11,9 +11,7 @@ define_suite!(
 impl GPUDeviceSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// This will return the number of gpu devices the host supports.
     /// * `effect_ref` - Effect reference from [`InData`](crate::InData::effect_ref).
@@ -29,7 +27,11 @@ impl GPUDeviceSuite {
     /// * `device_index` - The device index for the requested device.
     ///
     /// Returns the device info will to be filled.
-    pub fn device_info(&self, effect_ref: impl AsPtr<PF_ProgPtr>, device_index: usize) -> Result<ae_sys::PF_GPUDeviceInfo, Error> {
+    pub fn device_info(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        device_index: usize,
+    ) -> Result<ae_sys::PF_GPUDeviceInfo, Error> {
         call_suite_fn_single!(self, GetDeviceInfo -> ae_sys::PF_GPUDeviceInfo, effect_ref.as_ptr(), device_index as _)
     }
 
@@ -38,8 +40,17 @@ impl GPUDeviceSuite {
     /// These calls do not need to be made in that case.
     /// * `effect_ref`   - Effect reference from [`InData`](crate::InData::effect_ref).
     /// * `device_index` - The device index for the requested device.
-    pub fn acquire_exclusive_device_access(&self, effect_ref: impl AsPtr<PF_ProgPtr>, device_index: usize) -> Result<(), Error> {
-        call_suite_fn!(self, AcquireExclusiveDeviceAccess, effect_ref.as_ptr(), device_index as _)
+    pub fn acquire_exclusive_device_access(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        device_index: usize,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AcquireExclusiveDeviceAccess,
+            effect_ref.as_ptr(),
+            device_index as _
+        )
     }
 
     /// Acquire/release exclusive access to `device_index`. All calls below this point generally require access be held.
@@ -47,8 +58,17 @@ impl GPUDeviceSuite {
     /// These calls do not need to be made in that case.
     /// * `effect_ref`   - Effect reference from [`InData`](crate::InData::effect_ref).
     /// * `device_index` - The device index for the requested device.
-    pub fn release_exclusive_device_access(&self, effect_ref: impl AsPtr<PF_ProgPtr>, device_index: usize) -> Result<(), Error> {
-        call_suite_fn!(self, ReleaseExclusiveDeviceAccess, effect_ref.as_ptr(), device_index as _)
+    pub fn release_exclusive_device_access(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        device_index: usize,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            ReleaseExclusiveDeviceAccess,
+            effect_ref.as_ptr(),
+            device_index as _
+        )
     }
 
     /// All device memory must be allocated through this suite.
@@ -59,7 +79,12 @@ impl GPUDeviceSuite {
     /// * `size_bytes` - The size of the memory to allocate.
     ///
     /// Returns the pointer to the allocated memory.
-    pub fn allocate_device_memory(&self, effect_ref: impl AsPtr<PF_ProgPtr>, device_index: usize, size_bytes: usize) -> Result<*mut c_void, Error> {
+    pub fn allocate_device_memory(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        device_index: usize,
+        size_bytes: usize,
+    ) -> Result<*mut c_void, Error> {
         call_suite_fn_single!(self, AllocateDeviceMemory -> *mut c_void, effect_ref.as_ptr(), device_index as _, size_bytes)
     }
 
@@ -67,8 +92,19 @@ impl GPUDeviceSuite {
     /// * `effect_ref` - Effect reference from [`InData`](crate::InData::effect_ref).
     /// * `device_index` - The device index for the requested device.
     /// * `memory` - The pointer to the memory to free.
-    pub fn free_device_memory(&self, effect_ref: impl AsPtr<PF_ProgPtr>, device_index: usize, memory: *mut c_void) -> Result<(), Error> {
-        call_suite_fn!(self, FreeDeviceMemory, effect_ref.as_ptr(), device_index as _, memory)
+    pub fn free_device_memory(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        device_index: usize,
+        memory: *mut c_void,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            FreeDeviceMemory,
+            effect_ref.as_ptr(),
+            device_index as _,
+            memory
+        )
     }
 
     /// Purge the device memory.
@@ -77,8 +113,15 @@ impl GPUDeviceSuite {
     /// * `size_bytes` - The size of the memory to purge.
     ///
     /// Returns the number of bytes purged.
-    pub fn purge_device_memory(&self, effect_ref: impl AsPtr<PF_ProgPtr>, device_index: usize, size_bytes: usize) -> Result<usize, Error> {
-        Ok(call_suite_fn_single!(self, PurgeDeviceMemory -> usize, effect_ref.as_ptr(), device_index as _, size_bytes)?)
+    pub fn purge_device_memory(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        device_index: usize,
+        size_bytes: usize,
+    ) -> Result<usize, Error> {
+        Ok(
+            call_suite_fn_single!(self, PurgeDeviceMemory -> usize, effect_ref.as_ptr(), device_index as _, size_bytes)?,
+        )
     }
 
     /// All host (pinned) memory must be allocated through this suite.
@@ -89,7 +132,12 @@ impl GPUDeviceSuite {
     /// * `size_bytes` - The size of the memory to allocate.
     ///
     /// Returns the pointer to the allocated memory.
-    pub fn allocate_host_memory(&self, effect_ref: impl AsPtr<PF_ProgPtr>, device_index: usize, size_bytes: usize) -> Result<*mut c_void, Error> {
+    pub fn allocate_host_memory(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        device_index: usize,
+        size_bytes: usize,
+    ) -> Result<*mut c_void, Error> {
         call_suite_fn_single!(self, AllocateHostMemory -> *mut c_void, effect_ref.as_ptr(), device_index as _, size_bytes)
     }
 
@@ -97,8 +145,19 @@ impl GPUDeviceSuite {
     /// * `effect_ref` - Effect reference from [`InData`](crate::InData::effect_ref).
     /// * `device_index` - The device index for the requested device.
     /// * `memory` - The pointer to the memory to free.
-    pub fn free_host_memory(&self, effect_ref: impl AsPtr<PF_ProgPtr>, device_index: usize, memory: *mut c_void) -> Result<(), Error> {
-        call_suite_fn!(self, FreeHostMemory, effect_ref.as_ptr(), device_index as _, memory)
+    pub fn free_host_memory(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        device_index: usize,
+        memory: *mut c_void,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            FreeHostMemory,
+            effect_ref.as_ptr(),
+            device_index as _,
+            memory
+        )
     }
 
     /// Purge the host memory.
@@ -107,8 +166,15 @@ impl GPUDeviceSuite {
     /// * `bytes_to_purge` - The size of the memory to purge.
     ///
     /// Returns the number of bytes purged.
-    pub fn purge_host_memory(&self, effect_ref: impl AsPtr<PF_ProgPtr>, device_index: usize, bytes_to_purge: usize) -> Result<usize, Error> {
-        Ok(call_suite_fn_single!(self, PurgeHostMemory -> usize, effect_ref.as_ptr(), device_index as _, bytes_to_purge)?)
+    pub fn purge_host_memory(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        device_index: usize,
+        bytes_to_purge: usize,
+    ) -> Result<usize, Error> {
+        Ok(
+            call_suite_fn_single!(self, PurgeHostMemory -> usize, effect_ref.as_ptr(), device_index as _, bytes_to_purge)?,
+        )
     }
 
     /// This will allocate a gpu effect world. Caller is responsible for deallocating the buffer with [`dispose_gpu_world()`](Self::dispose_gpu_world).
@@ -122,19 +188,43 @@ impl GPUDeviceSuite {
     /// * `clear_pix` - Pass in 'true' for a transparent black frame.
     ///
     /// Returns the handle to the effect world to be created.
-    pub fn create_gpu_world(&self, in_data: impl AsPtr<*const PF_InData>, device_index: usize, width: i32, height: i32, pixel_aspect_ratio: RationalScale, field_type: Field, pixel_format: pf::PixelFormat, clear_pix: bool) -> Result<Layer, Error> {
+    pub fn create_gpu_world(
+        &self,
+        in_data: impl AsPtr<*const PF_InData>,
+        device_index: usize,
+        width: i32,
+        height: i32,
+        pixel_aspect_ratio: RationalScale,
+        field_type: Field,
+        pixel_format: pf::PixelFormat,
+        clear_pix: bool,
+    ) -> Result<Layer, Error> {
         let layer = call_suite_fn_single!(self, CreateGPUWorld -> *mut PF_EffectWorld, (*in_data.as_ptr()).effect_ref, device_index as _, width, height, pixel_aspect_ratio.into(), field_type.into(), pixel_format.into(), clear_pix as _)?;
 
-        Ok(Layer::from_raw(layer, in_data, Some(|self_layer| {
-            GPUDeviceSuite::new().unwrap().dispose_gpu_world(unsafe { (*self_layer.in_data_ptr).effect_ref }, self_layer.as_mut_ptr()).unwrap();
-        })))
+        Ok(Layer::from_raw(
+            layer,
+            in_data,
+            Some(|self_layer| {
+                GPUDeviceSuite::new()
+                    .unwrap()
+                    .dispose_gpu_world(
+                        unsafe { (*self_layer.in_data_ptr).effect_ref },
+                        self_layer.as_mut_ptr(),
+                    )
+                    .unwrap();
+            }),
+        ))
     }
 
     /// This will free this effect world. The effect world is no longer valid after this function is called.
     /// Plugin module is only allowed to dispose of gpu effect worlds they create.
     /// * `effect_ref` - Effect reference from [`InData`](crate::InData::effect_ref).
     /// * `world` - The effect world you want to dispose.
-    pub fn dispose_gpu_world(&self, effect_ref: impl AsPtr<PF_ProgPtr>, world: *mut ae_sys::PF_EffectWorld) -> Result<(), Error> {
+    pub fn dispose_gpu_world(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        world: *mut ae_sys::PF_EffectWorld,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, DisposeGPUWorld, effect_ref.as_ptr(), world)
     }
 
@@ -143,7 +233,11 @@ impl GPUDeviceSuite {
     /// * `world` - The effect world you want to operate on, has to be a gpu effect world.
     ///
     /// Returns the gpu buffer address.
-    pub fn gpu_world_data(&self, effect_ref: impl AsPtr<PF_ProgPtr>, mut world: impl AsMutPtr<*mut ae_sys::PF_EffectWorld>) -> Result<*mut std::ffi::c_void, Error> {
+    pub fn gpu_world_data(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        mut world: impl AsMutPtr<*mut ae_sys::PF_EffectWorld>,
+    ) -> Result<*mut std::ffi::c_void, Error> {
         call_suite_fn_single!(self, GetGPUWorldData -> *mut c_void, effect_ref.as_ptr(), world.as_mut_ptr())
     }
 
@@ -152,8 +246,14 @@ impl GPUDeviceSuite {
     /// * `world` - The effect world you want to operate on, has to be a gpu effect world.
     ///
     /// Returns the size of the total data in the effect world.
-    pub fn gpu_world_size(&self, effect_ref: impl AsPtr<PF_ProgPtr>, world: impl AsPtr<*mut ae_sys::PF_EffectWorld>) -> Result<usize, Error> {
-        Ok(call_suite_fn_single!(self, GetGPUWorldSize -> usize, effect_ref.as_ptr(), world.as_ptr())?)
+    pub fn gpu_world_size(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        world: impl AsPtr<*mut ae_sys::PF_EffectWorld>,
+    ) -> Result<usize, Error> {
+        Ok(
+            call_suite_fn_single!(self, GetGPUWorldSize -> usize, effect_ref.as_ptr(), world.as_ptr())?,
+        )
     }
 
     /// This will return device index the gpu effect world is associated with.
@@ -161,7 +261,14 @@ impl GPUDeviceSuite {
     /// * `world` - The effect world you want to operate on, has to be a gpu effect world.
     ///
     /// Returns the device index of the given effect world.
-    pub fn gpu_world_device_index(&self, effect_ref: impl AsPtr<PF_ProgPtr>, world: impl AsPtr<*mut ae_sys::PF_EffectWorld>) -> Result<usize, Error> {
-        Ok(call_suite_fn_single!(self, GetGPUWorldDeviceIndex -> A_u_long, effect_ref.as_ptr(), world.as_ptr())? as usize)
+    pub fn gpu_world_device_index(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        world: impl AsPtr<*mut ae_sys::PF_EffectWorld>,
+    ) -> Result<usize, Error> {
+        Ok(
+            call_suite_fn_single!(self, GetGPUWorldDeviceIndex -> A_u_long, effect_ref.as_ptr(), world.as_ptr())?
+                as usize,
+        )
     }
 }

--- a/after-effects/src/pf/suites/handle.rs
+++ b/after-effects/src/pf/suites/handle.rs
@@ -18,9 +18,7 @@ define_suite!(
 impl HandleSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Create a new handle of the given size.
     pub fn new_handle(&self, size: A_HandleSize) -> PF_Handle {

--- a/after-effects/src/pf/suites/helper.rs
+++ b/after-effects/src/pf/suites/helper.rs
@@ -10,9 +10,7 @@ define_suite!(
 impl HelperSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     pub fn current_tool(&self) -> Result<SuiteTool, Error> {
         Ok(call_suite_fn_single!(self, PF_GetCurrentTool -> ae_sys::PF_SuiteTool)?.into())
@@ -29,14 +27,10 @@ define_suite!(
 impl HelperSuite2 {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Causes After Effects to parse the clipboard immediately
-    pub fn parse_clipboard(&self) -> Result<(), Error> {
-        call_suite_fn!(self, PF_ParseClipboard,)
-    }
+    pub fn parse_clipboard(&self) -> Result<(), Error> { call_suite_fn!(self, PF_ParseClipboard,) }
 
     /// Sets the current [`ExtendedSuiteTool`].
     pub fn set_current_extended_tool(&self, tool: ExtendedSuiteTool) -> Result<(), Error> {
@@ -45,7 +39,10 @@ impl HelperSuite2 {
 
     /// Returns the current [`ExtendedSuiteTool`].
     pub fn current_extended_tool(&self) -> Result<ExtendedSuiteTool, Error> {
-        Ok(call_suite_fn_single!(self, PF_GetCurrentExtendedTool -> ae_sys::PF_ExtendedSuiteTool)?.into())
+        Ok(
+            call_suite_fn_single!(self, PF_GetCurrentExtendedTool -> ae_sys::PF_ExtendedSuiteTool)?
+                .into(),
+        )
     }
 }
 

--- a/after-effects/src/pf/suites/iterate.rs
+++ b/after-effects/src/pf/suites/iterate.rs
@@ -1,6 +1,6 @@
 use crate::*;
-use crate::{ define_iterate, define_iterate_lut_and_generic };
-use ae_sys::{ PF_EffectWorld, PF_Pixel, PF_Pixel16, PF_PixelFloat };
+use crate::{define_iterate, define_iterate_lut_and_generic};
+use ae_sys::{PF_EffectWorld, PF_Pixel, PF_Pixel16, PF_PixelFloat};
 use std::ffi::c_void;
 
 define_suite!(
@@ -22,20 +22,24 @@ define_suite!(
 );
 
 impl Iterate8Suite {
+    define_iterate!(+ in_data: &InData, iterate,                       Pixel8,  PF_Pixel);
+
+    define_iterate!(+ in_data: &InData, iterate_origin,                Pixel8,  PF_Pixel,   origin: Option<Point>);
+
+    define_iterate!(+ in_data: &InData, iterate_origin_non_clip_src,   Pixel8,  PF_Pixel,   origin: Option<Point>);
+
+    define_iterate_lut_and_generic!(+ in_data: &InData,);
+
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     // Helpers for the define_iterate macros
-    #[inline(always)] fn get_in_data(&self) -> *const ae_sys::PF_InData { std::ptr::null() }
-    #[inline(always)] fn get_funcs_ptr(&self) -> *const ae_sys::PF_Iterate8Suite2 { self.suite_ptr }
+    #[inline(always)]
+    fn get_in_data(&self) -> *const ae_sys::PF_InData { std::ptr::null() }
 
-    define_iterate!(+ in_data: &InData, iterate,                       Pixel8,  PF_Pixel);
-    define_iterate!(+ in_data: &InData, iterate_origin,                Pixel8,  PF_Pixel,   origin: Option<Point>);
-    define_iterate!(+ in_data: &InData, iterate_origin_non_clip_src,   Pixel8,  PF_Pixel,   origin: Option<Point>);
-    define_iterate_lut_and_generic!(+ in_data: &InData,);
+    #[inline(always)]
+    fn get_funcs_ptr(&self) -> *const ae_sys::PF_Iterate8Suite2 { self.suite_ptr }
 }
 
 define_suite!(
@@ -57,19 +61,22 @@ define_suite!(
 );
 
 impl Iterate16Suite {
+    define_iterate!(+ in_data: &InData, iterate,                       Pixel16,  PF_Pixel16);
+
+    define_iterate!(+ in_data: &InData, iterate_origin,                Pixel16,  PF_Pixel16,   origin: Option<Point>);
+
+    define_iterate!(+ in_data: &InData, iterate_origin_non_clip_src,   Pixel16,  PF_Pixel16,   origin: Option<Point>);
+
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     // Helpers for the define_iterate macros
-    #[inline(always)] fn get_in_data(&self) -> *const ae_sys::PF_InData { std::ptr::null() }
-    #[inline(always)] fn get_funcs_ptr(&self) -> *const ae_sys::PF_Iterate16Suite2 { self.suite_ptr }
+    #[inline(always)]
+    fn get_in_data(&self) -> *const ae_sys::PF_InData { std::ptr::null() }
 
-    define_iterate!(+ in_data: &InData, iterate,                       Pixel16,  PF_Pixel16);
-    define_iterate!(+ in_data: &InData, iterate_origin,                Pixel16,  PF_Pixel16,   origin: Option<Point>);
-    define_iterate!(+ in_data: &InData, iterate_origin_non_clip_src,   Pixel16,  PF_Pixel16,   origin: Option<Point>);
+    #[inline(always)]
+    fn get_funcs_ptr(&self) -> *const ae_sys::PF_Iterate16Suite2 { self.suite_ptr }
 }
 
 define_suite!(
@@ -91,17 +98,20 @@ define_suite!(
 );
 
 impl IterateFloatSuite {
+    define_iterate!(+ in_data: impl AsPtr<*const ae_sys::PF_InData>, iterate,                       PixelF32,  PF_PixelFloat);
+
+    define_iterate!(+ in_data: impl AsPtr<*const ae_sys::PF_InData>, iterate_origin,                PixelF32,  PF_PixelFloat,   origin: Option<Point>);
+
+    define_iterate!(+ in_data: impl AsPtr<*const ae_sys::PF_InData>, iterate_origin_non_clip_src,   PixelF32,  PF_PixelFloat,   origin: Option<Point>);
+
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     // Helpers for the define_iterate macros
-    #[inline(always)] fn get_in_data(&self) -> *const ae_sys::PF_InData { std::ptr::null() }
-    #[inline(always)] fn get_funcs_ptr(&self) -> *const ae_sys::PF_iterateFloatSuite2 { self.suite_ptr }
+    #[inline(always)]
+    fn get_in_data(&self) -> *const ae_sys::PF_InData { std::ptr::null() }
 
-    define_iterate!(+ in_data: impl AsPtr<*const ae_sys::PF_InData>, iterate,                       PixelF32,  PF_PixelFloat);
-    define_iterate!(+ in_data: impl AsPtr<*const ae_sys::PF_InData>, iterate_origin,                PixelF32,  PF_PixelFloat,   origin: Option<Point>);
-    define_iterate!(+ in_data: impl AsPtr<*const ae_sys::PF_InData>, iterate_origin_non_clip_src,   PixelF32,  PF_PixelFloat,   origin: Option<Point>);
+    #[inline(always)]
+    fn get_funcs_ptr(&self) -> *const ae_sys::PF_iterateFloatSuite2 { self.suite_ptr }
 }

--- a/after-effects/src/pf/suites/param_utils.rs
+++ b/after-effects/src/pf/suites/param_utils.rs
@@ -42,9 +42,7 @@ define_suite!(
 impl ParamUtilsSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Force After Effects to refresh the parameter's UI, in the effect controls palette.
     ///
@@ -69,8 +67,19 @@ impl ParamUtilsSuite {
     ///         slider_min, slider_max, precision, display_flags of any slider type
     /// For `PF_PUI_STD_CONTROL_ONLY` params, you can also change the value field by setting `PF_ChangeFlag_CHANGED_VALUE` before returning.
     /// But you are not allowed to change the value during `PF_Cmd_UPDATE_PARAMS_UI`.
-    pub fn update_param_ui(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, param_index: i32, param_def: &ParamDef) -> Result<(), Error> {
-        call_suite_fn!(self, PF_UpdateParamUI, effect_ref.as_ptr(), param_index, param_def.as_ref())
+    pub fn update_param_ui(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        param_index: i32,
+        param_def: &ParamDef,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PF_UpdateParamUI,
+            effect_ref.as_ptr(),
+            param_index,
+            param_def.as_ref()
+        )
     }
 
     /// This API, combined with [`are_states_identical()`](Self::are_states_identical) below, lets you determine if a set of inputs (either layers, other properties, or both)
@@ -88,7 +97,13 @@ impl ParamUtilsSuite {
     /// it will be expanded to include any times needed to produce that range.
     ///
     /// Populates a `PF_State`, an opaque data type used as a receipt for the current state of the effect's parameters (the `PF_State` is used in our internal frame caching database).
-    pub fn current_state(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, param_index: i32, start: Option<Time>, duration: Option<Time>) -> Result<ae_sys::PF_State, Error> {
+    pub fn current_state(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        param_index: i32,
+        start: Option<Time>,
+        duration: Option<Time>,
+    ) -> Result<ae_sys::PF_State, Error> {
         call_suite_fn_single!(self,
             PF_GetCurrentState -> ae_sys::PF_State,
             effect_ref.as_ptr(),
@@ -99,42 +114,94 @@ impl ParamUtilsSuite {
     }
 
     /// New in CS6. Compare two different states, retrieved using `PF_GetCurrentState`, above.
-    pub fn are_states_identical(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, state1: &ae_sys::PF_State, state2: &ae_sys::PF_State) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, PF_AreStatesIdentical -> ae_sys::A_Boolean, effect_ref.as_ptr(), state1, state2)? != 0)
+    pub fn are_states_identical(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        state1: &ae_sys::PF_State,
+        state2: &ae_sys::PF_State,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, PF_AreStatesIdentical -> ae_sys::A_Boolean, effect_ref.as_ptr(), state1, state2)?
+                != 0,
+        )
     }
 
     /// Returns `true` if a parameter's value is the same at the two passed times.
     ///
     /// Note: the times need not be contiguous; there could be different intervening values.
-    pub fn is_identical_checkout(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, param_index: i32, what_time1: i32, time_step1: i32, time_scale1: u32, what_time2: i32, time_step2: i32, time_scale2: u32) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, PF_IsIdenticalCheckout -> ae_sys::PF_Boolean, effect_ref.as_ptr(), param_index, what_time1, time_step1, time_scale1, what_time2, time_step2, time_scale2)? != 0)
+    pub fn is_identical_checkout(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        param_index: i32,
+        what_time1: i32,
+        time_step1: i32,
+        time_scale1: u32,
+        what_time2: i32,
+        time_step2: i32,
+        time_scale2: u32,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, PF_IsIdenticalCheckout -> ae_sys::PF_Boolean, effect_ref.as_ptr(), param_index, what_time1, time_step1, time_scale1, what_time2, time_step2, time_scale2)?
+                != 0,
+        )
     }
 
     /// Searches (in the specified direction) for the next keyframe in the parameter's stream. The last three parameters are optional.
     ///
     /// Returns a tuple containing: (found, key_index, key_time, key_timescale)
-    pub fn find_keyframe_time(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, param_index: i32, what_time: i32, time_scale: u32, time_dir: TimeDir) -> Result<(bool, i32, i32, u32), Error> {
+    pub fn find_keyframe_time(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        param_index: i32,
+        what_time: i32,
+        time_scale: u32,
+        time_dir: TimeDir,
+    ) -> Result<(bool, i32, i32, u32), Error> {
         let mut found: ae_sys::PF_Boolean = 0;
         let mut key_index: ae_sys::PF_KeyIndex = 0;
         let mut key_time: ae_sys::A_long = 0;
         let mut key_timescale: ae_sys::A_u_long = 0;
-        call_suite_fn!(self, PF_FindKeyframeTime, effect_ref.as_ptr(), param_index, what_time, time_scale, time_dir.into(), &mut found, &mut key_index, &mut key_time, &mut key_timescale)?;
+        call_suite_fn!(
+            self,
+            PF_FindKeyframeTime,
+            effect_ref.as_ptr(),
+            param_index,
+            what_time,
+            time_scale,
+            time_dir.into(),
+            &mut found,
+            &mut key_index,
+            &mut key_time,
+            &mut key_timescale
+        )?;
 
         Ok((
             found != 0,
             key_index as i32,
             key_time as i32,
-            key_timescale as u32
+            key_timescale as u32,
         ))
     }
 
     /// Returns the number of keyframes in the parameter's stream.
-    pub fn keyframe_count(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, param_index: i32) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, PF_GetKeyframeCount -> ae_sys::PF_KeyIndex, effect_ref.as_ptr(), param_index)? as i32)
+    pub fn keyframe_count(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        param_index: i32,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, PF_GetKeyframeCount -> ae_sys::PF_KeyIndex, effect_ref.as_ptr(), param_index)?
+                as i32,
+        )
     }
 
     /// Checks a keyframe for the specified parameter out of our keyframe database. `param_index` is zero-based. You can request time, timescale, or neither; useful if you're performing your own motion blur.
-    pub fn checkout_keyframe(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, param_index: i32, key_index: i32) -> Result<(i32, u32, ae_sys::PF_ParamDef), Error> {
+    pub fn checkout_keyframe(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        param_index: i32,
+        key_index: i32,
+    ) -> Result<(i32, u32, ae_sys::PF_ParamDef), Error> {
         let mut key_time: ae_sys::A_long = 0;
         let mut key_timescale: ae_sys::A_u_long = 0;
         let param = call_suite_fn_single!(self, PF_CheckoutKeyframe -> ae_sys::PF_ParamDef, effect_ref.as_ptr(), param_index, key_index, &mut key_time, &mut key_timescale)?;
@@ -142,17 +209,28 @@ impl ParamUtilsSuite {
     }
 
     /// All calls to `checkout_keyframe` must be balanced with this check-in, or pain will ensue.
-    pub fn checkin_keyframe(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, mut param: ae_sys::PF_ParamDef) -> Result<(), Error> {
-        call_suite_fn!(self, PF_CheckinKeyframe, effect_ref.as_ptr(), &mut param as *mut _)
+    pub fn checkin_keyframe(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        mut param: ae_sys::PF_ParamDef,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PF_CheckinKeyframe,
+            effect_ref.as_ptr(),
+            &mut param as *mut _
+        )
     }
 
     /// Returns the time (and timescale) of the specified keyframe.
-    pub fn key_index_to_time(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, param_index: i32, key_index: i32) -> Result<(i32, u32), Error> {
+    pub fn key_index_to_time(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        param_index: i32,
+        key_index: i32,
+    ) -> Result<(i32, u32), Error> {
         let (time, timesale) = call_suite_fn_double!(self, PF_KeyIndexToTime -> ae_sys::A_long, ae_sys::A_u_long, effect_ref.as_ptr(), param_index, key_index)?;
-        Ok((
-            time as i32,
-            timesale as u32
-        ))
+        Ok((time as i32, timesale as u32))
     }
 }
 
@@ -166,11 +244,13 @@ define_suite!(
 impl AngleParamSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
-    pub fn floating_point_value_from_angle_def(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, angle_def: *const ae_sys::PF_ParamDef) -> Result<f64, Error> {
+    pub fn floating_point_value_from_angle_def(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        angle_def: *const ae_sys::PF_ParamDef,
+    ) -> Result<f64, Error> {
         call_suite_fn_single!(self, PF_GetFloatingPointValueFromAngleDef -> ae_sys::A_FpLong, effect_ref.as_ptr(), angle_def)
     }
 }
@@ -184,10 +264,13 @@ define_suite!(
 impl ColorParamSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
-    pub fn floating_point_value_from_color_def(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, color_def: *const ae_sys::PF_ParamDef) -> Result<PixelF32, Error> {
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
+    pub fn floating_point_value_from_color_def(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        color_def: *const ae_sys::PF_ParamDef,
+    ) -> Result<PixelF32, Error> {
         call_suite_fn_single!(self, PF_GetFloatingPointColorFromColorDef -> ae_sys::PF_PixelFloat, effect_ref.as_ptr(), color_def)
     }
 }
@@ -202,10 +285,13 @@ define_suite!(
 impl PointParamSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
-    pub fn floating_point_value_from_point_def(&self, effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>, point_def: *const ae_sys::PF_ParamDef) -> Result<ae_sys::A_FloatPoint, Error> {
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
+    pub fn floating_point_value_from_point_def(
+        &self,
+        effect_ref: impl AsPtr<ae_sys::PF_ProgPtr>,
+        point_def: *const ae_sys::PF_ParamDef,
+    ) -> Result<ae_sys::A_FloatPoint, Error> {
         call_suite_fn_single!(self, PF_GetFloatingPointValueFromPointDef -> ae_sys::A_FloatPoint, effect_ref.as_ptr(), point_def)
     }
 }
@@ -218,7 +304,8 @@ pub const PARAM_INDEX_NONE: i32 = ae_sys::PF_ParamIndex_NONE;
 pub const PARAM_INDEX_CHECK_ALL: i32 = ae_sys::PF_ParamIndex_CHECK_ALL;
 
 /// omit all layers. Pass a specific layer parameter index to include that as the only layer parameter tested.
-pub const PARAM_INDEX_CHECK_ALL_EXCEPT_LAYER_PARAMS: i32 = ae_sys::PF_ParamIndex_CHECK_ALL_EXCEPT_LAYER_PARAMS;
+pub const PARAM_INDEX_CHECK_ALL_EXCEPT_LAYER_PARAMS: i32 =
+    ae_sys::PF_ParamIndex_CHECK_ALL_EXCEPT_LAYER_PARAMS;
 
 /// Similar to CHECK_ALL, but honor PF_ParamFlag_EXCLUDE_FROM_HAVE_INPUTS_CHANGED.
 pub const PARAM_INDEX_CHECK_ALL_HONOR_EXCLUDE: i32 = ae_sys::PF_ParamIndex_CHECK_ALL_HONOR_EXCLUDE;

--- a/after-effects/src/pf/suites/path.rs
+++ b/after-effects/src/pf/suites/path.rs
@@ -12,9 +12,7 @@ define_suite!(
 impl PathQuerySuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Retrieves the number of paths associated with the effect’s source layer.
     pub fn num_paths(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<i32, Error> {
@@ -22,14 +20,25 @@ impl PathQuerySuite {
     }
 
     /// Retrieves the `PF_PathID` for the specified path.
-    pub fn path_info(&self, effect_ref: impl AsPtr<PF_ProgPtr>, index: i32) -> Result<PF_PathID, Error> {
+    pub fn path_info(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        index: i32,
+    ) -> Result<PF_PathID, Error> {
         call_suite_fn_single!(self, PF_PathInfo -> PF_PathID, effect_ref.as_ptr(), index)
     }
 
     /// Acquires the [`PathOutline`] for the path at the specified time.
     /// `PathOutline` automatically calls `checkin_path` on drop.
     /// Note the result may be `None` even if `unique_id != PF_PathID_NONE` (the path may have been deleted).
-    pub fn checkout_path(&self, effect_ref: impl AsPtr<PF_ProgPtr>, unique_id: PF_PathID, what_time: i32, time_step: i32, time_scale: u32) -> Result<Option<PathOutline>, Error> {
+    pub fn checkout_path(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        unique_id: PF_PathID,
+        what_time: i32,
+        time_step: i32,
+        time_scale: u32,
+    ) -> Result<Option<PathOutline>, Error> {
         let effect_ref = effect_ref.as_ptr();
         let path = call_suite_fn_single!(self, PF_CheckoutPath -> PF_PathOutlinePtr, effect_ref, unique_id, what_time, time_step, time_scale)?;
         PathOutline::from_raw(effect_ref, unique_id, path)
@@ -38,8 +47,21 @@ impl PathQuerySuite {
     /// Releases the path back to After Effects. Always do this, regardless of any error conditions
     /// encountered. Every checkout must be balanced by a checkin, or pain will ensue. This function
     /// is automatically called in `PathOutline`'s `Drop` implementation.
-    pub fn checkin_path(&self, effect_ref: impl AsPtr<PF_ProgPtr>, unique_id: PF_PathID, changed: bool, path: PF_PathOutlinePtr) -> Result<(), Error> {
-        call_suite_fn!(self, PF_CheckinPath, effect_ref.as_ptr(), unique_id, changed as _, path)
+    pub fn checkin_path(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        unique_id: PF_PathID,
+        changed: bool,
+        path: PF_PathOutlinePtr,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PF_CheckinPath,
+            effect_ref.as_ptr(),
+            unique_id,
+            changed as _,
+            path
+        )
     }
 }
 
@@ -54,43 +76,76 @@ define_suite!(
 impl PathDataSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Returns `true` if the path is not closed (if the beginning and end vertex are not identical).
-    pub fn path_is_open(&self, effect_ref: impl AsPtr<PF_ProgPtr>, path: PF_PathOutlinePtr) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, PF_PathIsOpen -> PF_Boolean, effect_ref.as_ptr(), path)? != 0)
+    pub fn path_is_open(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        path: PF_PathOutlinePtr,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, PF_PathIsOpen -> PF_Boolean, effect_ref.as_ptr(), path)?
+                != 0,
+        )
     }
 
     /// Retrieves the number of segments in the path. N segments means there are segments `[0.N-1]`;
     /// segment J is defined by vertex `J` and `J+1`.
-    pub fn path_num_segments(&self, effect_ref: impl AsPtr<PF_ProgPtr>, path: PF_PathOutlinePtr) -> Result<i32, Error> {
+    pub fn path_num_segments(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        path: PF_PathOutlinePtr,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, PF_PathNumSegments -> A_long, effect_ref.as_ptr(), path)
     }
 
     /// Retrieves the `PF_PathVertex` for the specified path. The range of points is `[0.num_segments]`;
     /// for closed paths, `vertex[0] == vertex[num_segments]`.
-    pub fn path_vertex_info(&self, effect_ref: impl AsPtr<PF_ProgPtr>, path: PF_PathOutlinePtr, which_point: i32) -> Result<PF_PathVertex, Error> {
+    pub fn path_vertex_info(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        path: PF_PathOutlinePtr,
+        which_point: i32,
+    ) -> Result<PF_PathVertex, Error> {
         call_suite_fn_single!(self, PF_PathVertexInfo -> PF_PathVertex, effect_ref.as_ptr(), path, which_point)
     }
 
     /// This fairly counter-intuitive function informs After Effects that you’re going to ask for the
     /// length of a segment (using `path_get_seg_length` below), and it’d better get ready. `frequency`
     /// indicates how many times you’d like us to sample the length; our internal effects use 100.
-    pub fn path_prepare_seg_length(&self, effect_ref: impl AsPtr<PF_ProgPtr>, path: PF_PathOutlinePtr, which_seg: i32, frequency: i32) -> Result<PF_PathSegPrepPtr, Error> {
+    pub fn path_prepare_seg_length(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        path: PF_PathOutlinePtr,
+        which_seg: i32,
+        frequency: i32,
+    ) -> Result<PF_PathSegPrepPtr, Error> {
         call_suite_fn_single!(self, PF_PathPrepareSegLength -> PF_PathSegPrepPtr, effect_ref.as_ptr(), path, which_seg, frequency)
     }
 
     /// Retrieves the length of the given segment.
-    pub fn path_get_seg_length(&self, effect_ref: impl AsPtr<PF_ProgPtr>, path: PF_PathOutlinePtr, which_seg: i32, length_prep: &mut PF_PathSegPrepPtr) -> Result<f64, Error> {
+    pub fn path_get_seg_length(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        path: PF_PathOutlinePtr,
+        which_seg: i32,
+        length_prep: &mut PF_PathSegPrepPtr,
+    ) -> Result<f64, Error> {
         call_suite_fn_single!(self, PF_PathGetSegLength -> PF_FpLong, effect_ref.as_ptr(), path, which_seg, length_prep)
     }
 
     /// Retrieves the location of a point `length` along the given path segment.
     ///
     /// Returns a tuple containing `(x, y)`
-    pub fn path_eval_seg_length(&self, effect_ref: impl AsPtr<PF_ProgPtr>, path: PF_PathOutlinePtr, length_prep: &mut PF_PathSegPrepPtr, which_seg: i32, length: f64) -> Result<(f64, f64), Error> {
+    pub fn path_eval_seg_length(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        path: PF_PathOutlinePtr,
+        length_prep: &mut PF_PathSegPrepPtr,
+        which_seg: i32,
+        length: f64,
+    ) -> Result<(f64, f64), Error> {
         call_suite_fn_double!(self, PF_PathEvalSegLength -> PF_FpLong, PF_FpLong, effect_ref.as_ptr(), path, length_prep, which_seg, length)
     }
 
@@ -98,36 +153,91 @@ impl PathDataSuite {
     /// If you’re not sure why you’d ever need this, don’t use it. Math is hard.
     ///
     /// Returns a tuple containing `(x, y, deriv1x, deriv1y)`
-    pub fn path_eval_seg_length_deriv1(&self, effect_ref: impl AsPtr<PF_ProgPtr>, path: PF_PathOutlinePtr, length_prep: &mut PF_PathSegPrepPtr, which_seg: i32, length: f64) -> Result<(f64, f64, f64, f64), Error> {
+    pub fn path_eval_seg_length_deriv1(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        path: PF_PathOutlinePtr,
+        length_prep: &mut PF_PathSegPrepPtr,
+        which_seg: i32,
+        length: f64,
+    ) -> Result<(f64, f64, f64, f64), Error> {
         let mut x = 0.0;
         let mut y = 0.0;
         let mut deriv1x = 0.0;
         let mut deriv1y = 0.0;
-        call_suite_fn!(self, PF_PathEvalSegLengthDeriv1, effect_ref.as_ptr(), path, length_prep, which_seg, length, &mut x, &mut y, &mut deriv1x, &mut deriv1y)?;
+        call_suite_fn!(
+            self,
+            PF_PathEvalSegLengthDeriv1,
+            effect_ref.as_ptr(),
+            path,
+            length_prep,
+            which_seg,
+            length,
+            &mut x,
+            &mut y,
+            &mut deriv1x,
+            &mut deriv1y
+        )?;
         Ok((x, y, deriv1x, deriv1y))
     }
 
     /// Call this when you’re finished evaluating that segment length, so After Effects
     /// can properly clean up the `PF_PathSegPrepPtr`.
-    pub fn path_cleanup_seg_length(&self, effect_ref: impl AsPtr<PF_ProgPtr>, path: PF_PathOutlinePtr, which_seg: i32, length_prep: &mut PF_PathSegPrepPtr) -> Result<(), Error> {
-        call_suite_fn!(self, PF_PathCleanupSegLength, effect_ref.as_ptr(), path, which_seg, length_prep)
+    pub fn path_cleanup_seg_length(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        path: PF_PathOutlinePtr,
+        which_seg: i32,
+        length_prep: &mut PF_PathSegPrepPtr,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PF_PathCleanupSegLength,
+            effect_ref.as_ptr(),
+            path,
+            which_seg,
+            length_prep
+        )
     }
 
     /// Returns `true` if the path is inverted.
-    pub fn path_is_inverted(&self, effect_ref: impl AsPtr<PF_ProgPtr>, unique_id: PF_PathID) -> Result<bool, Error> {
-        Ok(call_suite_fn_single!(self, PF_PathIsInverted -> PF_Boolean, effect_ref.as_ptr(), unique_id)? != 0)
+    pub fn path_is_inverted(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        unique_id: PF_PathID,
+    ) -> Result<bool, Error> {
+        Ok(
+            call_suite_fn_single!(self, PF_PathIsInverted -> PF_Boolean, effect_ref.as_ptr(), unique_id)?
+                != 0,
+        )
     }
 
     /// Retrieves the mode for the given path.
-    pub fn path_get_mask_mode(&self, effect_ref: impl AsPtr<PF_ProgPtr>, unique_id: PF_PathID) -> Result<MaskMode, Error> {
+    pub fn path_get_mask_mode(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        unique_id: PF_PathID,
+    ) -> Result<MaskMode, Error> {
         Ok(call_suite_fn_single!(self, PF_PathGetMaskMode -> PF_MaskMode, effect_ref.as_ptr(), unique_id)?.into())
     }
 
     /// Retrieves the name of the path.
-    pub fn path_get_name(&self, effect_ref: impl AsPtr<PF_ProgPtr>, unique_id: PF_PathID) -> Result<String, Error> {
+    pub fn path_get_name(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        unique_id: PF_PathID,
+    ) -> Result<String, Error> {
         let mut name = [0; PF_MAX_PATH_NAME_LEN as usize + 1];
-        call_suite_fn!(self, PF_PathGetName, effect_ref.as_ptr(), unique_id, name.as_mut_ptr())?;
-        Ok(unsafe { std::ffi::CStr::from_ptr(name.as_ptr()) }.to_string_lossy().into_owned())
+        call_suite_fn!(
+            self,
+            PF_PathGetName,
+            effect_ref.as_ptr(),
+            unique_id,
+            name.as_mut_ptr()
+        )?;
+        Ok(unsafe { std::ffi::CStr::from_ptr(name.as_ptr()) }
+            .to_string_lossy()
+            .into_owned())
     }
 }
 
@@ -174,13 +284,15 @@ impl std::fmt::Debug for PathOutline {
 }
 
 impl AsPtr<PF_PathOutlinePtr> for PathOutline {
-    fn as_ptr(&self) -> PF_PathOutlinePtr {
-        self.path
-    }
+    fn as_ptr(&self) -> PF_PathOutlinePtr { self.path }
 }
 
 impl PathOutline {
-    pub fn from_raw(effect_ref: PF_ProgPtr, unique_id: PF_PathID, path: PF_PathOutlinePtr) -> Result<Option<Self>, Error> {
+    pub fn from_raw(
+        effect_ref: PF_ProgPtr,
+        unique_id: PF_PathID,
+        path: PF_PathOutlinePtr,
+    ) -> Result<Option<Self>, Error> {
         if path.is_null() {
             Ok(None)
         } else {
@@ -194,9 +306,7 @@ impl PathOutline {
     }
 
     /// Returns the ID of the path.
-    pub fn id(&self) -> PF_PathID {
-        self.unique_id
-    }
+    pub fn id(&self) -> PF_PathID { self.unique_id }
 
     /// Returns `true` if the path is not closed (if the beginning and end vertex are not identical).
     pub fn is_open(&self) -> Result<bool, Error> {
@@ -212,17 +322,27 @@ impl PathOutline {
     /// Retrieves the `PF_PathVertex` for the specified path. The range of points is `[0.num_segments]`;
     /// for closed paths, `vertex[0] == vertex[num_segments]`.
     pub fn vertex(&self, which_point: i32) -> Result<PF_PathVertex, Error> {
-        self.suite.path_vertex_info(self.effect_ref, self.path, which_point)
+        self.suite
+            .path_vertex_info(self.effect_ref, self.path, which_point)
     }
 
     /// This fairly counter-intuitive function informs After Effects that you’re going to ask for the
     /// length of a segment (using [`PathSegPrep::length`]), and it’d better get ready. `frequency`
     /// indicates how many times you’d like us to sample the length; our internal effects use 100.
-    pub fn prepare_seg_length(&self, which_seg: i32, frequency: i32) -> Result<PathSegPrep<'_>, Error> {
+    pub fn prepare_seg_length(
+        &self,
+        which_seg: i32,
+        frequency: i32,
+    ) -> Result<PathSegPrep<'_>, Error> {
         Ok(PathSegPrep {
             path: self,
             which_seg,
-            length_prep: self.suite.path_prepare_seg_length(self.effect_ref, self.path, which_seg, frequency)?,
+            length_prep: self.suite.path_prepare_seg_length(
+                self.effect_ref,
+                self.path,
+                which_seg,
+                frequency,
+            )?,
         })
     }
 
@@ -233,7 +353,8 @@ impl PathOutline {
 
     /// Retrieves the mode for the path.
     pub fn mask_mode(&self) -> Result<MaskMode, Error> {
-        self.suite.path_get_mask_mode(self.effect_ref, self.unique_id)
+        self.suite
+            .path_get_mask_mode(self.effect_ref, self.unique_id)
     }
 
     /// Retrieves the name of the path.
@@ -261,14 +382,25 @@ pub struct PathSegPrep<'a> {
 impl<'a> PathSegPrep<'a> {
     /// Retrieves the length of the segment.
     pub fn length(&mut self) -> Result<f64, Error> {
-        self.path.suite.path_get_seg_length(self.path.effect_ref, self.path.path, self.which_seg, &mut self.length_prep)
+        self.path.suite.path_get_seg_length(
+            self.path.effect_ref,
+            self.path.path,
+            self.which_seg,
+            &mut self.length_prep,
+        )
     }
 
     /// Retrieves the location of a point `length` along the segment.
     ///
     /// Returns a tuple containing `(x, y)`
     pub fn eval(&mut self, length: f64) -> Result<(f64, f64), Error> {
-        self.path.suite.path_eval_seg_length(self.path.effect_ref, self.path.path, &mut self.length_prep, self.which_seg, length)
+        self.path.suite.path_eval_seg_length(
+            self.path.effect_ref,
+            self.path.path,
+            &mut self.length_prep,
+            self.which_seg,
+            length,
+        )
     }
 
     /// Retrieves the location, and the first derivative, of a point `length` along the segment.
@@ -276,7 +408,13 @@ impl<'a> PathSegPrep<'a> {
     ///
     /// Returns a tuple containing `(x, y, deriv1x, deriv1y)`
     pub fn eval_deriv1(&mut self, length: f64) -> Result<(f64, f64, f64, f64), Error> {
-        self.path.suite.path_eval_seg_length_deriv1(self.path.effect_ref, self.path.path, &mut self.length_prep, self.which_seg, length)
+        self.path.suite.path_eval_seg_length_deriv1(
+            self.path.effect_ref,
+            self.path.path,
+            &mut self.length_prep,
+            self.which_seg,
+            length,
+        )
     }
 }
 
@@ -284,7 +422,12 @@ impl<'a> Drop for PathSegPrep<'a> {
     fn drop(&mut self) {
         self.path
             .suite
-            .path_cleanup_seg_length(self.path.effect_ref, self.path.path, self.which_seg, &mut self.length_prep)
+            .path_cleanup_seg_length(
+                self.path.effect_ref,
+                self.path.path,
+                self.which_seg,
+                &mut self.length_prep,
+            )
             .expect("Failed to clean up PF_PathSegPrepPtr");
     }
 }

--- a/after-effects/src/pf/suites/pixel_data.rs
+++ b/after-effects/src/pf/suites/pixel_data.rs
@@ -1,4 +1,3 @@
-
 use crate::*;
 use ae_sys::*;
 
@@ -13,18 +12,26 @@ define_suite!(
 impl PixelDataSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Obtain a pointer to a 8-bpc pixel within the specified world.
     ///
     /// It will return [`Error::BadCallbackParameter`] if the world is not 8-bpc.
     ///
     /// The second parameter is optional; if it is `Some`, the returned pixel will be an interpretation of the values in the passed-in pixel, as if it were in the specified PF_EffectWorld.
-    pub fn pixel_data8(self, world: impl AsPtr<*mut PF_EffectWorld>, pixels: Option<*mut Pixel8>) -> Result<*mut Pixel8, Error> {
+    pub fn pixel_data8(
+        self,
+        world: impl AsPtr<*mut PF_EffectWorld>,
+        pixels: Option<*mut Pixel8>,
+    ) -> Result<*mut Pixel8, Error> {
         let mut ptr = std::ptr::null_mut();
-        call_suite_fn!(self, get_pixel_data8, world.as_ptr(), pixels.unwrap_or(std::ptr::null_mut()), &mut ptr)?;
+        call_suite_fn!(
+            self,
+            get_pixel_data8,
+            world.as_ptr(),
+            pixels.unwrap_or(std::ptr::null_mut()),
+            &mut ptr
+        )?;
         if ptr.is_null() {
             return Err(Error::BadCallbackParameter);
         }
@@ -36,9 +43,19 @@ impl PixelDataSuite {
     /// It will return [`Error::BadCallbackParameter`] if the world is not 16-bpc.
     ///
     /// The second parameter is optional; if it is `Some`, the returned pixel will be an interpretation of the values in the passed-in pixel, as if it were in the specified PF_EffectWorld.
-    pub fn pixel_data16(self, world: impl AsPtr<*mut PF_EffectWorld>, pixels: Option<*mut Pixel8>) -> Result<*mut Pixel16, Error> {
+    pub fn pixel_data16(
+        self,
+        world: impl AsPtr<*mut PF_EffectWorld>,
+        pixels: Option<*mut Pixel8>,
+    ) -> Result<*mut Pixel16, Error> {
         let mut ptr = std::ptr::null_mut();
-        call_suite_fn!(self, get_pixel_data16, world.as_ptr(), pixels.unwrap_or(std::ptr::null_mut()), &mut ptr)?;
+        call_suite_fn!(
+            self,
+            get_pixel_data16,
+            world.as_ptr(),
+            pixels.unwrap_or(std::ptr::null_mut()),
+            &mut ptr
+        )?;
         if ptr.is_null() {
             return Err(Error::BadCallbackParameter);
         }
@@ -50,9 +67,19 @@ impl PixelDataSuite {
     /// It will return [`Error::BadCallbackParameter`] if the world is not 32-bpc.
     ///
     /// The second parameter is optional; if it is `Some`, the returned pixel will be an interpretation of the values in the passed-in pixel, as if it were in the specified PF_EffectWorld.
-    pub fn pixel_data_float(self, world: impl AsPtr<*mut PF_EffectWorld>, pixels: Option<*mut Pixel8>) -> Result<*mut PixelF32, Error> {
+    pub fn pixel_data_float(
+        self,
+        world: impl AsPtr<*mut PF_EffectWorld>,
+        pixels: Option<*mut Pixel8>,
+    ) -> Result<*mut PixelF32, Error> {
         let mut ptr = std::ptr::null_mut();
-        call_suite_fn!(self, get_pixel_data_float, world.as_ptr(), pixels.unwrap_or(std::ptr::null_mut()), &mut ptr)?;
+        call_suite_fn!(
+            self,
+            get_pixel_data_float,
+            world.as_ptr(),
+            pixels.unwrap_or(std::ptr::null_mut()),
+            &mut ptr
+        )?;
         if ptr.is_null() {
             return Err(Error::BadCallbackParameter);
         }
@@ -62,7 +89,10 @@ impl PixelDataSuite {
     /// Obtain a pointer to a 32-bpc float pixel within the specified GPU world.
     ///
     /// It will return [`Error::BadCallbackParameter`] if the world is not 32-bpc float.
-    pub fn pixel_data_float_gpu(self, world: impl AsPtr<*mut PF_EffectWorld>) -> Result<*mut std::ffi::c_void, Error> {
+    pub fn pixel_data_float_gpu(
+        self,
+        world: impl AsPtr<*mut PF_EffectWorld>,
+    ) -> Result<*mut std::ffi::c_void, Error> {
         let mut ptr = std::ptr::null_mut();
         call_suite_fn!(self, get_pixel_data_float_gpu, world.as_ptr(), &mut ptr)?;
         if ptr.is_null() {

--- a/after-effects/src/pf/suites/pixel_format.rs
+++ b/after-effects/src/pf/suites/pixel_format.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use ae_sys::{ PF_ProgPtr, PF_InData };
+use ae_sys::{PF_InData, PF_ProgPtr};
 
 define_suite!(
     /// Premiere pixel format suite. Not available in After Effects.
@@ -12,30 +12,60 @@ define_suite!(
 impl PixelFormatSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
+    pub fn add_supported_pixel_format(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        pixel_format: pr::PixelFormat,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AddSupportedPixelFormat,
+            effect_ref.as_ptr(),
+            pixel_format.into()
+        )
     }
 
-    pub fn add_supported_pixel_format(&self, effect_ref: impl AsPtr<PF_ProgPtr>, pixel_format: pr::PixelFormat) -> Result<(), Error> {
-        call_suite_fn!(self, AddSupportedPixelFormat, effect_ref.as_ptr(), pixel_format.into())
-    }
-
-    pub fn clear_supported_pixel_formats(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<(), Error> {
+    pub fn clear_supported_pixel_formats(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, ClearSupportedPixelFormats, effect_ref.as_ptr())
     }
 
-    pub fn new_world_of_pixel_format(&self, in_data: impl AsPtr<*const PF_InData>, width: u32, height: u32, flags: pf::NewWorldFlags, pixel_format: pr::PixelFormat) -> Result<Layer, Error> {
+    pub fn new_world_of_pixel_format(
+        &self,
+        in_data: impl AsPtr<*const PF_InData>,
+        width: u32,
+        height: u32,
+        flags: pf::NewWorldFlags,
+        pixel_format: pr::PixelFormat,
+    ) -> Result<Layer, Error> {
         let layer = call_suite_fn_single!(self, NewWorldOfPixelFormat -> ae_sys::PF_EffectWorld, (*in_data.as_ptr()).effect_ref, width, height, flags.bits(), pixel_format.into())?;
         Ok(Layer::from_owned(layer, in_data, |self_layer| {
-            PixelFormatSuite::new().unwrap().dispose_world(unsafe { (*self_layer.in_data_ptr).effect_ref }, self_layer.as_mut_ptr()).unwrap();
+            PixelFormatSuite::new()
+                .unwrap()
+                .dispose_world(
+                    unsafe { (*self_layer.in_data_ptr).effect_ref },
+                    self_layer.as_mut_ptr(),
+                )
+                .unwrap();
         }))
     }
 
-    pub fn dispose_world(&self, effect_ref: impl AsPtr<PF_ProgPtr>, world: *mut ae_sys::PF_EffectWorld) -> Result<(), Error> {
+    pub fn dispose_world(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        world: *mut ae_sys::PF_EffectWorld,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, DisposeWorld, effect_ref.as_ptr(), world)
     }
 
-    pub fn pixel_format(&self, world: impl AsPtr<*const ae_sys::PF_EffectWorld>) -> Result<pr::PixelFormat, Error> {
+    pub fn pixel_format(
+        &self,
+        world: impl AsPtr<*const ae_sys::PF_EffectWorld>,
+    ) -> Result<pr::PixelFormat, Error> {
         Ok(call_suite_fn_single!(self, GetPixelFormat -> ae_sys::PrPixelFormat, world.as_ptr() as *mut _)?.into())
     }
 
@@ -47,7 +77,12 @@ impl PixelFormatSuite {
     /// * `pixel_data` - a void pointer to data large enough to hold the pixel value (see note above)
     pub fn black_for_pixel_format(&self, pixel_format: pr::PixelFormat) -> Result<Vec<u8>, Error> {
         let mut pixel_data = vec![0u8; pixel_size(pixel_format)];
-        call_suite_fn!(self, GetBlackForPixelFormat, pixel_format.into(), pixel_data.as_mut_ptr() as *mut _)?;
+        call_suite_fn!(
+            self,
+            GetBlackForPixelFormat,
+            pixel_format.into(),
+            pixel_data.as_mut_ptr() as *mut _
+        )?;
         Ok(pixel_data)
     }
 
@@ -59,7 +94,12 @@ impl PixelFormatSuite {
     /// * `pixel_data` - a void pointer to data large enough to hold the pixel value (see note above)
     pub fn white_for_pixel_format(&self, pixel_format: pr::PixelFormat) -> Result<Vec<u8>, Error> {
         let mut pixel_data = vec![0u8; pixel_size(pixel_format)];
-        call_suite_fn!(self, GetWhiteForPixelFormat, pixel_format.into(), pixel_data.as_mut_ptr() as *mut _)?;
+        call_suite_fn!(
+            self,
+            GetWhiteForPixelFormat,
+            pixel_format.into(),
+            pixel_data.as_mut_ptr() as *mut _
+        )?;
         Ok(pixel_data)
     }
 
@@ -73,9 +113,25 @@ impl PixelFormatSuite {
     /// * `green`        - green value (0.0 - 1.0)
     /// * `blue`         - blue value (0.0 - 1.0)
     /// * `pixel_data`   - a void pointer to data large enough to hold the pixel value (see note above)
-    pub fn convert_color_to_pixel_formatted_data(&self, pixel_format: pr::PixelFormat, alpha: f32, red: f32, green: f32, blue: f32) -> Result<Vec<u8>, Error> {
+    pub fn convert_color_to_pixel_formatted_data(
+        &self,
+        pixel_format: pr::PixelFormat,
+        alpha: f32,
+        red: f32,
+        green: f32,
+        blue: f32,
+    ) -> Result<Vec<u8>, Error> {
         let mut pixel_data = vec![0u8; pixel_size(pixel_format)];
-        call_suite_fn!(self, ConvertColorToPixelFormattedData, pixel_format.into(), alpha, red, green, blue, pixel_data.as_mut_ptr() as *mut _)?;
+        call_suite_fn!(
+            self,
+            ConvertColorToPixelFormattedData,
+            pixel_format.into(),
+            alpha,
+            red,
+            green,
+            blue,
+            pixel_data.as_mut_ptr() as *mut _
+        )?;
         Ok(pixel_data)
     }
 }
@@ -83,20 +139,39 @@ impl PixelFormatSuite {
 fn pixel_size(pixel_format: pr::PixelFormat) -> usize {
     use pr::PixelFormat::*;
     match pixel_format {
-        Bgra4444_8u | Vuya4444_8u | Vuya4444_8u709 | Argb4444_8u | Bgrx4444_8u | Vuyx4444_8u | Vuyx4444_8u709 | Xrgb4444_8u | Bgrp4444_8u | Vuyp4444_8u |
-        Vuyp4444_8u709 | Prgb4444_8u | Vuya4444_16u | Rgb444_10u | Yuyv422_8u601 | Yuyv422_8u709 | Uyvy422_8u601 | Uyvy422_8u709 | Xrgb4444_32fLinear => 4,
+        Bgra4444_8u | Vuya4444_8u | Vuya4444_8u709 | Argb4444_8u | Bgrx4444_8u | Vuyx4444_8u
+        | Vuyx4444_8u709 | Xrgb4444_8u | Bgrp4444_8u | Vuyp4444_8u | Vuyp4444_8u709
+        | Prgb4444_8u | Vuya4444_16u | Rgb444_10u | Yuyv422_8u601 | Yuyv422_8u709
+        | Uyvy422_8u601 | Uyvy422_8u709 | Xrgb4444_32fLinear => 4,
 
-        Bgra4444_16u | Argb4444_16u | Bgrx4444_16u | Xrgb4444_16u | Bgrp4444_16u | Prgb4444_16u => 8,
+        Bgra4444_16u | Argb4444_16u | Bgrx4444_16u | Xrgb4444_16u | Bgrp4444_16u | Prgb4444_16u => {
+            8
+        }
 
-        Bgra4444_32f | Vuya4444_32f | Vuya4444_32f709 | Argb4444_32f | Bgrx4444_32f | Vuyx4444_32f | Vuyx4444_32f709 | Xrgb4444_32f | Bgrp4444_32f | Vuyp4444_32f | Vuyp4444_32f709 | Prgb4444_32f |
-        V210422_10u601 | V210422_10u709 | Uyvy422_32f601 | Uyvy422_32f709 | Bgra4444_32fLinear | Bgrp4444_32fLinear | Bgrx4444_32fLinear | Argb4444_32fLinear | Prgb4444_32fLinear => 16,
+        Bgra4444_32f | Vuya4444_32f | Vuya4444_32f709 | Argb4444_32f | Bgrx4444_32f
+        | Vuyx4444_32f | Vuyx4444_32f709 | Xrgb4444_32f | Bgrp4444_32f | Vuyp4444_32f
+        | Vuyp4444_32f709 | Prgb4444_32f | V210422_10u601 | V210422_10u709 | Uyvy422_32f601
+        | Uyvy422_32f709 | Bgra4444_32fLinear | Bgrp4444_32fLinear | Bgrx4444_32fLinear
+        | Argb4444_32fLinear | Prgb4444_32fLinear => 16,
 
-        Yuv420Mpeg2FramePicturePlanar8u601 | Yuv420Mpeg2FieldPicturePlanar8u601 | Yuv420Mpeg2FramePicturePlanar8u601FullRange | Yuv420Mpeg2FieldPicturePlanar8u601FullRange |
-        Yuv420Mpeg2FramePicturePlanar8u709 | Yuv420Mpeg2FieldPicturePlanar8u709 | Yuv420Mpeg2FramePicturePlanar8u709FullRange | Yuv420Mpeg2FieldPicturePlanar8u709FullRange |
-        Yuv420Mpeg4FramePicturePlanar8u601 | Yuv420Mpeg4FieldPicturePlanar8u601 | Yuv420Mpeg4FramePicturePlanar8u601FullRange | Yuv420Mpeg4FieldPicturePlanar8u601FullRange |
-        Yuv420Mpeg4FramePicturePlanar8u709 | Yuv420Mpeg4FieldPicturePlanar8u709 | Yuv420Mpeg4FramePicturePlanar8u709FullRange | Yuv420Mpeg4FieldPicturePlanar8u709FullRange => 1,
+        Yuv420Mpeg2FramePicturePlanar8u601
+        | Yuv420Mpeg2FieldPicturePlanar8u601
+        | Yuv420Mpeg2FramePicturePlanar8u601FullRange
+        | Yuv420Mpeg2FieldPicturePlanar8u601FullRange
+        | Yuv420Mpeg2FramePicturePlanar8u709
+        | Yuv420Mpeg2FieldPicturePlanar8u709
+        | Yuv420Mpeg2FramePicturePlanar8u709FullRange
+        | Yuv420Mpeg2FieldPicturePlanar8u709FullRange
+        | Yuv420Mpeg4FramePicturePlanar8u601
+        | Yuv420Mpeg4FieldPicturePlanar8u601
+        | Yuv420Mpeg4FramePicturePlanar8u601FullRange
+        | Yuv420Mpeg4FieldPicturePlanar8u601FullRange
+        | Yuv420Mpeg4FramePicturePlanar8u709
+        | Yuv420Mpeg4FieldPicturePlanar8u709
+        | Yuv420Mpeg4FramePicturePlanar8u709FullRange
+        | Yuv420Mpeg4FieldPicturePlanar8u709FullRange => 1,
 
-        _ => 32 // just to be safe
+        _ => 32, // just to be safe
     }
 }
 

--- a/after-effects/src/pf/suites/source_settings.rs
+++ b/after-effects/src/pf/suites/source_settings.rs
@@ -1,4 +1,3 @@
-
 use crate::*;
 use ae_sys::*;
 
@@ -51,12 +50,21 @@ define_suite!(
 impl SourceSettingsSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
-    pub fn perform_source_settings_command(&self, effect_ref: impl AsPtr<PF_ProgPtr>, command_struct: *mut std::ffi::c_void, data_size: usize) -> Result<(), Error> {
-        call_suite_fn!(self, PerformSourceSettingsCommand, effect_ref.as_ptr(), command_struct, data_size as _)
+    pub fn perform_source_settings_command(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        command_struct: *mut std::ffi::c_void,
+        data_size: usize,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PerformSourceSettingsCommand,
+            effect_ref.as_ptr(),
+            command_struct,
+            data_size as _
+        )
     }
 
     // pub fn set_is_source_settings_effect(&self, effect_ref: impl AsPtr<PF_ProgPtr>, value: bool) -> Result<(), Error> {

--- a/after-effects/src/pf/suites/transition.rs
+++ b/after-effects/src/pf/suites/transition.rs
@@ -1,4 +1,3 @@
-
 use crate::*;
 use ae_sys::*;
 
@@ -31,23 +30,48 @@ define_suite!(
 impl TransitionSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Register an effect as a transition using the passed in input layer as the outgoing clip.
     /// When registered the effect will be available to be dragged directly onto clip ends rather than only applied to layers.
-    pub fn register_transition_input_param(&self, effect_ref: impl AsPtr<PF_ProgPtr>, index: i32) -> Result<(), Error> {
-        call_suite_fn!(self, RegisterTransitionInputParam, effect_ref.as_ptr(), index as _)
+    pub fn register_transition_input_param(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        index: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            RegisterTransitionInputParam,
+            effect_ref.as_ptr(),
+            index as _
+        )
     }
 
     /// Register a PF_ADD_FLOAT_SLIDER parameter to receive changes to the start of the transition region through the [`Command::UserChangedParam`] command.
-    pub fn register_transition_start_param(&self, effect_ref: impl AsPtr<PF_ProgPtr>, index: i32) -> Result<(), Error> {
-        call_suite_fn!(self, RegisterTransitionStartParam, effect_ref.as_ptr(), index as _)
+    pub fn register_transition_start_param(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        index: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            RegisterTransitionStartParam,
+            effect_ref.as_ptr(),
+            index as _
+        )
     }
 
     /// Register a PF_ADD_FLOAT_SLIDER parameter to receive changes to the end of the transition region through the [`Command::UserChangedParam`] command.
-    pub fn register_transition_end_param(&self, effect_ref: impl AsPtr<PF_ProgPtr>, index: i32) -> Result<(), Error> {
-        call_suite_fn!(self, RegisterTransitionEndParam, effect_ref.as_ptr(), index as _)
+    pub fn register_transition_end_param(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        index: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            RegisterTransitionEndParam,
+            effect_ref.as_ptr(),
+            index as _
+        )
     }
 }

--- a/after-effects/src/pf/suites/utility.rs
+++ b/after-effects/src/pf/suites/utility.rs
@@ -10,9 +10,7 @@ define_suite!(
 );
 
 impl UtilitySuite {
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Gets the filter ID for the current effect reference.
     pub fn filter_instance_id(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<i32, Error> {
@@ -22,7 +20,10 @@ impl UtilitySuite {
     /// Retrieves formatted timecode, as well as the currently active video frame.
     ///
     /// Returns a tuple containing `(current_frame, time_display)`
-    pub fn media_timecode(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<(i32, PF_TimeDisplay), Error> {
+    pub fn media_timecode(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<(i32, PF_TimeDisplay), Error> {
         call_suite_fn_double!(self, GetMediaTimecode -> i32, PF_TimeDisplay, effect_ref.as_ptr())
     }
 
@@ -43,12 +44,18 @@ impl UtilitySuite {
 
     /// Retrieves the duration of the clip, unaffected by any speed or retiming changes.
     pub fn unscaled_clip_duration(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, GetUnscaledClipDuration -> A_long, effect_ref.as_ptr())? as i32)
+        Ok(
+            call_suite_fn_single!(self, GetUnscaledClipDuration -> A_long, effect_ref.as_ptr())?
+                as i32,
+        )
     }
 
     /// Retrives the start time of the clip, unaffected by any speed or retiming changes.
     pub fn unscaled_clip_start(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, GetUnscaledClipStart -> A_long, effect_ref.as_ptr())? as i32)
+        Ok(
+            call_suite_fn_single!(self, GetUnscaledClipStart -> A_long, effect_ref.as_ptr())?
+                as i32,
+        )
     }
 
     /// Gets the start time of the track item.
@@ -57,7 +64,10 @@ impl UtilitySuite {
     }
 
     /// Retrieves the filed type in use with the media.
-    pub fn media_field_type(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<prFieldType, Error> {
+    pub fn media_field_type(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<prFieldType, Error> {
         call_suite_fn_single!(self, GetMediaFieldType -> prFieldType, effect_ref.as_ptr())
     }
 
@@ -67,151 +77,312 @@ impl UtilitySuite {
     }
 
     /// Gets the ID of the timeline containing the clip to which the effect is applied.
-    pub fn containing_timeline_id(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<PrTimelineID, Error> {
+    pub fn containing_timeline_id(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<PrTimelineID, Error> {
         call_suite_fn_single!(self, GetContainingTimelineID -> PrTimelineID, effect_ref.as_ptr())
     }
 
     /// Gets the name of the clip to which the effect is applied (or the master clip).
-    pub fn clip_name(&self, effect_ref: impl AsPtr<PF_ProgPtr>, get_master_clip_name: bool) -> Result<String, Error> {
+    pub fn clip_name(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        get_master_clip_name: bool,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetClipName -> PrSDKString, effect_ref.as_ptr(), get_master_clip_name as _)?).into())
     }
 
     /// Indicates that the effect wants to received checked out frames, in the same format used for destination rendering.
-    pub fn effect_wants_checked_out_frames_to_match_render_pixel_format(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<(), Error> {
-        call_suite_fn!(self, EffectWantsCheckedOutFramesToMatchRenderPixelFormat, effect_ref.as_ptr())
+    pub fn effect_wants_checked_out_frames_to_match_render_pixel_format(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            EffectWantsCheckedOutFramesToMatchRenderPixelFormat,
+            effect_ref.as_ptr()
+        )
     }
 
     /// Indicates whether the effect depends on the name of the clip to which it is applied.
-    pub fn set_effect_depends_on_clip_name(&self, effect_ref: impl AsPtr<PF_ProgPtr>, depends_on_clip_name: bool) -> Result<(), Error> {
-        call_suite_fn!(self, EffectDependsOnClipName, effect_ref.as_ptr(), depends_on_clip_name as _)
+    pub fn set_effect_depends_on_clip_name(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        depends_on_clip_name: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            EffectDependsOnClipName,
+            effect_ref.as_ptr(),
+            depends_on_clip_name as _
+        )
     }
 
     /// Sets the instance name of the effect.
-    pub fn set_effect_instance_name(&self, effect_ref: impl AsPtr<PF_ProgPtr>, name: &str) -> Result<(), Error> {
+    pub fn set_effect_instance_name(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        name: &str,
+    ) -> Result<(), Error> {
         let pr_string = PrStringSuite::new()?.allocate_from_utf8(name)?;
         call_suite_fn!(self, SetEffectInstanceName, effect_ref.as_ptr(), &pr_string)
     }
 
     /// Retrieves the name of the media file to which the effect instance is applied.
     pub fn file_name(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<String, Error> {
-        Ok(PrString(call_suite_fn_single!(self, GetFileName -> PrSDKString, effect_ref.as_ptr())?).into())
+        Ok(
+            PrString(call_suite_fn_single!(self, GetFileName -> PrSDKString, effect_ref.as_ptr())?)
+                .into(),
+        )
     }
 
     /// Retrieves the original (non-interpreted, un-re-timed) frame rate, of the media to which the effect instance is applied.
-    pub fn original_clip_frame_rate(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<PrTime, Error> {
+    pub fn original_clip_frame_rate(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<PrTime, Error> {
         call_suite_fn_single!(self, GetOriginalClipFrameRate -> PrTime, effect_ref.as_ptr())
     }
 
     /// Retrieves the source media timecode for the specified frame within the specified layer, with or without transforms and start time offsets applied.
-    pub fn source_track_media_timecode(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, apply_transform: bool, add_start_time_offset: bool) -> Result<A_long, Error> {
+    pub fn source_track_media_timecode(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        apply_transform: bool,
+        add_start_time_offset: bool,
+    ) -> Result<A_long, Error> {
         call_suite_fn_single!(self, GetSourceTrackMediaTimecode -> A_long, effect_ref.as_ptr(), layer_param_index, apply_transform, add_start_time_offset)
     }
 
     /// Retrieves the name of the layer in use by the effect instance.
-    pub fn source_track_clip_name(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, get_master_clip_name: bool) -> Result<String, Error> {
+    pub fn source_track_clip_name(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        get_master_clip_name: bool,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetSourceTrackClipName -> PrSDKString, effect_ref.as_ptr(), layer_param_index, get_master_clip_name as _)?).into())
     }
 
     /// Retrieves the file name of the source track item for the specified layer parameter.
-    pub fn source_track_file_name(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32) -> Result<String, Error> {
+    pub fn source_track_file_name(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetSourceTrackFileName -> PrSDKString, effect_ref.as_ptr(), layer_param_index)?).into())
     }
 
     /// Specifies whether the effect instance depends on the specified layer parameter.
-    pub fn set_effect_depends_on_clip_name2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, depends_on_clip_name: bool, layer_param_index: u8) -> Result<(), Error> {
-        call_suite_fn!(self, EffectDependsOnClipName2, effect_ref.as_ptr(), layer_param_index, depends_on_clip_name as _)
+    pub fn set_effect_depends_on_clip_name2(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        depends_on_clip_name: bool,
+        layer_param_index: u8,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            EffectDependsOnClipName2,
+            effect_ref.as_ptr(),
+            layer_param_index,
+            depends_on_clip_name as _
+        )
     }
 
     /// Retrieves formatted timecode and current frame number, with or without trims applied.
     ///
     /// Returns a tuple containing `(current_frame, time_display)`
-    pub fn media_timecode2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, apply_trim: bool) -> Result<(i32, PF_TimeDisplay), Error> {
+    pub fn media_timecode2(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        apply_trim: bool,
+    ) -> Result<(i32, PF_TimeDisplay), Error> {
         call_suite_fn_double!(self, GetMediaTimecode2 -> i32, PF_TimeDisplay, effect_ref.as_ptr(), apply_trim)
     }
 
     /// Given a specific sequence time, retrieves the source track media timecode for the specified layer parameter.
-    pub fn source_track_media_timecode2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, apply_transform: bool, add_start_time_offset: bool, sequence_time: PrTime) -> Result<A_long, Error> {
+    pub fn source_track_media_timecode2(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        apply_transform: bool,
+        add_start_time_offset: bool,
+        sequence_time: PrTime,
+    ) -> Result<A_long, Error> {
         call_suite_fn_single!(self, GetSourceTrackMediaTimecode2 -> A_long, effect_ref.as_ptr(), layer_param_index, apply_transform, add_start_time_offset, sequence_time)
     }
 
     /// Retrieves the clip name used by the specific layer parameter.
-    pub fn source_track_clip_name2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, get_master_clip_name: bool, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn source_track_clip_name2(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        get_master_clip_name: bool,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         let mut val: PrSDKString = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, GetSourceTrackClipName2, effect_ref.as_ptr(), layer_param_index, get_master_clip_name as _, &mut val, sequence_time)?;
+        call_suite_fn!(
+            self,
+            GetSourceTrackClipName2,
+            effect_ref.as_ptr(),
+            layer_param_index,
+            get_master_clip_name as _,
+            &mut val,
+            sequence_time
+        )?;
 
         Ok(PrString(val).into())
     }
 
     /// Retrieves the clip name in use by the specified layer parameter.
-    pub fn source_track_file_name2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn source_track_file_name2(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         let mut val: PrSDKString = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, GetSourceTrackFileName2, effect_ref.as_ptr(), layer_param_index, &mut val, sequence_time)?;
+        call_suite_fn!(
+            self,
+            GetSourceTrackFileName2,
+            effect_ref.as_ptr(),
+            layer_param_index,
+            &mut val,
+            sequence_time
+        )?;
 
         Ok(PrString(val).into())
     }
 
     /// Retrieves the comment string associated with the specified source track item, at the specified time.
-    pub fn comment_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn comment_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetCommentString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the log note associated with the source track, at the specified time.
-    pub fn log_note_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn log_note_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetLogNoteString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the camera rolll info associated with the source track, at the specified time.
-    pub fn camera_roll_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn camera_roll_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetCameraRollString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the metadata string associated with the source track, at the specified time.
-    pub fn client_metadata_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn client_metadata_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetClientMetadataString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the daily roll string associated with the source track, at the specified time.
-    pub fn daily_roll_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn daily_roll_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetDailyRollString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the description metadata string associated with the source track, at the specified time.
-    pub fn description_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn description_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetDescriptionString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the lab roll string associated with the source track, at the specified time.
-    pub fn lab_roll_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn lab_roll_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetLabRollString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the scene string associated with the source track, at the specified time.
-    pub fn scene_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn scene_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetSceneString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the shot string associated with the source track item, at the specified time.
-    pub fn shot_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn shot_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetShotString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the tape name string associated with the source track item, at the specified time.
-    pub fn tape_name_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn tape_name_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetTapeNameString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves a string representing the video codec associated with the source track item, at the specified time.
-    pub fn video_codec_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn video_codec_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetVideoCodecString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves a string representing the "good" state of the source track item, at the specified time.
-    pub fn good_metadata_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn good_metadata_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetGoodMetadataString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves a string representing the "sound roll" state of the source track item, at the specified time.
-    pub fn sound_roll_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn sound_roll_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetSoundRollString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
@@ -221,42 +392,81 @@ impl UtilitySuite {
     }
 
     /// Retrieves the frame of the specified source time.
-    pub fn sound_timecode(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, GetSoundTimecode -> A_long, effect_ref.as_ptr(), source_track, sequence_time)? as i32)
+    pub fn sound_timecode(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, GetSoundTimecode -> A_long, effect_ref.as_ptr(), source_track, sequence_time)?
+                as i32,
+        )
     }
 
     /// Retrieves the original "ticks per frame" for the specified source track.
-    pub fn original_clip_frame_rate_for_source_track(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32) -> Result<PrTime, Error> {
+    pub fn original_clip_frame_rate_for_source_track(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+    ) -> Result<PrTime, Error> {
         call_suite_fn_single!(self, GetOriginalClipFrameRateForSourceTrack -> PrTime, effect_ref.as_ptr(), source_track)
     }
 
     /// Retrieves the media frame rate for the specified source track.
-    pub fn media_frame_rate_for_source_track(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<PrTime, Error> {
+    pub fn media_frame_rate_for_source_track(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<PrTime, Error> {
         call_suite_fn_single!(self, GetMediaFrameRateForSourceTrack -> PrTime, effect_ref.as_ptr(), source_track, sequence_time)
     }
 
     /// Retrieves the start time of the specified layer parameter.
-    pub fn source_track_media_actual_start_time(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, sequence_time: PrTime) -> Result<PrTime, Error> {
+    pub fn source_track_media_actual_start_time(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        sequence_time: PrTime,
+    ) -> Result<PrTime, Error> {
         call_suite_fn_single!(self, GetSourceTrackMediaActualStartTime -> PrTime, effect_ref.as_ptr(), layer_param_index, sequence_time)
     }
 
     /// Retrieves whether the source track item has been trimmed.
-    pub fn is_source_track_media_trimmed(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, sequence_time: PrTime) -> Result<bool, Error> {
+    pub fn is_source_track_media_trimmed(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        sequence_time: PrTime,
+    ) -> Result<bool, Error> {
         call_suite_fn_single!(self, IsSourceTrackMediaTrimmed -> bool, effect_ref.as_ptr(), layer_param_index, sequence_time)
     }
 
     /// Retrieves whether the track item has been trimmed.
-    pub fn is_media_trimmed(&self, effect_ref: impl AsPtr<PF_ProgPtr>, sequence_time: PrTime) -> Result<bool, Error> {
+    pub fn is_media_trimmed(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        sequence_time: PrTime,
+    ) -> Result<bool, Error> {
         call_suite_fn_single!(self, IsMediaTrimmed -> bool, effect_ref.as_ptr(), sequence_time)
     }
 
     /// Retrieves whether, for the specified layer parameter, the track is empty.
-    pub fn is_track_empty(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, sequence_time: PrTime) -> Result<bool, Error> {
+    pub fn is_track_empty(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        sequence_time: PrTime,
+    ) -> Result<bool, Error> {
         call_suite_fn_single!(self, IsTrackEmpty -> bool, effect_ref.as_ptr(), layer_param_index, sequence_time)
     }
 
     /// Retrieves whether the effect is applied to a track item backed by a synthetic importer.
-    pub fn is_track_item_effect_applied_to_synthetic(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<bool, Error> {
+    pub fn is_track_item_effect_applied_to_synthetic(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<bool, Error> {
         call_suite_fn_single!(self, IsTrackItemEffectAppliedToSynthetic -> bool, effect_ref.as_ptr())
     }
 

--- a/after-effects/src/pf/suites/world.rs
+++ b/after-effects/src/pf/suites/world.rs
@@ -12,20 +12,35 @@ define_suite!(
 impl WorldSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Creates a new [`Layer`].
-    pub fn new_world(&self, in_data: impl AsPtr<*const ae_sys::PF_InData>, width: i32, height: i32, clear_pix: bool, pixel_format: PixelFormat) -> Result<Layer, Error> {
+    pub fn new_world(
+        &self,
+        in_data: impl AsPtr<*const ae_sys::PF_InData>,
+        width: i32,
+        height: i32,
+        clear_pix: bool,
+        pixel_format: PixelFormat,
+    ) -> Result<Layer, Error> {
         let layer = call_suite_fn_single!(self, PF_NewWorld -> ae_sys::PF_EffectWorld, (*in_data.as_ptr()).effect_ref, width, height, clear_pix as _, pixel_format.into())?;
         Ok(Layer::from_owned(layer, in_data, |self_layer| {
-            WorldSuite::new().unwrap().dispose_world(unsafe { (*self_layer.in_data_ptr).effect_ref }, self_layer.as_mut_ptr()).unwrap();
+            WorldSuite::new()
+                .unwrap()
+                .dispose_world(
+                    unsafe { (*self_layer.in_data_ptr).effect_ref },
+                    self_layer.as_mut_ptr(),
+                )
+                .unwrap();
         }))
     }
 
     /// Dispose of an [`Layer`].
-    pub fn dispose_world(&self, effect_ref: impl AsPtr<PF_ProgPtr>, effect_world: *mut ae_sys::PF_EffectWorld) -> Result<(), Error> {
+    pub fn dispose_world(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        effect_world: *mut ae_sys::PF_EffectWorld,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, PF_DisposeWorld, effect_ref.as_ptr(), effect_world)
     }
 
@@ -36,7 +51,10 @@ impl WorldSuite {
     /// * [`PixelFormat::Argb32`] - standard 8-bit RGB
     /// * [`PixelFormat::Argb64`] - 16-bit RGB
     /// * [`PixelFormat::Argb128`] - 32-bit floating point RGB
-    pub fn pixel_format(&self, effect_world: impl AsPtr<*const ae_sys::PF_EffectWorld>) -> Result<PixelFormat, Error> {
+    pub fn pixel_format(
+        &self,
+        effect_world: impl AsPtr<*const ae_sys::PF_EffectWorld>,
+    ) -> Result<PixelFormat, Error> {
         Ok(call_suite_fn_single!(self, PF_GetPixelFormat -> ae_sys::PF_PixelFormat, effect_world.as_ptr())?.into())
     }
 }

--- a/after-effects/src/pf/suites/world_transform.rs
+++ b/after-effects/src/pf/suites/world_transform.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use ae_sys::{ PF_ProgPtr, PF_EffectWorld, PF_FloatMatrix };
+use ae_sys::{PF_EffectWorld, PF_FloatMatrix, PF_ProgPtr};
 use std::ffi::c_void;
 
 define_suite!(
@@ -13,9 +13,8 @@ define_suite!(
 impl WorldTransformSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
     /// Composite a rectangle from one `PF_EffectWorld` into another, using one of After Effects' transfer modes.
     /// * `src_rect` - rectangle in source image
     /// * `src_opacity` - opacity of src
@@ -23,16 +22,61 @@ impl WorldTransformSuite {
     /// * `dest_x`, `dest_y` - upper left-hand corner of src rect in composite image
     /// * `field` - which scanlines to render ([`Field::Frame`], [`Field::Upper`] or [`Field::Lower`])
     /// * `transfer_mode` - can be [`TransferMode::Copy`], [`TransferMode::Behind`] or [`TransferMode::InFront`]
-    pub fn composite_rect(&self, effect_ref: impl AsPtr<PF_ProgPtr>, src_rect: Option<Rect>, src_opacity: i32, src: impl AsPtr<*const PF_EffectWorld>, dest_x: i32, dest_y: i32, field: Field, transfer_mode: TransferMode, mut dst: impl AsMutPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
-        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
-        call_suite_fn!(self, composite_rect, effect_ref.as_ptr(), src_rect.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x), src_opacity, src.as_ptr() as _, dest_x, dest_y, field.into(), transfer_mode.into(), dst.as_mut_ptr())
+    pub fn composite_rect(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        src_rect: Option<Rect>,
+        src_opacity: i32,
+        src: impl AsPtr<*const PF_EffectWorld>,
+        dest_x: i32,
+        dest_y: i32,
+        field: Field,
+        transfer_mode: TransferMode,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
+        call_suite_fn!(
+            self,
+            composite_rect,
+            effect_ref.as_ptr(),
+            src_rect
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |x| x),
+            src_opacity,
+            src.as_ptr() as _,
+            dest_x,
+            dest_y,
+            field.into(),
+            transfer_mode.into(),
+            dst.as_mut_ptr()
+        )
     }
 
     /// Blends two images, alpha-weighted. Does not deal with different-sized sources, though the destination may be either `PF_EffectWorld`.
     /// - `ratio` should be between 0.0 and 1.0
-    pub fn blend(&self, effect_ref: impl AsPtr<PF_ProgPtr>, src1: impl AsPtr<*const PF_EffectWorld>, src2: impl AsPtr<*const PF_EffectWorld>, ratio: f32, mut dst: impl AsMutPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
-        if src1.as_ptr().is_null() || src2.as_ptr().is_null() || dst.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
-        call_suite_fn!(self, blend, effect_ref.as_ptr(), src1.as_ptr(), src2.as_ptr(), Fixed::from(ratio).as_fixed() as _, dst.as_mut_ptr())
+    pub fn blend(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        src1: impl AsPtr<*const PF_EffectWorld>,
+        src2: impl AsPtr<*const PF_EffectWorld>,
+        ratio: f32,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        if src1.as_ptr().is_null() || src2.as_ptr().is_null() || dst.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
+        call_suite_fn!(
+            self,
+            blend,
+            effect_ref.as_ptr(),
+            src1.as_ptr(),
+            src2.as_ptr(),
+            Fixed::from(ratio).as_fixed() as _,
+            dst.as_mut_ptr()
+        )
     }
 
     /// Convolve an image with an arbitrary size kernel on each of the a, r, g, and b channels separately.
@@ -50,43 +94,140 @@ impl WorldTransformSuite {
     ///
     /// Note: some 2D convolutions are seperable and can be implemented with a horizontal 1D convolve and a vertical 1D convolve.
     /// This filter may have different high and low quality versions.
-    pub fn convolve(&self, effect_ref: impl AsPtr<PF_ProgPtr>, src: impl AsPtr<*const PF_EffectWorld>, area: Option<Rect>, flags: KernelFlags, kernel_size: i32, a_kernel: *mut c_void, r_kernel: *mut c_void, g_kernel: *mut c_void, b_kernel: *mut c_void, mut dst: impl AsMutPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
-        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
-        call_suite_fn!(self, convolve, effect_ref.as_ptr(), src.as_ptr() as _, area.map(Into::into).as_ref().map_or(std::ptr::null_mut(), |x| x), flags.bits() as _, kernel_size, a_kernel, r_kernel, g_kernel, b_kernel, dst.as_mut_ptr())
+    pub fn convolve(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        src: impl AsPtr<*const PF_EffectWorld>,
+        area: Option<Rect>,
+        flags: KernelFlags,
+        kernel_size: i32,
+        a_kernel: *mut c_void,
+        r_kernel: *mut c_void,
+        g_kernel: *mut c_void,
+        b_kernel: *mut c_void,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
+        call_suite_fn!(
+            self,
+            convolve,
+            effect_ref.as_ptr(),
+            src.as_ptr() as _,
+            area.map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null_mut(), |x| x),
+            flags.bits() as _,
+            kernel_size,
+            a_kernel,
+            r_kernel,
+            g_kernel,
+            b_kernel,
+            dst.as_mut_ptr()
+        )
     }
 
     /// This blits a region from one PF_EffectWorld to another.
     /// This is an alpha-preserving (unlike CopyBits), 32-bit only, non-antialiased stretch blit.
     /// The high quality version does an anti-aliased blit (ie. it interpolates).
-    pub fn copy(&self, effect_ref: impl AsPtr<PF_ProgPtr>, src: impl AsPtr<*const PF_EffectWorld>, mut dst: impl AsMutPtr<*mut PF_EffectWorld>, src_rect: Option<Rect>, dst_rect: Option<Rect>) -> Result<(), Error> {
-        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
-        call_suite_fn!(self, copy, effect_ref.as_ptr(), src.as_ptr() as *mut _, dst.as_mut_ptr(), src_rect.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x), dst_rect.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x))
+    pub fn copy(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        src: impl AsPtr<*const PF_EffectWorld>,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+        src_rect: Option<Rect>,
+        dst_rect: Option<Rect>,
+    ) -> Result<(), Error> {
+        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
+        call_suite_fn!(
+            self,
+            copy,
+            effect_ref.as_ptr(),
+            src.as_ptr() as *mut _,
+            dst.as_mut_ptr(),
+            src_rect
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |x| x),
+            dst_rect
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |x| x)
+        )
     }
 
     /// This blits a region from one PF_EffectWorld to another.
     /// This is an alpha-preserving (unlike CopyBits), 32-bit only, non-antialiased stretch blit.
     /// The high quality version does an anti-aliased blit (ie. it interpolates).
-    pub fn copy_hq(&self, effect_ref: impl AsPtr<PF_ProgPtr>, src: impl AsPtr<*const PF_EffectWorld>, mut dst: impl AsMutPtr<*mut PF_EffectWorld>, src_rect: Option<Rect>, dst_rect: Option<Rect>) -> Result<(), Error> {
-        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
-        call_suite_fn!(self, copy_hq, effect_ref.as_ptr(), src.as_ptr() as *mut _, dst.as_mut_ptr(), src_rect.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x), dst_rect.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x))
+    pub fn copy_hq(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        src: impl AsPtr<*const PF_EffectWorld>,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+        src_rect: Option<Rect>,
+        dst_rect: Option<Rect>,
+    ) -> Result<(), Error> {
+        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
+        call_suite_fn!(
+            self,
+            copy_hq,
+            effect_ref.as_ptr(),
+            src.as_ptr() as *mut _,
+            dst.as_mut_ptr(),
+            src_rect
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |x| x),
+            dst_rect
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |x| x)
+        )
     }
 
     /// Blends using a transfer mode, with an optional mask.
-    pub fn transfer_rect(&self, effect_ref: impl AsPtr<PF_ProgPtr>, quality: Quality, flags: ModeFlags, field: Field, src_rect: Option<Rect>, src: impl AsPtr<*const PF_EffectWorld>, comp_mode: CompositeMode, mask_world: Option<MaskWorld>, dest_x: i32, dest_y: i32, mut dst: impl AsMutPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
-        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
+    pub fn transfer_rect(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        quality: Quality,
+        flags: ModeFlags,
+        field: Field,
+        src_rect: Option<Rect>,
+        src: impl AsPtr<*const PF_EffectWorld>,
+        comp_mode: CompositeMode,
+        mask_world: Option<MaskWorld>,
+        dest_x: i32,
+        dest_y: i32,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
 
         let comp_mode: ae_sys::PF_CompositeMode = comp_mode.into();
 
-        call_suite_fn!(self,
+        call_suite_fn!(
+            self,
             transfer_rect,
             effect_ref.as_ptr(),
             quality.into(),
             flags.into(),
             field.into(),
-            src_rect.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x),
+            src_rect
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |x| x),
             src.as_ptr(),
             &comp_mode,
-            mask_world.map(Into::into).as_ref().map_or(std::ptr::null(), |x| x),
+            mask_world
+                .map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null(), |x| x),
             dest_x,
             dest_y,
             dst.as_mut_ptr()
@@ -98,14 +239,31 @@ impl WorldTransformSuite {
     /// The matrices pointer points to a matrix array used for motion-blur.
     ///
     /// When is a transform not a transform? A Z-scale transform is not a transform, unless the transformed layer is a parent of other layers that do not all lie in the z=0 plane.
-    pub fn transform_world(&self, effect_ref: impl AsPtr<PF_ProgPtr>, quality: Quality, mode_flags: ModeFlags, field: Field, src: *const PF_EffectWorld, comp_mode: CompositeMode, mask_world: Option<MaskWorld>, matrices: &[Matrix3], src2dst_matrix: bool, dest_rect: Option<Rect>, dst: *mut PF_EffectWorld) -> Result<(), Error> {
-        if src.is_null() || dst.is_null() { return Err(Error::BadCallbackParameter); }
+    pub fn transform_world(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        quality: Quality,
+        mode_flags: ModeFlags,
+        field: Field,
+        src: *const PF_EffectWorld,
+        comp_mode: CompositeMode,
+        mask_world: Option<MaskWorld>,
+        matrices: &[Matrix3],
+        src2dst_matrix: bool,
+        dest_rect: Option<Rect>,
+        dst: *mut PF_EffectWorld,
+    ) -> Result<(), Error> {
+        if src.is_null() || dst.is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
 
-        const _: () = assert!(std::mem::size_of::<PF_FloatMatrix>() == std::mem::size_of::<Matrix3>());
+        const _: () =
+            assert!(std::mem::size_of::<PF_FloatMatrix>() == std::mem::size_of::<Matrix3>());
 
         let comp_mode: ae_sys::PF_CompositeMode = comp_mode.into();
 
-        call_suite_fn!(self,
+        call_suite_fn!(
+            self,
             transform_world,
             effect_ref.as_ptr(),
             quality.into(),
@@ -113,11 +271,17 @@ impl WorldTransformSuite {
             field.into(),
             src,
             &comp_mode,
-            mask_world.map(Into::into).as_ref().map_or(std::ptr::null(), |x| x),
+            mask_world
+                .map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null(), |x| x),
             matrices.as_ptr() as *const _,
             matrices.len() as _,
             src2dst_matrix as _,
-            dest_rect.map(Into::into).as_ref().map_or(std::ptr::null(), |x| x),
+            dest_rect
+                .map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null(), |x| x),
             dst
         )
     }

--- a/after-effects/src/pf/util_callbacks.rs
+++ b/after-effects/src/pf/util_callbacks.rs
@@ -1,6 +1,6 @@
 use crate::*;
+use ae_sys::{_PF_UtilCallbacks, PF_EffectWorld, PF_FloatMatrix, PF_Pixel, PF_Pixel16, PF_ProgPtr};
 use std::ffi::c_void;
-use ae_sys::{ PF_ProgPtr, PF_EffectWorld, _PF_UtilCallbacks, PF_Pixel, PF_Pixel16, PF_FloatMatrix };
 
 macro_rules! call_fn {
     ($self:ident, $fn:ident, $($args:expr),*) => {
@@ -168,6 +168,20 @@ pub const ONCE_PER_PROCESSOR: i32 = ae_sys::PF_Iterations_ONCE_PER_PROCESSOR as 
 pub struct UtilCallbacks(*const ae_sys::PF_InData);
 
 impl UtilCallbacks {
+    define_iterate!(iterate, Pixel8, PF_Pixel);
+
+    define_iterate!(iterate16, Pixel16, PF_Pixel16);
+
+    define_iterate!(iterate_origin,                Pixel8,  PF_Pixel,   origin: Option<Point>);
+
+    define_iterate!(iterate_origin16,              Pixel16, PF_Pixel16, origin: Option<Point>);
+
+    define_iterate!(iterate_origin_non_clip_src,   Pixel8,  PF_Pixel,   origin: Option<Point>);
+
+    define_iterate!(iterate_origin_non_clip_src16, Pixel16, PF_Pixel16, origin: Option<Point>);
+
+    define_iterate_lut_and_generic!();
+
     pub fn new(in_data: impl AsPtr<*const ae_sys::PF_InData>) -> Self {
         assert!(!in_data.as_ptr().is_null());
         Self(in_data.as_ptr())
@@ -180,16 +194,57 @@ impl UtilCallbacks {
     /// * `dest_x`, `dest_y` - upper left-hand corner of src rect in composite image
     /// * `field` - which scanlines to render ([`Field::Frame`], [`Field::Upper`] or [`Field::Lower`])
     /// * `transfer_mode` - can be [`TransferMode::Copy`], [`TransferMode::Behind`] or [`TransferMode::InFront`]
-    pub fn composite_rect(&self, src_rect: Option<Rect>, src_opacity: i32, src: impl AsPtr<*const PF_EffectWorld>, dest_x: i32, dest_y: i32, field: Field, transfer_mode: TransferMode, mut dst: impl AsMutPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
-        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
-        call_fn!(self, composite_rect, src_rect.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x), src_opacity, src.as_ptr() as _, dest_x, dest_y, field.into(), transfer_mode.into(), dst.as_mut_ptr())
+    pub fn composite_rect(
+        &self,
+        src_rect: Option<Rect>,
+        src_opacity: i32,
+        src: impl AsPtr<*const PF_EffectWorld>,
+        dest_x: i32,
+        dest_y: i32,
+        field: Field,
+        transfer_mode: TransferMode,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
+        call_fn!(
+            self,
+            composite_rect,
+            src_rect
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |x| x),
+            src_opacity,
+            src.as_ptr() as _,
+            dest_x,
+            dest_y,
+            field.into(),
+            transfer_mode.into(),
+            dst.as_mut_ptr()
+        )
     }
 
     /// Blends two images, alpha-weighted. Does not deal with different-sized sources, though the destination may be either `PF_EffectWorld`.
     /// - `ratio` should be between 0.0 and 1.0
-    pub fn blend(&self, src1: impl AsPtr<*const PF_EffectWorld>, src2: impl AsPtr<*const PF_EffectWorld>, ratio: f32, mut dst: impl AsMutPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
-        if src1.as_ptr().is_null() || src2.as_ptr().is_null() || dst.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
-        call_fn!(self, blend, src1.as_ptr(), src2.as_ptr(), Fixed::from(ratio).as_fixed(), dst.as_mut_ptr())
+    pub fn blend(
+        &self,
+        src1: impl AsPtr<*const PF_EffectWorld>,
+        src2: impl AsPtr<*const PF_EffectWorld>,
+        ratio: f32,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        if src1.as_ptr().is_null() || src2.as_ptr().is_null() || dst.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
+        call_fn!(
+            self,
+            blend,
+            src1.as_ptr(),
+            src2.as_ptr(),
+            Fixed::from(ratio).as_fixed(),
+            dst.as_mut_ptr()
+        )
     }
 
     /// Convolve an image with an arbitrary size kernel on each of the a, r, g, and b channels separately.
@@ -207,9 +262,36 @@ impl UtilCallbacks {
     ///
     /// Note: some 2D convolutions are seperable and can be implemented with a horizontal 1D convolve and a vertical 1D convolve.
     /// This filter may have different high and low quality versions.
-    pub fn convolve(&self, src: impl AsPtr<*const PF_EffectWorld>, area: Option<Rect>, flags: KernelFlags, kernel_size: i32, a_kernel: *mut c_void, r_kernel: *mut c_void, g_kernel: *mut c_void, b_kernel: *mut c_void, mut dst: impl AsMutPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
-        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
-        call_fn!(self, convolve, src.as_ptr() as _, area.map(Into::into).as_ref().map_or(std::ptr::null_mut(), |x| x), flags.bits() as _, kernel_size, a_kernel, r_kernel, g_kernel, b_kernel, dst.as_mut_ptr())
+    pub fn convolve(
+        &self,
+        src: impl AsPtr<*const PF_EffectWorld>,
+        area: Option<Rect>,
+        flags: KernelFlags,
+        kernel_size: i32,
+        a_kernel: *mut c_void,
+        r_kernel: *mut c_void,
+        g_kernel: *mut c_void,
+        b_kernel: *mut c_void,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
+        call_fn!(
+            self,
+            convolve,
+            src.as_ptr() as _,
+            area.map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null_mut(), |x| x),
+            flags.bits() as _,
+            kernel_size,
+            a_kernel,
+            r_kernel,
+            g_kernel,
+            b_kernel,
+            dst.as_mut_ptr()
+        )
     }
 
     /// Generate a kernel with a Gaussian distribution of values.
@@ -224,16 +306,37 @@ impl UtilCallbacks {
     /// * Use longs-chars-fixeds
     ///
     /// This filter will be the same high and low quality.
-    pub fn gaussian_kernel(&self, radius: f64, flags: KernelFlags, multiplier: f64, diameter: &mut i32, kernel: *mut c_void) -> Result<(), Error> {
-        call_fn!(self, gaussian_kernel, radius, flags.bits() as _, multiplier, diameter, kernel)
+    pub fn gaussian_kernel(
+        &self,
+        radius: f64,
+        flags: KernelFlags,
+        multiplier: f64,
+        diameter: &mut i32,
+        kernel: *mut c_void,
+    ) -> Result<(), Error> {
+        call_fn!(
+            self,
+            gaussian_kernel,
+            radius,
+            flags.bits() as _,
+            multiplier,
+            diameter,
+            kernel
+        )
     }
 
     /// Converts to (and from) r, g, and b color values pre-multiplied with black to represent the alpha channel.
     /// * `forward` - `true` means convert non-premultiplied to pre-multiplied; `false` means un-pre-multiply.
     ///
     /// Quality independent.
-    pub fn premultiply(&self, forward: bool, mut dst: impl AsMutPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
-        if dst.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
+    pub fn premultiply(
+        &self,
+        forward: bool,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        if dst.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
         call_fn!(self, premultiply, forward as _, dst.as_mut_ptr())
     }
 
@@ -242,9 +345,24 @@ impl UtilCallbacks {
     /// * `forward` - `true` means convert non-premultiplied to pre-multiplied; `false` means un-pre-multiply.
     ///
     /// To convert between premul and straight pixel buffers where the color channels were matted with a color other than black.
-    pub fn premultiply_color(&self, src: impl AsPtr<*const PF_EffectWorld>, color: &Pixel8, forward: bool, mut dst: impl AsMutPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
-        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
-        call_fn!(self, premultiply_color, src.as_ptr() as _, color, forward as _, dst.as_mut_ptr())
+    pub fn premultiply_color(
+        &self,
+        src: impl AsPtr<*const PF_EffectWorld>,
+        color: &Pixel8,
+        forward: bool,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
+        call_fn!(
+            self,
+            premultiply_color,
+            src.as_ptr() as _,
+            color,
+            forward as _,
+            dst.as_mut_ptr()
+        )
     }
 
     /// Converts to (and from) having r, g, and b color values premultiplied with any color to represent the alpha channel.
@@ -252,22 +370,47 @@ impl UtilCallbacks {
     /// * `forward` - `true` means convert non-premultiplied to pre-multiplied; `false` means un-pre-multiply.
     ///
     /// To convert between premul and straight pixel buffers where the color channels were matted with a color other than black.
-    pub fn premultiply_color16(&self, src: impl AsPtr<*const PF_EffectWorld>, color: &Pixel16, forward: bool, mut dst: impl AsMutPtr<*mut PF_EffectWorld>) -> Result<(), Error> {
-        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
-        call_fn!(self, premultiply_color16, src.as_ptr() as _, color, forward as _, dst.as_mut_ptr())
+    pub fn premultiply_color16(
+        &self,
+        src: impl AsPtr<*const PF_EffectWorld>,
+        color: &Pixel16,
+        forward: bool,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+    ) -> Result<(), Error> {
+        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
+        call_fn!(
+            self,
+            premultiply_color16,
+            src.as_ptr() as _,
+            color,
+            forward as _,
+            dst.as_mut_ptr()
+        )
     }
 
     /// Call this routine before you plan to perform a large number of image resamplings.
     /// Depending on platform, this routine could start up the DSP chip, compute an index table to each scanline
     /// of the buffer, or whatever might be needed to speed up image resampling.
-    pub fn begin_sampling(&self, quality: Quality, mode_flags: ModeFlags) -> Result<Sampling, Error> {
+    pub fn begin_sampling(
+        &self,
+        quality: Quality,
+        mode_flags: ModeFlags,
+    ) -> Result<Sampling, Error> {
         let mut params = Sampling {
             in_data_ptr: self.0.as_ptr(),
             params: unsafe { std::mem::zeroed() },
             quality: quality.into(),
             mode_flags: mode_flags.into(),
         };
-        let _ = call_fn!(self, begin_sampling, quality.into(), mode_flags.into(), &mut params.params)?;
+        let _ = call_fn!(
+            self,
+            begin_sampling,
+            quality.into(),
+            mode_flags.into(),
+            &mut params.params
+        )?;
         Ok(params)
     }
 
@@ -275,39 +418,87 @@ impl UtilCallbacks {
     /// Setting `color` to `None` will fill the rectangle with black.
     /// Setting `rect` to `None` will fill the entire image.
     /// Quality setting doesn't matter.
-    pub fn fill(&self, mut world: impl AsMutPtr<*mut PF_EffectWorld>, color: Option<Pixel8>, rect: Option<Rect>) -> Result<(), Error> {
-        if world.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
-        call_fn!(self, fill, color.as_ref().map_or(std::ptr::null(), |x| x), rect.map(Into::into).as_ref().map_or(std::ptr::null(), |x| x), world.as_mut_ptr())
+    pub fn fill(
+        &self,
+        mut world: impl AsMutPtr<*mut PF_EffectWorld>,
+        color: Option<Pixel8>,
+        rect: Option<Rect>,
+    ) -> Result<(), Error> {
+        if world.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
+        call_fn!(
+            self,
+            fill,
+            color.as_ref().map_or(std::ptr::null(), |x| x),
+            rect.map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null(), |x| x),
+            world.as_mut_ptr()
+        )
     }
 
     /// This fills a rectangle in the 8-bit image with the given color.
     /// Setting `color` to `None` will fill the rectangle with black.
     /// Setting `rect` to `None` will fill the entire image.
     /// Quality setting doesn't matter.
-    pub fn fill16(&self, mut world: impl AsMutPtr<*mut PF_EffectWorld>, color: Option<Pixel16>, rect: Option<Rect>) -> Result<(), Error> {
-        if world.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
-        call_fn!(self, fill16, color.as_ref().map_or(std::ptr::null(), |x| x), rect.map(Into::into).as_ref().map_or(std::ptr::null(), |x| x), world.as_mut_ptr())
+    pub fn fill16(
+        &self,
+        mut world: impl AsMutPtr<*mut PF_EffectWorld>,
+        color: Option<Pixel16>,
+        rect: Option<Rect>,
+    ) -> Result<(), Error> {
+        if world.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
+        call_fn!(
+            self,
+            fill16,
+            color.as_ref().map_or(std::ptr::null(), |x| x),
+            rect.map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null(), |x| x),
+            world.as_mut_ptr()
+        )
     }
 
     /// This blits a region from one PF_EffectWorld to another.
     /// This is an alpha-preserving (unlike CopyBits), 32-bit only, non-antialiased stretch blit.
     /// The high qual version does an anti-aliased blit (ie. it interpolates).
-    pub fn copy(&self, src: impl AsPtr<*const PF_EffectWorld>, mut dst: impl AsMutPtr<*mut PF_EffectWorld>, src_rect: Option<Rect>, dst_rect: Option<Rect>) -> Result<(), Error> {
-        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() { return Err(Error::BadCallbackParameter); }
-        call_fn!(self, copy, src.as_ptr() as *mut _, dst.as_mut_ptr(), src_rect.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x), dst_rect.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x))
+    pub fn copy(
+        &self,
+        src: impl AsPtr<*const PF_EffectWorld>,
+        mut dst: impl AsMutPtr<*mut PF_EffectWorld>,
+        src_rect: Option<Rect>,
+        dst_rect: Option<Rect>,
+    ) -> Result<(), Error> {
+        if src.as_ptr().is_null() || dst.as_mut_ptr().is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
+        call_fn!(
+            self,
+            copy,
+            src.as_ptr() as *mut _,
+            dst.as_mut_ptr(),
+            src_rect
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |x| x),
+            dst_rect
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |x| x)
+        )
     }
 
     // Helpers for the define_iterate macros
-    #[inline(always)] fn get_in_data(&self) -> *const ae_sys::PF_InData { self.0.as_ptr() }
-    #[inline(always)] fn get_funcs_ptr(&self) -> *mut ae_sys::_PF_UtilCallbacks { unsafe { (*self.0.as_ptr()).utils } }
+    #[inline(always)]
+    fn get_in_data(&self) -> *const ae_sys::PF_InData { self.0.as_ptr() }
 
-    define_iterate!(iterate,                       Pixel8,  PF_Pixel);
-    define_iterate!(iterate16,                     Pixel16, PF_Pixel16);
-    define_iterate!(iterate_origin,                Pixel8,  PF_Pixel,   origin: Option<Point>);
-    define_iterate!(iterate_origin16,              Pixel16, PF_Pixel16, origin: Option<Point>);
-    define_iterate!(iterate_origin_non_clip_src,   Pixel8,  PF_Pixel,   origin: Option<Point>);
-    define_iterate!(iterate_origin_non_clip_src16, Pixel16, PF_Pixel16, origin: Option<Point>);
-    define_iterate_lut_and_generic!();
+    #[inline(always)]
+    fn get_funcs_ptr(&self) -> *mut ae_sys::_PF_UtilCallbacks {
+        unsafe { (*self.0.as_ptr()).utils }
+    }
 
     pub fn host_new_handle(&self, size: usize) -> Result<RawHandle, Error> {
         unsafe {
@@ -315,7 +506,9 @@ impl UtilCallbacks {
             if size == 0 || in_data.utils.is_null() {
                 return Err(Error::BadCallbackParameter);
             }
-            let new = (*in_data.utils).host_new_handle.ok_or(Error::BadCallbackParameter)?;
+            let new = (*in_data.utils)
+                .host_new_handle
+                .ok_or(Error::BadCallbackParameter)?;
             let ptr = new(size as _);
             if ptr.is_null() {
                 return Err(Error::OutOfMemory);
@@ -329,17 +522,31 @@ impl UtilCallbacks {
             }
             Ok(RawHandle {
                 utils_ptr: in_data.utils,
-                handle: ptr
+                handle: ptr,
             })
         }
     }
 
     /// This creates a new [`Layer`] for scratch for you. You must dispose of it. This is quality independent.
-    pub fn new_world(&self, width: usize, height: usize, flags: NewWorldFlags) -> Result<Layer, Error> {
+    pub fn new_world(
+        &self,
+        width: usize,
+        height: usize,
+        flags: NewWorldFlags,
+    ) -> Result<Layer, Error> {
         let mut world = unsafe { std::mem::zeroed() };
-        call_fn!(self, new_world, width as _, height as _, flags.bits() as _, &mut world)?;
+        call_fn!(
+            self,
+            new_world,
+            width as _,
+            height as _,
+            flags.bits() as _,
+            &mut world
+        )?;
         Ok(Layer::from_owned(world, self.0.clone(), |self_layer| {
-            UtilCallbacks::new(self_layer.in_data_ptr).dispose_world(self_layer.as_mut_ptr()).unwrap();
+            UtilCallbacks::new(self_layer.in_data_ptr)
+                .dispose_world(self_layer.as_mut_ptr())
+                .unwrap();
         }))
     }
 
@@ -349,20 +556,41 @@ impl UtilCallbacks {
     }
 
     /// Blends using a transfer mode, with an optional mask.
-    pub fn transfer_rect(&self, quality: Quality, flags: ModeFlags, field: Field, src_rect: Option<Rect>, src: *const PF_EffectWorld, comp_mode: CompositeMode, mask_world: Option<MaskWorld>, dest_x: i32, dest_y: i32, dst: *mut PF_EffectWorld) -> Result<(), Error> {
-        if src.is_null() || dst.is_null() { return Err(Error::BadCallbackParameter); }
+    pub fn transfer_rect(
+        &self,
+        quality: Quality,
+        flags: ModeFlags,
+        field: Field,
+        src_rect: Option<Rect>,
+        src: *const PF_EffectWorld,
+        comp_mode: CompositeMode,
+        mask_world: Option<MaskWorld>,
+        dest_x: i32,
+        dest_y: i32,
+        dst: *mut PF_EffectWorld,
+    ) -> Result<(), Error> {
+        if src.is_null() || dst.is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
 
         let comp_mode: ae_sys::PF_CompositeMode = comp_mode.into();
 
-        call_fn!(self,
+        call_fn!(
+            self,
             transfer_rect,
             quality.into(),
             flags.into(),
             field.into(),
-            src_rect.map(Into::into).as_mut().map_or(std::ptr::null_mut(), |x| x),
+            src_rect
+                .map(Into::into)
+                .as_mut()
+                .map_or(std::ptr::null_mut(), |x| x),
             src,
             &comp_mode,
-            mask_world.map(Into::into).as_ref().map_or(std::ptr::null(), |x| x),
+            mask_world
+                .map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null(), |x| x),
             dest_x,
             dest_y,
             dst
@@ -374,25 +602,47 @@ impl UtilCallbacks {
     /// The matrices pointer points to a matrix array used for motion-blur.
     ///
     /// When is a transform not a transform? A Z-scale transform is not a transform, unless the transformed layer is a parent of other layers that do not all lie in the z=0 plane.
-    pub fn transform_world(&self, quality: Quality, mode_flags: ModeFlags, field: Field, src: *const PF_EffectWorld, comp_mode: CompositeMode, mask_world: Option<MaskWorld>, matrices: &[Matrix3], src2dst_matrix: bool, dest_rect: Option<Rect>, dst: *mut PF_EffectWorld) -> Result<(), Error> {
-        if src.is_null() || dst.is_null() { return Err(Error::BadCallbackParameter); }
+    pub fn transform_world(
+        &self,
+        quality: Quality,
+        mode_flags: ModeFlags,
+        field: Field,
+        src: *const PF_EffectWorld,
+        comp_mode: CompositeMode,
+        mask_world: Option<MaskWorld>,
+        matrices: &[Matrix3],
+        src2dst_matrix: bool,
+        dest_rect: Option<Rect>,
+        dst: *mut PF_EffectWorld,
+    ) -> Result<(), Error> {
+        if src.is_null() || dst.is_null() {
+            return Err(Error::BadCallbackParameter);
+        }
 
-        const _: () = assert!(std::mem::size_of::<PF_FloatMatrix>() == std::mem::size_of::<Matrix3>());
+        const _: () =
+            assert!(std::mem::size_of::<PF_FloatMatrix>() == std::mem::size_of::<Matrix3>());
 
         let comp_mode: ae_sys::PF_CompositeMode = comp_mode.into();
 
-        call_fn!(self,
+        call_fn!(
+            self,
             transform_world,
             quality.into(),
             mode_flags.into(),
             field.into(),
             src,
             &comp_mode,
-            mask_world.map(Into::into).as_ref().map_or(std::ptr::null(), |x| x),
+            mask_world
+                .map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null(), |x| x),
             matrices.as_ptr() as *const _,
             matrices.len() as _,
             src2dst_matrix as _,
-            dest_rect.map(Into::into).as_ref().map_or(std::ptr::null(), |x| x),
+            dest_rect
+                .map(Into::into)
+                .as_ref()
+                .map_or(std::ptr::null(), |x| x),
             dst
         )
     }
@@ -401,29 +651,62 @@ impl UtilCallbacks {
         match type_ {
             PlatformDataType::MainWnd => {
                 let mut hwnd: usize = 0;
-                call_fn!(self, get_platform_data, type_.into(), &mut hwnd as *mut _ as *mut c_void)?;
+                call_fn!(
+                    self,
+                    get_platform_data,
+                    type_.into(),
+                    &mut hwnd as *mut _ as *mut c_void
+                )?;
                 Ok(PlatformData::MainWnd(hwnd as _))
-            },
+            }
             PlatformDataType::ResDllinstance => {
                 let mut handle = std::ptr::null_mut();
-                call_fn!(self, get_platform_data, type_.into(), &mut handle as *mut _ as *mut c_void)?;
+                call_fn!(
+                    self,
+                    get_platform_data,
+                    type_.into(),
+                    &mut handle as *mut _ as *mut c_void
+                )?;
                 Ok(PlatformData::ResDllinstance(handle))
-            },
+            }
             PlatformDataType::BundleRef => {
                 let mut handle = std::ptr::null_mut();
-                call_fn!(self, get_platform_data, type_.into(), &mut handle as *mut _ as *mut c_void)?;
+                call_fn!(
+                    self,
+                    get_platform_data,
+                    type_.into(),
+                    &mut handle as *mut _ as *mut c_void
+                )?;
                 Ok(PlatformData::BundleRef(handle))
-            },
+            }
             PlatformDataType::ExeFilePath => {
                 let mut path = [0u16; 260]; // AEFX_MAX_PATH
-                call_fn!(self, get_platform_data, type_.into(), path.as_mut_ptr() as *mut c_void)?;
-                Ok(PlatformData::ExeFilePath(String::from_utf16_lossy(&path).trim_end_matches('\0').to_string()))
-            },
+                call_fn!(
+                    self,
+                    get_platform_data,
+                    type_.into(),
+                    path.as_mut_ptr() as *mut c_void
+                )?;
+                Ok(PlatformData::ExeFilePath(
+                    String::from_utf16_lossy(&path)
+                        .trim_end_matches('\0')
+                        .to_string(),
+                ))
+            }
             PlatformDataType::ResFilePath => {
                 let mut path = [0u16; 260]; // AEFX_MAX_PATH
-                call_fn!(self, get_platform_data, type_.into(), path.as_mut_ptr() as *mut c_void)?;
-                Ok(PlatformData::ResFilePath(String::from_utf16_lossy(&path).trim_end_matches('\0').to_string()))
-            },
+                call_fn!(
+                    self,
+                    get_platform_data,
+                    type_.into(),
+                    path.as_mut_ptr() as *mut c_void
+                )?;
+                Ok(PlatformData::ResFilePath(
+                    String::from_utf16_lossy(&path)
+                        .trim_end_matches('\0')
+                        .to_string(),
+                ))
+            }
         }
     }
 
@@ -432,45 +715,58 @@ impl UtilCallbacks {
     /// It will return [`Error::BadCallbackParameter`] if the world is not 8-bpc.
     ///
     /// The second parameter is optional; if it is `Some`, the returned pixel will be an interpretation of the values in the passed-in pixel, as if it were in the specified PF_EffectWorld.
-    pub fn pixel_data8(&self, world: *mut PF_EffectWorld, pixels: Option<*mut Pixel8>) -> Result<*mut Pixel8, Error> {
+    pub fn pixel_data8(
+        &self,
+        world: *mut PF_EffectWorld,
+        pixels: Option<*mut Pixel8>,
+    ) -> Result<*mut Pixel8, Error> {
         let mut ret = std::ptr::null_mut();
         unsafe {
             let in_data = &(*self.0.as_ptr());
             if in_data.utils.is_null() || in_data.effect_ref.is_null() || world.is_null() {
                 return Err(Error::BadCallbackParameter);
             }
-            let f = (*in_data.utils).get_pixel_data8.ok_or(Error::BadCallbackParameter)?;
+            let f = (*in_data.utils)
+                .get_pixel_data8
+                .ok_or(Error::BadCallbackParameter)?;
             match f(world, pixels.unwrap_or(std::ptr::null_mut()), &mut ret) {
                 0 => {
                     if ret.is_null() {
                         return Err(Error::BadCallbackParameter);
                     }
                     Ok(ret)
-                },
+                }
                 e => Err(e.into()),
             }
         }
     }
+
     /// Obtain a pointer to a 16-bpc pixel within the specified world.
     ///
     /// It will return [`Error::BadCallbackParameter`] if the world is not 16-bpc.
     ///
     /// The second parameter is optional; if it is `Some`, the returned pixel will be an interpretation of the values in the passed-in pixel, as if it were in the specified PF_EffectWorld.
-    pub fn pixel_data16(&self, world: *mut PF_EffectWorld, pixels: Option<*mut Pixel8>) -> Result<*mut Pixel16, Error> {
+    pub fn pixel_data16(
+        &self,
+        world: *mut PF_EffectWorld,
+        pixels: Option<*mut Pixel8>,
+    ) -> Result<*mut Pixel16, Error> {
         let mut ret = std::ptr::null_mut();
         unsafe {
             let in_data = &(*self.0.as_ptr());
             if in_data.utils.is_null() || in_data.effect_ref.is_null() || world.is_null() {
                 return Err(Error::BadCallbackParameter);
             }
-            let f = (*in_data.utils).get_pixel_data16.ok_or(Error::BadCallbackParameter)?;
+            let f = (*in_data.utils)
+                .get_pixel_data16
+                .ok_or(Error::BadCallbackParameter)?;
             match f(world, pixels.unwrap_or(std::ptr::null_mut()), &mut ret) {
                 0 => {
                     if ret.is_null() {
                         return Err(Error::BadCallbackParameter);
                     }
                     Ok(ret)
-                },
+                }
                 e => Err(e.into()),
             }
         }
@@ -483,7 +779,7 @@ impl UtilCallbacks {
             assert!(!in_data.utils.is_null() && !in_data.effect_ref.is_null());
             ColorCallbacks {
                 effect_ref: in_data.effect_ref,
-                utils: in_data.utils
+                utils: in_data.utils,
             }
         }
     }
@@ -519,8 +815,15 @@ impl ColorCallbacks {
     pub fn rgb_to_hls(&self, rgb: &Pixel8) -> Result<HLSPixel, Error> {
         let mut hls = HLSPixel::default();
         unsafe {
-            let f = (*self.utils).colorCB.RGBtoHLS.ok_or(Error::BadCallbackParameter)?;
-            match f(self.effect_ref, rgb as *const _ as *mut _, &mut hls as *mut _ as *mut _) {
+            let f = (*self.utils)
+                .colorCB
+                .RGBtoHLS
+                .ok_or(Error::BadCallbackParameter)?;
+            match f(
+                self.effect_ref,
+                rgb as *const _ as *mut _,
+                &mut hls as *mut _ as *mut _,
+            ) {
                 0 => Ok(hls),
                 e => Err(e.into()),
             }
@@ -531,7 +834,10 @@ impl ColorCallbacks {
     pub fn hls_to_rgb(&self, hls: &HLSPixel) -> Result<Pixel8, Error> {
         unsafe {
             let mut rgb = std::mem::zeroed();
-            let f = (*self.utils).colorCB.HLStoRGB.ok_or(Error::BadCallbackParameter)?;
+            let f = (*self.utils)
+                .colorCB
+                .HLStoRGB
+                .ok_or(Error::BadCallbackParameter)?;
             match f(self.effect_ref, hls as *const _ as *mut _, &mut rgb) {
                 0 => Ok(rgb),
                 e => Err(e.into()),
@@ -544,8 +850,15 @@ impl ColorCallbacks {
     pub fn rgb_to_yiq(&self, rgb: &Pixel8) -> Result<YIQPixel, Error> {
         let mut yiq = YIQPixel::default();
         unsafe {
-            let f = (*self.utils).colorCB.RGBtoYIQ.ok_or(Error::BadCallbackParameter)?;
-            match f(self.effect_ref, rgb as *const _ as *mut _, &mut yiq as *mut _ as *mut _) {
+            let f = (*self.utils)
+                .colorCB
+                .RGBtoYIQ
+                .ok_or(Error::BadCallbackParameter)?;
+            match f(
+                self.effect_ref,
+                rgb as *const _ as *mut _,
+                &mut yiq as *mut _ as *mut _,
+            ) {
                 0 => Ok(yiq),
                 e => Err(e.into()),
             }
@@ -556,7 +869,10 @@ impl ColorCallbacks {
     pub fn yiq_to_rgb(&self, yiq: &YIQPixel) -> Result<Pixel8, Error> {
         unsafe {
             let mut rgb = std::mem::zeroed();
-            let f = (*self.utils).colorCB.YIQtoRGB.ok_or(Error::BadCallbackParameter)?;
+            let f = (*self.utils)
+                .colorCB
+                .YIQtoRGB
+                .ok_or(Error::BadCallbackParameter)?;
             match f(self.effect_ref, yiq as *const _ as *mut _, &mut rgb) {
                 0 => Ok(rgb),
                 e => Err(e.into()),
@@ -568,7 +884,10 @@ impl ColorCallbacks {
     pub fn luminance(&self, rgb: &Pixel8) -> Result<i32, Error> {
         let mut x = 0;
         unsafe {
-            let f = (*self.utils).colorCB.Luminance.ok_or(Error::BadCallbackParameter)?;
+            let f = (*self.utils)
+                .colorCB
+                .Luminance
+                .ok_or(Error::BadCallbackParameter)?;
             match f(self.effect_ref, rgb as *const _ as *mut _, &mut x) {
                 0 => Ok(x),
                 e => Err(e.into()),
@@ -580,7 +899,10 @@ impl ColorCallbacks {
     pub fn hue(&self, rgb: &Pixel8) -> Result<i32, Error> {
         let mut x = 0;
         unsafe {
-            let f = (*self.utils).colorCB.Hue.ok_or(Error::BadCallbackParameter)?;
+            let f = (*self.utils)
+                .colorCB
+                .Hue
+                .ok_or(Error::BadCallbackParameter)?;
             match f(self.effect_ref, rgb as *const _ as *mut _, &mut x) {
                 0 => Ok(x),
                 e => Err(e.into()),
@@ -592,7 +914,10 @@ impl ColorCallbacks {
     pub fn lightness(&self, rgb: &Pixel8) -> Result<i32, Error> {
         let mut x = 0;
         unsafe {
-            let f = (*self.utils).colorCB.Lightness.ok_or(Error::BadCallbackParameter)?;
+            let f = (*self.utils)
+                .colorCB
+                .Lightness
+                .ok_or(Error::BadCallbackParameter)?;
             match f(self.effect_ref, rgb as *const _ as *mut _, &mut x) {
                 0 => Ok(x),
                 e => Err(e.into()),
@@ -604,7 +929,10 @@ impl ColorCallbacks {
     pub fn saturation(&self, rgb: &Pixel8) -> Result<i32, Error> {
         let mut x = 0;
         unsafe {
-            let f = (*self.utils).colorCB.Saturation.ok_or(Error::BadCallbackParameter)?;
+            let f = (*self.utils)
+                .colorCB
+                .Saturation
+                .ok_or(Error::BadCallbackParameter)?;
             match f(self.effect_ref, rgb as *const _ as *mut _, &mut x) {
                 0 => Ok(x),
                 e => Err(e.into()),
@@ -689,9 +1017,8 @@ pub struct RawHandle {
     handle: ae_sys::PF_Handle,
 }
 impl RawHandle {
-    pub fn as_raw(&self) -> ae_sys::PF_Handle {
-        self.handle
-    }
+    pub fn as_raw(&self) -> ae_sys::PF_Handle { self.handle }
+
     /// Returns a guard exposing a pointer to the handle's data.
     ///
     /// `host_lock_handle` has been a no-op in After Effects since CS6, so we no
@@ -708,16 +1035,22 @@ impl RawHandle {
             _marker: std::marker::PhantomData,
         })
     }
+
     pub fn size(&self) -> Result<usize, Error> {
         unsafe {
-            let get_size = (*self.utils_ptr).host_get_handle_size.ok_or(Error::BadCallbackParameter)?;
+            let get_size = (*self.utils_ptr)
+                .host_get_handle_size
+                .ok_or(Error::BadCallbackParameter)?;
             let size = get_size(self.handle);
             Ok(size as _)
         }
     }
+
     pub fn resize(&mut self, new_size: usize) -> Result<(), Error> {
         unsafe {
-            let resize = (*self.utils_ptr).host_resize_handle.ok_or(Error::BadCallbackParameter)?;
+            let resize = (*self.utils_ptr)
+                .host_resize_handle
+                .ok_or(Error::BadCallbackParameter)?;
             match resize(new_size as _, &mut self.handle) {
                 0 => Ok(()),
                 e => Err(e.into()),
@@ -741,9 +1074,7 @@ pub struct RawHandleLock<'a> {
     _marker: std::marker::PhantomData<&'a RawHandle>,
 }
 impl<'a> RawHandleLock<'a> {
-    pub fn as_ptr(&self) -> *mut c_void {
-        self.ptr
-    }
+    pub fn as_ptr(&self) -> *mut c_void { self.ptr }
 }
 
 pub struct Sampling {
@@ -758,8 +1089,16 @@ impl Sampling {
     pub fn subpixel_sample(&self, x: f32, y: f32) -> Result<Pixel8, Error> {
         unsafe {
             let mut pixel = std::mem::zeroed();
-            let f = (*(*self.in_data_ptr).utils).subpixel_sample.ok_or(Error::BadCallbackParameter)?;
-            match f((*self.in_data_ptr).effect_ref, Fixed::from(x).as_fixed(), Fixed::from(y).as_fixed(), &self.params, &mut pixel) {
+            let f = (*(*self.in_data_ptr).utils)
+                .subpixel_sample
+                .ok_or(Error::BadCallbackParameter)?;
+            match f(
+                (*self.in_data_ptr).effect_ref,
+                Fixed::from(x).as_fixed(),
+                Fixed::from(y).as_fixed(),
+                &self.params,
+                &mut pixel,
+            ) {
                 0 => Ok(pixel),
                 e => Err(e.into()),
             }
@@ -771,12 +1110,19 @@ impl Sampling {
     pub fn subpixel_sample16(&self, x: f32, y: f32) -> Result<Pixel16, Error> {
         unsafe {
             let mut pixel = std::mem::zeroed();
-            let f = (*(*self.in_data_ptr).utils).subpixel_sample16.ok_or(Error::BadCallbackParameter)?;
-            match f((*self.in_data_ptr).effect_ref, Fixed::from(x).as_fixed(), Fixed::from(y).as_fixed(), &self.params, &mut pixel) {
+            let f = (*(*self.in_data_ptr).utils)
+                .subpixel_sample16
+                .ok_or(Error::BadCallbackParameter)?;
+            match f(
+                (*self.in_data_ptr).effect_ref,
+                Fixed::from(x).as_fixed(),
+                Fixed::from(y).as_fixed(),
+                &self.params,
+                &mut pixel,
+            ) {
                 0 => Ok(pixel),
                 e => Err(e.into()),
             }
-
         }
     }
 
@@ -786,8 +1132,16 @@ impl Sampling {
     pub fn area_sample(&self, x: f32, y: f32) -> Result<Pixel8, Error> {
         unsafe {
             let mut pixel = std::mem::zeroed();
-            let f = (*(*self.in_data_ptr).utils).area_sample.ok_or(Error::BadCallbackParameter)?;
-            match f((*self.in_data_ptr).effect_ref, Fixed::from(x).as_fixed(), Fixed::from(y).as_fixed(), &self.params, &mut pixel) {
+            let f = (*(*self.in_data_ptr).utils)
+                .area_sample
+                .ok_or(Error::BadCallbackParameter)?;
+            match f(
+                (*self.in_data_ptr).effect_ref,
+                Fixed::from(x).as_fixed(),
+                Fixed::from(y).as_fixed(),
+                &self.params,
+                &mut pixel,
+            ) {
                 0 => Ok(pixel),
                 e => Err(e.into()),
             }
@@ -800,8 +1154,16 @@ impl Sampling {
     pub fn area_sample16(&self, x: f32, y: f32) -> Result<Pixel16, Error> {
         unsafe {
             let mut pixel = std::mem::zeroed();
-            let f = (*(*self.in_data_ptr).utils).area_sample16.ok_or(Error::BadCallbackParameter)?;
-            match f((*self.in_data_ptr).effect_ref, Fixed::from(x).as_fixed(), Fixed::from(y).as_fixed(), &self.params, &mut pixel) {
+            let f = (*(*self.in_data_ptr).utils)
+                .area_sample16
+                .ok_or(Error::BadCallbackParameter)?;
+            match f(
+                (*self.in_data_ptr).effect_ref,
+                Fixed::from(x).as_fixed(),
+                Fixed::from(y).as_fixed(),
+                &self.params,
+                &mut pixel,
+            ) {
                 0 => Ok(pixel),
                 e => Err(e.into()),
             }
@@ -816,7 +1178,12 @@ impl Drop for Sampling {
                 return;
             }
             let end_sampling = (*in_data.utils).end_sampling.unwrap(); // We're safe to unwrap because begin_sampling was successful
-            let _ = end_sampling(in_data.effect_ref, self.quality, self.mode_flags, &mut self.params);
+            let _ = end_sampling(
+                in_data.effect_ref,
+                self.quality,
+                self.mode_flags,
+                &mut self.params,
+            );
         }
     }
 }

--- a/after-effects/src/pr.rs
+++ b/after-effects/src/pr.rs
@@ -1,5 +1,5 @@
-use crate::ae_sys;
 use crate::AsPtr;
+use crate::ae_sys;
 
 #[derive(Copy, Clone, Debug, Hash)]
 pub struct InDataHandle {
@@ -13,9 +13,7 @@ impl InDataHandle {
     }
 
     #[inline]
-    pub fn as_ptr(self) -> *const ae_sys::PR_InData {
-        self.in_data_ptr
-    }
+    pub fn as_ptr(self) -> *const ae_sys::PR_InData { self.in_data_ptr }
 
     #[inline]
     pub fn pica_basic_handle(self) -> crate::PicaBasicSuiteHandle {
@@ -23,9 +21,7 @@ impl InDataHandle {
     }
 
     #[inline]
-    pub fn plugin_id(self) -> i32 {
-        unsafe { (*self.in_data_ptr).aegp_plug_id }
-    }
+    pub fn plugin_id(self) -> i32 { unsafe { (*self.in_data_ptr).aegp_plug_id } }
 
     // Fixme: do we own this memory???!
     #[inline]

--- a/after-effects/src/pr_string.rs
+++ b/after-effects/src/pr_string.rs
@@ -12,9 +12,7 @@ define_suite!(
 impl PrStringSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// This will dispose of an SDKString. It is OK to pass in an empty string.
     /// * `sdk_string` - the string to dispose of
@@ -39,7 +37,12 @@ impl PrStringSuite {
     pub fn allocate_from_utf8(&self, string: &str) -> Result<PrSDKString, Error> {
         let mut out_sdk_string = unsafe { std::mem::zeroed() };
         let in_string = CString::new(string).map_err(|_| Error::InvalidParms)?;
-        call_suite_fn!(self, AllocateFromUTF8, in_string.as_bytes_with_nul().as_ptr(), &mut out_sdk_string)?;
+        call_suite_fn!(
+            self,
+            AllocateFromUTF8,
+            in_string.as_bytes_with_nul().as_ptr(),
+            &mut out_sdk_string
+        )?;
         Ok(out_sdk_string)
     }
 
@@ -52,17 +55,29 @@ impl PrStringSuite {
         let mut buffer = vec![0u8; 128];
         let mut buffer_size = buffer.len() as u32;
 
-        let mut result = call_suite_fn!(self, CopyToUTF8String, sdk_string, buffer.as_mut_ptr() as *mut _, &mut buffer_size);
+        let mut result = call_suite_fn!(
+            self,
+            CopyToUTF8String,
+            sdk_string,
+            buffer.as_mut_ptr() as *mut _,
+            &mut buffer_size
+        );
         if result == Err(Error::StringBufferTooSmall) {
             buffer = vec![0u8; buffer_size as usize + 1];
-            result = call_suite_fn!(self, CopyToUTF8String, sdk_string, buffer.as_mut_ptr() as *mut _, &mut buffer_size);
+            result = call_suite_fn!(
+                self,
+                CopyToUTF8String,
+                sdk_string,
+                buffer.as_mut_ptr() as *mut _,
+                &mut buffer_size
+            );
         }
         match result {
             Ok(()) => {
                 buffer.resize(buffer_size as usize - 1, 0u8);
                 String::from_utf8(buffer).map_err(|_| Error::InvalidParms)
             }
-            Err(e) => Err(Error::from(e))
+            Err(e) => Err(Error::from(e)),
         }
     }
 }
@@ -70,17 +85,21 @@ impl PrStringSuite {
 #[repr(transparent)]
 pub struct PrString(pub PrSDKString);
 impl From<&str> for PrString {
-    fn from(s: &str) -> Self {
-        Self(PrStringSuite::new().unwrap().allocate_from_utf8(s).unwrap())
-    }
+    fn from(s: &str) -> Self { Self(PrStringSuite::new().unwrap().allocate_from_utf8(s).unwrap()) }
 }
 impl From<PrString> for String {
     fn from(s: PrString) -> Self {
-        PrStringSuite::new().unwrap().copy_to_utf8_string(&s.0).unwrap()
+        PrStringSuite::new()
+            .unwrap()
+            .copy_to_utf8_string(&s.0)
+            .unwrap()
     }
 }
 impl Drop for PrString {
     fn drop(&mut self) {
-        PrStringSuite::new().unwrap().dispose_string(&self.0).unwrap();
+        PrStringSuite::new()
+            .unwrap()
+            .dispose_string(&self.0)
+            .unwrap();
     }
 }

--- a/examples/aegp/src/lib.rs
+++ b/examples/aegp/src/lib.rs
@@ -1,11 +1,11 @@
 use after_effects::{
+    AegpPlugin, Error, Layer, Time,
     aegp::{
-        suites::{Command, Item, Register, Render, RenderOptions, Utility},
         CommandHookStatus, HookPriority, ItemType, MenuOrder,
+        suites::{Command, Item, Register, Render, RenderOptions, Utility},
     },
     define_general_plugin,
     sys::{AEGP_PluginID, PF_InData},
-    AegpPlugin, Error, Layer, Time,
 };
 
 mod img_proc;

--- a/examples/checkout/src/lib.rs
+++ b/examples/checkout/src/lib.rs
@@ -3,31 +3,44 @@ use after_effects as ae;
 #[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
 enum Params {
     Frame,
-    Layer
+    Layer,
 }
-const CHECK_FRAME_MIN:  i32 = -100;
-const CHECK_FRAME_MAX:  i32 = 100;
+const CHECK_FRAME_MIN: i32 = -100;
+const CHECK_FRAME_MAX: i32 = 100;
 const CHECK_FRAME_DFLT: i32 = 0;
 
 #[derive(Default)]
-struct Plugin { }
+struct Plugin {}
 
 ae::define_effect!(Plugin, (), Params);
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, in_data: ae::InData, _: ae::OutData) -> Result<(), Error> {
-        params.add(Params::Frame, "Frame offset", ae::SliderDef::setup(|f| {
-            f.set_slider_min(CHECK_FRAME_MIN);
-            f.set_slider_max(CHECK_FRAME_MAX);
-            f.set_valid_min(CHECK_FRAME_MIN);
-            f.set_valid_max(CHECK_FRAME_MAX);
-            f.set_default(CHECK_FRAME_DFLT);
-            f.set_value(f.default());
-        }))?;
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        in_data: ae::InData,
+        _: ae::OutData,
+    ) -> Result<(), Error> {
+        params.add(
+            Params::Frame,
+            "Frame offset",
+            ae::SliderDef::setup(|f| {
+                f.set_slider_min(CHECK_FRAME_MIN);
+                f.set_slider_max(CHECK_FRAME_MAX);
+                f.set_valid_min(CHECK_FRAME_MIN);
+                f.set_valid_max(CHECK_FRAME_MAX);
+                f.set_default(CHECK_FRAME_DFLT);
+                f.set_value(f.default());
+            }),
+        )?;
 
-        params.add(Params::Layer, "Layer to checkout", ae::LayerDef::setup(|f| {
-            f.set_default_to_this_layer();
-        }))?;
+        params.add(
+            Params::Layer,
+            "Layer to checkout",
+            ae::LayerDef::setup(|f| {
+                f.set_default_to_this_layer();
+            }),
+        )?;
 
         if !in_data.is_premiere() {
             ae::pf::suites::EffectUI::new()?
@@ -37,22 +50,44 @@ impl AdobePluginGlobal for Plugin {
         Ok(())
     }
 
-    fn handle_command(&self, cmd: ae::Command, in_data: ae::InData, mut out_data: ae::OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        in_data: ae::InData,
+        mut out_data: ae::OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Checkout, v2.6,\rChecks out layers at other times.\rCopyright 1994-2023\r\rAdobe Inc.");
             }
             ae::Command::DoDialog => {
-                out_data.set_error_msg("This would be a fine place for\ra platform-specific options dialog.");
+                out_data.set_error_msg(
+                    "This would be a fine place for\ra platform-specific options dialog.",
+                );
             }
-            ae::Command::Render { in_layer, mut out_layer } => {
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
                 // Premiere Pro/Elements does not support this suite
                 if !in_data.is_premiere() {
                     let cs = ae::pf::suites::Channel::new()?;
                     let num_channels = cs.layer_channel_count(in_data.effect_ref(), 0)?;
                     if num_channels > 0 {
-                        if let Some((ref_, desc)) = cs.layer_channel_typed_ref_and_desc(in_data.effect_ref(), 0, ae::ChannelType::Depth)? {
-                            let chunk = cs.checkout_layer_channel(in_data.effect_ref(), &ref_, in_data.current_time(), in_data.time_step(), in_data.time_scale(), desc.data_type.into())?;
+                        if let Some((ref_, desc)) = cs.layer_channel_typed_ref_and_desc(
+                            in_data.effect_ref(),
+                            0,
+                            ae::ChannelType::Depth,
+                        )? {
+                            let chunk = cs.checkout_layer_channel(
+                                in_data.effect_ref(),
+                                &ref_,
+                                in_data.current_time(),
+                                in_data.time_step(),
+                                in_data.time_scale(),
+                                desc.data_type.into(),
+                            )?;
 
                             // do interesting 3d stuff here;
 
@@ -63,28 +98,33 @@ impl AdobePluginGlobal for Plugin {
 
                 // set the checked-out rect to be the top half of the layer
                 let mut halfsies = ae::Rect {
-                    top:    0,
-                    left:   0,
-                    right:  out_layer.width() as _,
-                    bottom: out_layer.height() as i32 / 2
+                    top: 0,
+                    left: 0,
+                    right: out_layer.width() as _,
+                    bottom: out_layer.height() as i32 / 2,
                 };
                 let slider = params.get(Params::Frame)?.as_slider()?.value();
 
-                let checkout = params.checkout_at(Params::Layer, Some(in_data.current_time() + slider * in_data.time_step()), None, None)?;
+                let checkout = params.checkout_at(
+                    Params::Layer,
+                    Some(in_data.current_time() + slider * in_data.time_step()),
+                    None,
+                    None,
+                )?;
                 let layer = checkout.as_layer()?;
 
                 if let Some(layer) = layer.value() {
                     out_layer.copy_from(&layer, None, Some(halfsies))?;
-                }  else  {
+                } else {
                     // no layer? Zero-alpha black.
                     out_layer.fill(None, None)?;
                 }
 
-                halfsies.top    = halfsies.bottom; // reset rect, copy.
+                halfsies.top = halfsies.bottom; // reset rect, copy.
                 halfsies.bottom = out_layer.height() as _;
                 out_layer.copy_from(&in_layer, None, Some(halfsies))?;
             }
-            _ => { }
+            _ => {}
         }
         Ok(())
     }

--- a/examples/color_grid/src/lib.rs
+++ b/examples/color_grid/src/lib.rs
@@ -2,12 +2,12 @@ use after_effects as ae;
 
 mod ui;
 
-const UI_GRID_WIDTH : u16 = 203;
+const UI_GRID_WIDTH: u16 = 203;
 const UI_GRID_HEIGHT: u16 = UI_GRID_WIDTH;
-const ARB_REFCON    : u64 = 0xDEADBEEFDEADBEEF;
+const ARB_REFCON: u64 = 0xDEADBEEFDEADBEEF;
 
-const BOXES_ACROSS  : usize = 3;
-const BOXES_DOWN    : usize = 3;
+const BOXES_ACROSS: usize = 3;
+const BOXES_DOWN: usize = 3;
 const BOXES_PER_GRID: usize = BOXES_ACROSS * BOXES_DOWN; // Ones based
 const CG_ARBDATA_ELEMENTS: usize = BOXES_PER_GRID;
 
@@ -22,7 +22,7 @@ struct FloatPixel {
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, PartialOrd)]
 struct ArbData {
     colors: [FloatPixel; CG_ARBDATA_ELEMENTS],
-    string: String
+    string: String,
 }
 impl ArbData {
     fn interp_pixel(intrp_amt: f32, lpix: &FloatPixel, rpix: &FloatPixel) -> FloatPixel {
@@ -66,17 +66,62 @@ impl Default for ArbData {
     fn default() -> Self {
         Self {
             colors: [
-                FloatPixel { alpha: 1.0, blue: 0.0,    green: 0.5,    red: 1.0 },
-                FloatPixel { alpha: 1.0, blue: 0.5,    green: 0.32,   red: 0.67 },
-                FloatPixel { alpha: 1.0, blue: 0.6,    green: 0.27,   red: 0.34 },
-                FloatPixel { alpha: 1.0, blue: 1.0,    green: 0.4039, red: 0.47 },
-                FloatPixel { alpha: 1.0, blue: 0.47,   green: 0.54,   red: 0.603 },
-                FloatPixel { alpha: 1.0, blue: 0.0603, green: 0.67,   red: 0.9 },
-                FloatPixel { alpha: 1.0, blue: 0.737,  green: 0.81,   red: 0.89 },
-                FloatPixel { alpha: 1.0, blue: 0.5,    green: 1.0,    red: 0.5 },
-                FloatPixel { alpha: 1.0, blue: 0.5,    green: 0.5,    red: 0.9 },
+                FloatPixel {
+                    alpha: 1.0,
+                    blue: 0.0,
+                    green: 0.5,
+                    red: 1.0,
+                },
+                FloatPixel {
+                    alpha: 1.0,
+                    blue: 0.5,
+                    green: 0.32,
+                    red: 0.67,
+                },
+                FloatPixel {
+                    alpha: 1.0,
+                    blue: 0.6,
+                    green: 0.27,
+                    red: 0.34,
+                },
+                FloatPixel {
+                    alpha: 1.0,
+                    blue: 1.0,
+                    green: 0.4039,
+                    red: 0.47,
+                },
+                FloatPixel {
+                    alpha: 1.0,
+                    blue: 0.47,
+                    green: 0.54,
+                    red: 0.603,
+                },
+                FloatPixel {
+                    alpha: 1.0,
+                    blue: 0.0603,
+                    green: 0.67,
+                    red: 0.9,
+                },
+                FloatPixel {
+                    alpha: 1.0,
+                    blue: 0.737,
+                    green: 0.81,
+                    red: 0.89,
+                },
+                FloatPixel {
+                    alpha: 1.0,
+                    blue: 0.5,
+                    green: 1.0,
+                    red: 0.5,
+                },
+                FloatPixel {
+                    alpha: 1.0,
+                    blue: 0.5,
+                    green: 0.5,
+                    red: 0.9,
+                },
             ],
-            string: "Hello world".to_owned()
+            string: "Hello world".to_owned(),
         }
     }
 }
@@ -96,36 +141,56 @@ enum Params {
 }
 
 #[derive(Default)]
-struct Plugin { }
+struct Plugin {}
 
 ae::define_effect!(Plugin, (), Params);
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, in_data: InData, _: OutData) -> Result<(), Error> {
-        params.add_customized(Params::GridUI, "Color Grid", ae::ArbitraryDef::setup(|f| {
-            f.set_default(ArbData::default()).unwrap();
-            f.set_refcon(ARB_REFCON as _);
-        }), |param| {
-            param.set_ui_flags(ae::ParamUIFlags::CONTROL | ae::ParamUIFlags::DO_NOT_ERASE_CONTROL);
-            param.set_ui_width(UI_GRID_WIDTH);
-            param.set_ui_height(UI_GRID_HEIGHT);
-            -1
-        })?;
-
-        in_data.interact().register_ui(
-            CustomUIInfo::new()
-                .events(ae::CustomEventFlags::EFFECT)
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        params.add_customized(
+            Params::GridUI,
+            "Color Grid",
+            ae::ArbitraryDef::setup(|f| {
+                f.set_default(ArbData::default()).unwrap();
+                f.set_refcon(ARB_REFCON as _);
+            }),
+            |param| {
+                param.set_ui_flags(
+                    ae::ParamUIFlags::CONTROL | ae::ParamUIFlags::DO_NOT_ERASE_CONTROL,
+                );
+                param.set_ui_width(UI_GRID_WIDTH);
+                param.set_ui_height(UI_GRID_HEIGHT);
+                -1
+            },
         )?;
+
+        in_data
+            .interact()
+            .register_ui(CustomUIInfo::new().events(ae::CustomEventFlags::EFFECT))?;
 
         Ok(())
     }
 
-    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("ColorGrid v3.3\rCopyright 2007-2023 Adobe Inc.\rArbitrary data and Custom UI sample.");
             }
-            ae::Command::Render { in_layer, mut out_layer } => {
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
                 let param = params.get(Params::GridUI)?;
                 let colors = param.as_arbitrary()?.value::<ArbData>()?;
 
@@ -146,50 +211,70 @@ impl AdobePluginGlobal for Plugin {
                         box_down += 1;
                         box_across = 0;
                     }
-                    let current_rect = ui::colorgrid_get_box_in_grid(&origin,
-                        (in_data.width()  as f32 * f32::from(in_data.downsample_x())).round() as _,
+                    let current_rect = ui::colorgrid_get_box_in_grid(
+                        &origin,
+                        (in_data.width() as f32 * f32::from(in_data.downsample_x())).round() as _,
                         (in_data.height() as f32 * f32::from(in_data.downsample_y())).round() as _,
                         box_across,
-                        box_down
+                        box_down,
                     );
 
                     let cur_color = &colors.colors[current_color];
-                    let color8_r  = (cur_color.red   * ae::MAX_CHANNEL8 as f32) as u16;
-                    let color8_g  = (cur_color.green * ae::MAX_CHANNEL8 as f32) as u16;
-                    let color8_b  = (cur_color.blue  * ae::MAX_CHANNEL8 as f32) as u16;
+                    let color8_r = (cur_color.red * ae::MAX_CHANNEL8 as f32) as u16;
+                    let color8_g = (cur_color.green * ae::MAX_CHANNEL8 as f32) as u16;
+                    let color8_b = (cur_color.blue * ae::MAX_CHANNEL8 as f32) as u16;
 
                     progress_base += 1;
 
-                    in_layer.iterate_with(&mut out_layer, progress_base, progress_final as _, Some(current_rect), |_x: i32, _y: i32, pixel: ae::GenericPixel, out_pixel: ae::GenericPixelMut| -> Result<(), Error> {
-                        match (pixel, out_pixel) {
-                            (ae::GenericPixel::Pixel8(pixel), ae::GenericPixelMut::Pixel8(out_pixel)) => {
-                                out_pixel.alpha = pixel.alpha as _;
-                                out_pixel.red   = ((pixel.red   as u16 + color8_r) / 2) as u8;
-                                out_pixel.green = ((pixel.green as u16 + color8_g) / 2) as u8;
-                                out_pixel.blue  = ((pixel.blue  as u16 + color8_b) / 2) as u8;
+                    in_layer.iterate_with(
+                        &mut out_layer,
+                        progress_base,
+                        progress_final as _,
+                        Some(current_rect),
+                        |_x: i32,
+                         _y: i32,
+                         pixel: ae::GenericPixel,
+                         out_pixel: ae::GenericPixelMut|
+                         -> Result<(), Error> {
+                            match (pixel, out_pixel) {
+                                (
+                                    ae::GenericPixel::Pixel8(pixel),
+                                    ae::GenericPixelMut::Pixel8(out_pixel),
+                                ) => {
+                                    out_pixel.alpha = pixel.alpha as _;
+                                    out_pixel.red = ((pixel.red as u16 + color8_r) / 2) as u8;
+                                    out_pixel.green = ((pixel.green as u16 + color8_g) / 2) as u8;
+                                    out_pixel.blue = ((pixel.blue as u16 + color8_b) / 2) as u8;
+                                }
+                                _ => return Err(Error::BadCallbackParameter),
                             }
-                            _ => return Err(Error::BadCallbackParameter)
-                        }
-                        Ok(())
-                    })?;
+                            Ok(())
+                        },
+                    )?;
 
                     current_color += 1;
                     box_across += 1;
                 }
-
             }
             ae::Command::SmartPreRender { mut extra } => {
                 let req = extra.output_request();
 
-                if let Ok(in_result) = extra.callbacks().checkout_layer(0, 0, &req, in_data.current_time(), in_data.time_step(), in_data.time_scale()) {
+                if let Ok(in_result) = extra.callbacks().checkout_layer(
+                    0,
+                    0,
+                    &req,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                ) {
                     let _ = extra.union_result_rect(in_result.result_rect.into());
                     let _ = extra.union_max_result_rect(in_result.max_result_rect.into());
                 }
             }
             ae::Command::SmartRender { extra } => {
                 let mut origin = ae::Point::empty();
-                let mut box_across    = 0;
-                let mut box_down      = 0;
+                let mut box_across = 0;
+                let mut box_down = 0;
                 let mut current_color = 0;
 
                 let cb = extra.callbacks();
@@ -206,52 +291,75 @@ impl AdobePluginGlobal for Plugin {
                         box_across = 0;
                     }
 
-                    let current_rect = ui::colorgrid_get_box_in_grid(&origin,
-                        (in_data.width()  as f32 * f32::from(in_data.downsample_x())).round() as _,
+                    let current_rect = ui::colorgrid_get_box_in_grid(
+                        &origin,
+                        (in_data.width() as f32 * f32::from(in_data.downsample_x())).round() as _,
                         (in_data.height() as f32 * f32::from(in_data.downsample_y())).round() as _,
                         box_across,
-                        box_down
+                        box_down,
                     );
 
                     let color32 = &colors.colors[current_color];
 
-                    let color8_r  = (color32.red   * ae::MAX_CHANNEL8  as f32) as u16;
-                    let color8_g  = (color32.green * ae::MAX_CHANNEL8  as f32) as u16;
-                    let color8_b  = (color32.blue  * ae::MAX_CHANNEL8  as f32) as u16;
+                    let color8_r = (color32.red * ae::MAX_CHANNEL8 as f32) as u16;
+                    let color8_g = (color32.green * ae::MAX_CHANNEL8 as f32) as u16;
+                    let color8_b = (color32.blue * ae::MAX_CHANNEL8 as f32) as u16;
 
-                    let color16_r = (color32.red   * ae::MAX_CHANNEL16 as f32) as u32;
+                    let color16_r = (color32.red * ae::MAX_CHANNEL16 as f32) as u32;
                     let color16_g = (color32.green * ae::MAX_CHANNEL16 as f32) as u32;
-                    let color16_b = (color32.blue  * ae::MAX_CHANNEL16 as f32) as u32;
+                    let color16_b = (color32.blue * ae::MAX_CHANNEL16 as f32) as u32;
 
                     if let Ok(Some(mut output_world)) = cb.checkout_output() {
                         let progress_final = output_world.height() as _;
 
                         origin = in_data.output_origin();
 
-                        input_world.iterate_with(&mut output_world, 0, progress_final, Some(current_rect), |_x: i32, _y: i32, pixel: ae::GenericPixel, out_pixel: ae::GenericPixelMut| -> Result<(), Error> {
-                            match (pixel, out_pixel) {
-                                (ae::GenericPixel::Pixel8(pixel), ae::GenericPixelMut::Pixel8(out_pixel)) => {
-                                    out_pixel.alpha = pixel.alpha as _;
-                                    out_pixel.red   = ((pixel.red   as u16 + color8_r) / 2) as u8;
-                                    out_pixel.green = ((pixel.green as u16 + color8_g) / 2) as u8;
-                                    out_pixel.blue  = ((pixel.blue  as u16 + color8_b) / 2) as u8;
+                        input_world.iterate_with(
+                            &mut output_world,
+                            0,
+                            progress_final,
+                            Some(current_rect),
+                            |_x: i32,
+                             _y: i32,
+                             pixel: ae::GenericPixel,
+                             out_pixel: ae::GenericPixelMut|
+                             -> Result<(), Error> {
+                                match (pixel, out_pixel) {
+                                    (
+                                        ae::GenericPixel::Pixel8(pixel),
+                                        ae::GenericPixelMut::Pixel8(out_pixel),
+                                    ) => {
+                                        out_pixel.alpha = pixel.alpha as _;
+                                        out_pixel.red = ((pixel.red as u16 + color8_r) / 2) as u8;
+                                        out_pixel.green =
+                                            ((pixel.green as u16 + color8_g) / 2) as u8;
+                                        out_pixel.blue = ((pixel.blue as u16 + color8_b) / 2) as u8;
+                                    }
+                                    (
+                                        ae::GenericPixel::Pixel16(pixel),
+                                        ae::GenericPixelMut::Pixel16(out_pixel),
+                                    ) => {
+                                        out_pixel.alpha = pixel.alpha as _;
+                                        out_pixel.red = ((pixel.red as u32 + color16_r) / 2) as u16;
+                                        out_pixel.green =
+                                            ((pixel.green as u32 + color16_g) / 2) as u16;
+                                        out_pixel.blue =
+                                            ((pixel.blue as u32 + color16_b) / 2) as u16;
+                                    }
+                                    (
+                                        ae::GenericPixel::PixelF32(pixel),
+                                        ae::GenericPixelMut::PixelF32(out_pixel),
+                                    ) => {
+                                        out_pixel.alpha = pixel.alpha as _;
+                                        out_pixel.red = (pixel.red + color32.red) / 2.0;
+                                        out_pixel.green = (pixel.green + color32.green) / 2.0;
+                                        out_pixel.blue = (pixel.blue + color32.blue) / 2.0;
+                                    }
+                                    _ => return Err(Error::BadCallbackParameter),
                                 }
-                                (ae::GenericPixel::Pixel16(pixel), ae::GenericPixelMut::Pixel16(out_pixel)) => {
-                                    out_pixel.alpha = pixel.alpha as _;
-                                    out_pixel.red   = ((pixel.red   as u32 + color16_r) / 2) as u16;
-                                    out_pixel.green = ((pixel.green as u32 + color16_g) / 2) as u16;
-                                    out_pixel.blue  = ((pixel.blue  as u32 + color16_b) / 2) as u16;
-                                }
-                                (ae::GenericPixel::PixelF32(pixel), ae::GenericPixelMut::PixelF32(out_pixel)) => {
-                                    out_pixel.alpha = pixel.alpha as _;
-                                    out_pixel.red   = (pixel.red   + color32.red)   / 2.0;
-                                    out_pixel.green = (pixel.green + color32.green) / 2.0;
-                                    out_pixel.blue  = (pixel.blue  + color32.blue)  / 2.0;
-                                }
-                                _ => return Err(Error::BadCallbackParameter)
-                            }
-                            Ok(())
-                        })?;
+                                Ok(())
+                            },
+                        )?;
                     }
                     current_color += 1;
                     box_across += 1;
@@ -262,15 +370,19 @@ impl AdobePluginGlobal for Plugin {
             ae::Command::ArbitraryCallback { mut extra } => {
                 extra.dispatch::<ArbData, Params>(Params::GridUI)?;
             }
-            ae::Command::Event { mut extra } => {
-                match extra.event() {
-                    ae::Event::Click(_) => { ui::click(&in_data, params, &mut extra)?; }
-                    ae::Event::Draw(_)  => { ui::draw(&in_data, params, &mut extra)?; }
-                    ae::Event::AdjustCursor(_) => { ui::change_cursor(&in_data, &mut extra)?; }
-                    _ => {}
+            ae::Command::Event { mut extra } => match extra.event() {
+                ae::Event::Click(_) => {
+                    ui::click(&in_data, params, &mut extra)?;
                 }
-            }
-            _ => { }
+                ae::Event::Draw(_) => {
+                    ui::draw(&in_data, params, &mut extra)?;
+                }
+                ae::Event::AdjustCursor(_) => {
+                    ui::change_cursor(&in_data, &mut extra)?;
+                }
+                _ => {}
+            },
+            _ => {}
         }
         Ok(())
     }

--- a/examples/color_grid/src/ui.rs
+++ b/examples/color_grid/src/ui.rs
@@ -1,28 +1,34 @@
 use super::*;
 
-pub fn colorgrid_get_box_in_grid(origin: &ae::Point, grid_width: i32, grid_height: i32, box_across: usize, box_down: usize) -> ae::Rect {
-    let box_width  = grid_width  / BOXES_ACROSS as i32;
-    let box_height = grid_height / BOXES_DOWN   as i32;
+pub fn colorgrid_get_box_in_grid(
+    origin: &ae::Point,
+    grid_width: i32,
+    grid_height: i32,
+    box_across: usize,
+    box_down: usize,
+) -> ae::Rect {
+    let box_width = grid_width / BOXES_ACROSS as i32;
+    let box_height = grid_height / BOXES_DOWN as i32;
 
     // Given the grid h+w and the box coord (0,0 through BOXES_ACROSS,BOXES_DOWN) return the rect of the box
 
-    let left = (box_width  * box_across as i32) + origin.h;
-    let top  = (box_height * box_down   as i32) + origin.v;
+    let left = (box_width * box_across as i32) + origin.h;
+    let top = (box_height * box_down as i32) + origin.v;
 
     ae::Rect {
         left,
         top,
-        right:  left + box_width,
-        bottom: top  + box_height,
+        right: left + box_width,
+        bottom: top + box_height,
     }
 }
 
 pub fn pf_to_drawbot_rect(in_rect: &ae::Rect) -> ae::drawbot::RectF32 {
     ae::drawbot::RectF32 {
-        left:   in_rect.left as f32 + 0.5,
-        top:    in_rect.top  as f32 + 0.5,
-        width:  (in_rect.right - in_rect.left) as f32,
-        height: (in_rect.bottom - in_rect.top) as f32
+        left: in_rect.left as f32 + 0.5,
+        top: in_rect.top as f32 + 0.5,
+        width: (in_rect.right - in_rect.left) as f32,
+        height: (in_rect.bottom - in_rect.top) as f32,
     }
 }
 
@@ -31,17 +37,16 @@ pub fn qd_to_drawbot_color(c: &ae::sys::PF_App_Color) -> ae::drawbot::ColorRgba 
     let inv_sixty_five_k = 1.0 / MAX_SHORT_COLOR;
 
     ae::drawbot::ColorRgba {
-        red:   c.red   as f32 * inv_sixty_five_k,
+        red: c.red as f32 * inv_sixty_five_k,
         green: c.green as f32 * inv_sixty_five_k,
-        blue:  c.blue  as f32 * inv_sixty_five_k,
+        blue: c.blue as f32 * inv_sixty_five_k,
         alpha: 1.0,
     }
 }
 
 pub fn acquire_background_color() -> Result<ae::drawbot::ColorRgba, ae::Error> {
     Ok(qd_to_drawbot_color(
-        &ae::pf::suites::App::new()?
-            .bg_color()?
+        &ae::pf::suites::App::new()?.bg_color()?,
     ))
 }
 
@@ -52,7 +57,7 @@ pub fn colorgrid_point_in_rect(point: &ae::Point, rect: &ae::Rect) -> bool {
 // Calculate the space taken up by the grid
 // Allow the width to scale horizontally, but not too much
 fn get_grid_rect(origin: &ae::Point, current_frame: &ae::Rect) -> ae::Rect {
-    let mut grid_width  = current_frame.width();
+    let mut grid_width = current_frame.width();
     let grid_height = current_frame.height();
     if (grid_width as f32) < UI_GRID_WIDTH as f32 / 1.5 {
         grid_width = (UI_GRID_WIDTH as f32 / 1.5) as _;
@@ -60,14 +65,19 @@ fn get_grid_rect(origin: &ae::Point, current_frame: &ae::Rect) -> ae::Rect {
         grid_width = (UI_GRID_WIDTH as f32 * 1.5) as _;
     }
     ae::Rect {
-        left:   origin.h,
-        top:    origin.v,
-        right:  origin.h + grid_width as i32,
+        left: origin.h,
+        top: origin.v,
+        right: origin.h + grid_width as i32,
         bottom: origin.v + grid_height as i32,
     }
 }
 
-pub fn colorgrid_get_new_color(in_data: &ae::InData, hpos: usize, vpos: usize, arb_data: &mut ArbData) -> Result<(), Error> {
+pub fn colorgrid_get_new_color(
+    in_data: &ae::InData,
+    hpos: usize,
+    vpos: usize,
+    arb_data: &mut ArbData,
+) -> Result<(), Error> {
     let pos = vpos * BOXES_ACROSS + hpos;
 
     if hpos < BOXES_ACROSS && vpos < BOXES_DOWN {
@@ -75,21 +85,34 @@ pub fn colorgrid_get_new_color(in_data: &ae::InData, hpos: usize, vpos: usize, a
 
         // Premiere Pro/Elements don't support the color picker dialog
         if !in_data.is_premiere() {
-            let color = pf::PixelF32 { alpha: box_color.alpha, red: box_color.red, green: box_color.green, blue: box_color.blue };
-            let new_color = ae::pf::suites::App::new()?.color_picker_dialog(Some("ColorGrid!"), &color, true)?;
-            box_color.red   = new_color.red;
+            let color = pf::PixelF32 {
+                alpha: box_color.alpha,
+                red: box_color.red,
+                green: box_color.green,
+                blue: box_color.blue,
+            };
+            let new_color = ae::pf::suites::App::new()?.color_picker_dialog(
+                Some("ColorGrid!"),
+                &color,
+                true,
+            )?;
+            box_color.red = new_color.red;
             box_color.green = new_color.green;
-            box_color.blue  = new_color.blue;
+            box_color.blue = new_color.blue;
         } else {
-            box_color.red   = fastrand::f32();
+            box_color.red = fastrand::f32();
             box_color.green = fastrand::f32();
-            box_color.blue  = fastrand::f32();
+            box_color.blue = fastrand::f32();
         }
     }
     Ok(())
 }
 
-pub fn click(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &mut ae::EventExtra) -> Result<(), ae::Error> {
+pub fn click(
+    in_data: &ae::InData,
+    params: &mut ae::Parameters<Params>,
+    event: &mut ae::EventExtra,
+) -> Result<(), ae::Error> {
     let mouse_pt = event.screen_point();
     let current_frame = event.current_frame();
     let origin = current_frame.origin();
@@ -105,7 +128,13 @@ pub fn click(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &
             let mut box_down = 0;
 
             for _ in 0..CG_ARBDATA_ELEMENTS {
-                let box_rect = colorgrid_get_box_in_grid(&origin, grid_rect.width(), grid_rect.height(), box_across, box_down);
+                let box_rect = colorgrid_get_box_in_grid(
+                    &origin,
+                    grid_rect.width(),
+                    grid_rect.height(),
+                    box_across,
+                    box_down,
+                );
 
                 if colorgrid_point_in_rect(&mouse_pt, &box_rect) {
                     break;
@@ -125,7 +154,9 @@ pub fn click(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &
             let inval = event.current_frame();
             ae::pf::suites::App::new()?.invalidate_rect(event.context_handle(), Some(inval))?;
 
-            event.set_event_out_flags(ae::EventOutFlags::HANDLED_EVENT | ae::EventOutFlags::UPDATE_NOW);
+            event.set_event_out_flags(
+                ae::EventOutFlags::HANDLED_EVENT | ae::EventOutFlags::UPDATE_NOW,
+            );
         }
     }
 
@@ -159,13 +190,17 @@ pub fn change_cursor(in_data: &ae::InData, event: &mut ae::EventExtra) -> Result
     Ok(())
 }
 
-pub fn draw(_in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &mut ae::EventExtra) -> Result<(), ae::Error> {
+pub fn draw(
+    _in_data: &ae::InData,
+    params: &mut ae::Parameters<Params>,
+    event: &mut ae::EventExtra,
+) -> Result<(), ae::Error> {
     let current_frame = event.current_frame();
     let origin = current_frame.origin();
     let grid_rect = get_grid_rect(&origin, &current_frame);
 
-    let mut box_across  = 0;
-    let mut box_down    = 0;
+    let mut box_across = 0;
+    let mut box_down = 0;
 
     let drawbot = event.context_handle().drawing_reference()?;
     let supplier = drawbot.supplier()?;
@@ -176,10 +211,10 @@ pub fn draw(_in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &
     if event.effect_area() == ae::EffectArea::Control {
         // Use to fill background with AE's BG color
         let onscreen_rect = ae::drawbot::RectF32 {
-            left:   current_frame.left   as f32,
-            top:    current_frame.top    as f32,
-            width:  current_frame.right  as f32 - current_frame.left as f32,
-            height: current_frame.bottom as f32 - current_frame.top  as f32 + 1.0,
+            left: current_frame.left as f32,
+            top: current_frame.top as f32,
+            width: current_frame.right as f32 - current_frame.left as f32,
+            height: current_frame.bottom as f32 - current_frame.top as f32 + 1.0,
         };
         surface.paint_rect(&background_color, &onscreen_rect)?;
     }
@@ -189,17 +224,24 @@ pub fn draw(_in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &
     let arb_data = arb_param.as_arbitrary()?.value::<ArbData>()?;
 
     if true {
-        let mut pixel_colr: [ae::drawbot::ColorRgba; CG_ARBDATA_ELEMENTS] = unsafe { std::mem::zeroed() };
+        let mut pixel_colr: [ae::drawbot::ColorRgba; CG_ARBDATA_ELEMENTS] =
+            unsafe { std::mem::zeroed() };
         for i in 0..CG_ARBDATA_ELEMENTS {
-            pixel_colr[i].red   = arb_data.colors[i].red;
+            pixel_colr[i].red = arb_data.colors[i].red;
             pixel_colr[i].green = arb_data.colors[i].green;
-            pixel_colr[i].blue  = arb_data.colors[i].blue;
+            pixel_colr[i].blue = arb_data.colors[i].blue;
             pixel_colr[i].alpha = 1.0;
         }
 
         for i in 0..BOXES_PER_GRID {
             // Fill in our grid
-            let box_rect = colorgrid_get_box_in_grid(&origin, grid_rect.width(), grid_rect.height(), box_across, box_down);
+            let box_rect = colorgrid_get_box_in_grid(
+                &origin,
+                grid_rect.width(),
+                grid_rect.height(),
+                box_across,
+                box_down,
+            );
 
             let mut path = supplier.new_path()?;
             path.add_rect(&pf_to_drawbot_rect(&box_rect))?;
@@ -216,13 +258,24 @@ pub fn draw(_in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &
         }
     }
 
-    let black_color = ae::drawbot::ColorRgba { red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0 };
+    let black_color = ae::drawbot::ColorRgba {
+        red: 0.0,
+        green: 0.0,
+        blue: 0.0,
+        alpha: 1.0,
+    };
     let pen = supplier.new_pen(&black_color, 1.0)?;
 
     // Draw the grid - outline
     for box_down in 0..BOXES_DOWN {
         for box_across in 0..BOXES_ACROSS {
-            let box_rect = colorgrid_get_box_in_grid(&origin, grid_rect.width(), grid_rect.height(), box_across, box_down);
+            let box_rect = colorgrid_get_box_in_grid(
+                &origin,
+                grid_rect.width(),
+                grid_rect.height(),
+                box_across,
+                box_down,
+            );
 
             let mut path = supplier.new_path()?;
             path.add_rect(&pf_to_drawbot_rect(&box_rect))?;

--- a/examples/convolutrix/src/lib.rs
+++ b/examples/convolutrix/src/lib.rs
@@ -1,10 +1,10 @@
 use after_effects as ae;
 
-const CONVO_AMOUNT_MIN:  f32 = 0.0;
-const CONVO_AMOUNT_MAX:  f32 = 100.0;
+const CONVO_AMOUNT_MIN: f32 = 0.0;
+const CONVO_AMOUNT_MAX: f32 = 100.0;
 const CONVO_AMOUNT_DFLT: f64 = 50.0;
-const CURVE_TOLERANCE:   f32 = 0.05;
-const KERNEL_SIZE:       i32 = 3;
+const CURVE_TOLERANCE: f32 = 0.05;
+const KERNEL_SIZE: i32 = 3;
 
 #[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
 enum Params {
@@ -12,30 +12,25 @@ enum Params {
     BlendGroupStart,
     BlendColorAmount,
     BlendColor,
-    BlendGroupEnd
+    BlendGroupEnd,
 }
 
 #[derive(Default)]
-struct Plugin { }
+struct Plugin {}
 
 ae::define_effect!(Plugin, (), Params);
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, _in_data: InData, _: OutData) -> Result<(), Error> {
-        params.add(Params::Amount, "Convolve", ae::FloatSliderDef::setup(|f| {
-            f.set_valid_min(CONVO_AMOUNT_MIN);
-            f.set_valid_max(CONVO_AMOUNT_MAX);
-            f.set_slider_min(CONVO_AMOUNT_MIN);
-            f.set_slider_max(CONVO_AMOUNT_MAX);
-            f.set_default(CONVO_AMOUNT_DFLT);
-            f.set_value(f.default());
-            f.set_curve_tolerance(CURVE_TOLERANCE);
-            f.set_precision(2);
-            f.set_display_flags(ae::ValueDisplayFlag::PERCENT);
-        }))?;
-
-        params.add_group(Params::BlendGroupStart, Params::BlendGroupEnd, "Blend Controls", false, |params| {
-            params.add(Params::BlendColorAmount, "Blend percentage", ae::FloatSliderDef::setup(|f| {
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        params.add(
+            Params::Amount,
+            "Convolve",
+            ae::FloatSliderDef::setup(|f| {
                 f.set_valid_min(CONVO_AMOUNT_MIN);
                 f.set_valid_max(CONVO_AMOUNT_MAX);
                 f.set_slider_min(CONVO_AMOUNT_MIN);
@@ -45,37 +40,79 @@ impl AdobePluginGlobal for Plugin {
                 f.set_curve_tolerance(CURVE_TOLERANCE);
                 f.set_precision(2);
                 f.set_display_flags(ae::ValueDisplayFlag::PERCENT);
-            }))?;
+            }),
+        )?;
 
-            params.add(Params::BlendColor, "Blend color", ae::ColorDef::setup(|f| {
-                f.set_default(ae::Pixel8 {
-                    red:   255,
-                    green: 0,
-                    blue:  255,
-                    alpha: 255
-                });
-                f.set_value(f.default());
-            }))?;
-            Ok(())
-        })?;
+        params.add_group(
+            Params::BlendGroupStart,
+            Params::BlendGroupEnd,
+            "Blend Controls",
+            false,
+            |params| {
+                params.add(
+                    Params::BlendColorAmount,
+                    "Blend percentage",
+                    ae::FloatSliderDef::setup(|f| {
+                        f.set_valid_min(CONVO_AMOUNT_MIN);
+                        f.set_valid_max(CONVO_AMOUNT_MAX);
+                        f.set_slider_min(CONVO_AMOUNT_MIN);
+                        f.set_slider_max(CONVO_AMOUNT_MAX);
+                        f.set_default(CONVO_AMOUNT_DFLT);
+                        f.set_value(f.default());
+                        f.set_curve_tolerance(CURVE_TOLERANCE);
+                        f.set_precision(2);
+                        f.set_display_flags(ae::ValueDisplayFlag::PERCENT);
+                    }),
+                )?;
+
+                params.add(
+                    Params::BlendColor,
+                    "Blend color",
+                    ae::ColorDef::setup(|f| {
+                        f.set_default(ae::Pixel8 {
+                            red: 255,
+                            green: 0,
+                            blue: 255,
+                            alpha: 255,
+                        });
+                        f.set_value(f.default());
+                    }),
+                )?;
+                Ok(())
+            },
+        )?;
 
         Ok(())
     }
 
-    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Convolutrix, v3.2,\rDemonstrate our image processing callbacks.\rCopyright 2007-2023 Adobe Inc.");
             }
-            ae::Command::Render { in_layer, mut out_layer } => {
-                let sharpen   = params.get(Params::Amount)?.as_float_slider()?.value() as f32 / 16.0;
-                let color_amt = params.get(Params::BlendColorAmount)?.as_float_slider()?.value() as f32 / 100.0;
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
+                let sharpen = params.get(Params::Amount)?.as_float_slider()?.value() as f32 / 16.0;
+                let color_amt = params
+                    .get(Params::BlendColorAmount)?
+                    .as_float_slider()?
+                    .value() as f32
+                    / 100.0;
 
-                if sharpen > 0.0 { // we're doing some convolving...
+                if sharpen > 0.0 {
+                    // we're doing some convolving...
                     let mut kernel_sum = 256.0 * 9.0;
                     let mut conv_kernel = [0i32; 9];
                     conv_kernel[4] = (sharpen * kernel_sum).trunc() as _;
-                    kernel_sum    = (256.0 * 9.0 - conv_kernel[4] as f32) / 4.0;
+                    kernel_sum = (256.0 * 9.0 - conv_kernel[4] as f32) / 4.0;
                     let sum_long = kernel_sum.trunc() as _;
                     conv_kernel[1] = sum_long;
                     conv_kernel[3] = sum_long;
@@ -95,7 +132,7 @@ impl AdobePluginGlobal for Plugin {
                             kernel_ptr,
                             kernel_ptr,
                             kernel_ptr,
-                            &mut out_layer
+                            &mut out_layer,
                         )?;
                     } else {
                         in_data.utils().convolve(
@@ -107,23 +144,43 @@ impl AdobePluginGlobal for Plugin {
                             kernel_ptr,
                             kernel_ptr,
                             kernel_ptr,
-                            &mut out_layer
+                            &mut out_layer,
                         )?;
                     }
 
-                    if color_amt > 0.0 { // we're blending in a color.
+                    if color_amt > 0.0 {
+                        // we're blending in a color.
                         let color = params.get(Params::BlendColor)?.as_color()?.value();
                         // Allocate a world full of the color to blend.
-                        let mut temp = in_data.utils().new_world(out_layer.width() as _, out_layer.height() as _, ae::NewWorldFlags::NONE)?;
+                        let mut temp = in_data.utils().new_world(
+                            out_layer.width() as _,
+                            out_layer.height() as _,
+                            ae::NewWorldFlags::NONE,
+                        )?;
                         in_data.utils().fill(&mut temp, Some(color), None)?;
 
-                        in_data.utils().blend(out_layer.as_ptr(), temp, color_amt, out_layer)?;
+                        in_data
+                            .utils()
+                            .blend(out_layer.as_ptr(), temp, color_amt, out_layer)?;
                     }
-                } else { // No matter what, we populate the output buffer.
+                } else {
+                    // No matter what, we populate the output buffer.
                     if in_data.quality() == ae::Quality::Hi && !in_data.is_premiere() {
-                        ae::pf::suites::WorldTransform::new()?.copy_hq(in_data.effect_ref(), in_layer, out_layer, None, None)?;
+                        ae::pf::suites::WorldTransform::new()?.copy_hq(
+                            in_data.effect_ref(),
+                            in_layer,
+                            out_layer,
+                            None,
+                            None,
+                        )?;
                     } else if !in_data.is_premiere() {
-                        ae::pf::suites::WorldTransform::new()?.copy(in_data.effect_ref(), in_layer, out_layer, None, None)?;
+                        ae::pf::suites::WorldTransform::new()?.copy(
+                            in_data.effect_ref(),
+                            in_layer,
+                            out_layer,
+                            None,
+                            None,
+                        )?;
                     } else {
                         out_layer.copy_from(&in_layer, None, None)?;
                     }
@@ -140,7 +197,7 @@ impl AdobePluginGlobal for Plugin {
                             extra.set_dependencies_str("Missing Dependencies requested.")?;
                         }
                     }
-                    _ => extra.set_dependencies_str("None")?
+                    _ => extra.set_dependencies_str("None")?,
                 }
             }
             _ => {}

--- a/examples/custom_comp_ui/src/lib.rs
+++ b/examples/custom_comp_ui/src/lib.rs
@@ -6,95 +6,122 @@ const OVAL_PTS: usize = 64;
 const CCU_SLOP: i32 = 16;
 
 const CCU_RADIUS_BIG_MAX: f32 = 4000.0;
-const CCU_RADIUS_MAX    : f32 = 250.0;
-const CCU_RADIUS_MIN    : f32 = 0.0;
-const CCU_RADIUS_DFLT   : f64 = 50.0;
-const CCU_PTX_DFLT      : f32 = 50.0;
-const CCU_PTY_DFLT      : f32 = 50.0;
-const SLIDER_PRECISION  : i16 = 1;
+const CCU_RADIUS_MAX: f32 = 250.0;
+const CCU_RADIUS_MIN: f32 = 0.0;
+const CCU_RADIUS_DFLT: f64 = 50.0;
+const CCU_PTX_DFLT: f32 = 50.0;
+const CCU_PTY_DFLT: f32 = 50.0;
+const SLIDER_PRECISION: i16 = 1;
 
 #[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
 enum Params {
     XRadius,
     YRadius,
-    Point
+    Point,
 }
 
 enum Ccu {
     None,
-    Handles
+    Handles,
 }
 
 #[derive(Default)]
-struct Plugin { }
+struct Plugin {}
 
 ae::define_effect!(Plugin, (), Params);
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, in_data: InData, _: OutData) -> Result<(), Error> {
-        params.add(Params::XRadius, "Horizontal Radius", ae::FloatSliderDef::setup(|f| {
-            f.set_valid_min(CCU_RADIUS_MIN);
-            f.set_valid_max(CCU_RADIUS_BIG_MAX);
-            f.set_slider_min(CCU_RADIUS_MIN);
-            f.set_slider_max(CCU_RADIUS_MAX);
-            f.set_default(CCU_RADIUS_DFLT);
-            f.set_precision(SLIDER_PRECISION);
-        }))?;
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        params.add(
+            Params::XRadius,
+            "Horizontal Radius",
+            ae::FloatSliderDef::setup(|f| {
+                f.set_valid_min(CCU_RADIUS_MIN);
+                f.set_valid_max(CCU_RADIUS_BIG_MAX);
+                f.set_slider_min(CCU_RADIUS_MIN);
+                f.set_slider_max(CCU_RADIUS_MAX);
+                f.set_default(CCU_RADIUS_DFLT);
+                f.set_precision(SLIDER_PRECISION);
+            }),
+        )?;
 
-        params.add(Params::YRadius, "Vertical Radius", ae::FloatSliderDef::setup(|f| {
-            f.set_valid_min(CCU_RADIUS_MIN);
-            f.set_valid_max(CCU_RADIUS_BIG_MAX);
-            f.set_slider_min(CCU_RADIUS_MIN);
-            f.set_slider_max(CCU_RADIUS_MAX);
-            f.set_default(CCU_RADIUS_DFLT);
-            f.set_precision(SLIDER_PRECISION);
-        }))?;
+        params.add(
+            Params::YRadius,
+            "Vertical Radius",
+            ae::FloatSliderDef::setup(|f| {
+                f.set_valid_min(CCU_RADIUS_MIN);
+                f.set_valid_max(CCU_RADIUS_BIG_MAX);
+                f.set_slider_min(CCU_RADIUS_MIN);
+                f.set_slider_max(CCU_RADIUS_MAX);
+                f.set_default(CCU_RADIUS_DFLT);
+                f.set_precision(SLIDER_PRECISION);
+            }),
+        )?;
 
-        params.add(Params::Point, "Center", ae::PointDef::setup(|f| {
-            f.set_x_value(CCU_PTX_DFLT);
-            f.set_y_value(CCU_PTY_DFLT);
-            f.set_default_x(f.x_value());
-            f.set_default_y(f.y_value());
-            f.set_restrict_bounds(false);
-        }))?;
+        params.add(
+            Params::Point,
+            "Center",
+            ae::PointDef::setup(|f| {
+                f.set_x_value(CCU_PTX_DFLT);
+                f.set_y_value(CCU_PTY_DFLT);
+                f.set_default_x(f.x_value());
+                f.set_default_y(f.y_value());
+                f.set_restrict_bounds(false);
+            }),
+        )?;
 
         in_data.interact().register_ui(
-            CustomUIInfo::new()
-                .events(ae::CustomEventFlags::LAYER | ae::CustomEventFlags::COMP)
+            CustomUIInfo::new().events(ae::CustomEventFlags::LAYER | ae::CustomEventFlags::COMP),
         )?;
 
         Ok(())
     }
 
-    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Custom Comp UI, v3.3,\rManages a custom Comp (and Layer) window UI.\rCopyright 1994-2023\rAdobe Inc.");
             }
-            ae::Command::Event { mut extra } => {
-                match extra.event() {
-                    ae::Event::Click(_) => {
-                        if extra.send_drag() {
-                            ui::drag(&in_data, params, &mut extra)?;
-                        } else {
-                            ui::click(&in_data, params, &mut extra)?;
-                        }
+            ae::Command::Event { mut extra } => match extra.event() {
+                ae::Event::Click(_) => {
+                    if extra.send_drag() {
+                        ui::drag(&in_data, params, &mut extra)?;
+                    } else {
+                        ui::click(&in_data, params, &mut extra)?;
                     }
-                    ae::Event::Drag(_) => { ui::drag(&in_data, params, &mut extra)?; }
-                    ae::Event::Draw(_) => { ui::draw(&in_data, params, &mut extra)?; }
-                    _ => {}
                 }
-            }
-            ae::Command::Render { in_layer, mut out_layer } => {
+                ae::Event::Drag(_) => {
+                    ui::drag(&in_data, params, &mut extra)?;
+                }
+                ae::Event::Draw(_) => {
+                    ui::draw(&in_data, params, &mut extra)?;
+                }
+                _ => {}
+            },
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
                 let out_extent = out_layer.extent_hint();
-                let min_x      = out_extent.left;
-                let max_x      = out_extent.right;
-                let min_y      = out_extent.top;
-                let max_y      = out_extent.bottom;
-                let rad_x      = params.get(Params::XRadius)?.as_float_slider()?.value() as f32;
-                let rad_y      = params.get(Params::YRadius)?.as_float_slider()?.value() as f32;
-                let rad_x_sqr  = rad_x.powi(2);
-                let rad_y_sqr  = rad_y.powi(2);
+                let min_x = out_extent.left;
+                let max_x = out_extent.right;
+                let min_y = out_extent.top;
+                let max_y = out_extent.bottom;
+                let rad_x = params.get(Params::XRadius)?.as_float_slider()?.value() as f32;
+                let rad_y = params.get(Params::YRadius)?.as_float_slider()?.value() as f32;
+                let rad_x_sqr = rad_x.powi(2);
+                let rad_y_sqr = rad_y.powi(2);
                 let center = params.get(Params::Point)?.as_point()?.value();
 
                 let par = f32::from(in_data.pixel_aspect_ratio());
@@ -106,50 +133,88 @@ impl AdobePluginGlobal for Plugin {
                 if rad_x == 0.0 || rad_y == 0.0 {
                     // Premiere Pro/Elements doesn't support WorldTransformSuite1, but it does support many of the callbacks in utils
                     if in_data.quality() == ae::Quality::Hi && !in_data.is_premiere() {
-                        ae::pf::suites::WorldTransform::new()?.copy_hq(in_data.effect_ref(), in_layer, out_layer, None, None)?;
+                        ae::pf::suites::WorldTransform::new()?.copy_hq(
+                            in_data.effect_ref(),
+                            in_layer,
+                            out_layer,
+                            None,
+                            None,
+                        )?;
                     } else if !in_data.is_premiere() {
-                        ae::pf::suites::WorldTransform::new()?.copy(in_data.effect_ref(), in_layer, out_layer, None, None)?;
+                        ae::pf::suites::WorldTransform::new()?.copy(
+                            in_data.effect_ref(),
+                            in_layer,
+                            out_layer,
+                            None,
+                            None,
+                        )?;
                     } else {
                         out_layer.copy_from(&in_layer, None, None)?;
                     }
                 } else {
                     // iterate over image data.
-                    in_layer.iterate_with(&mut out_layer, 0, out_extent.height(), Some(out_extent), |x: i32, y: i32, pixel: ae::GenericPixel, out_pixel: ae::GenericPixelMut| -> Result<(), Error> {
-                        let in_ellipse = {
-                            let dy = (y as f32 - center.1) * downsample_y_inv;
-                            if dy > rad_y || dy < -rad_y || y < min_y || y > max_y {
-                                false
-                            } else {
-                                let dx = (x as f32 - center.0) * downsample_x_inv * par;
-                                // If the pixel is out of the visible x range covered by the circle
-                                if dx > rad_x || dx < -rad_x || x < min_x || x > max_x {
+                    in_layer.iterate_with(
+                        &mut out_layer,
+                        0,
+                        out_extent.height(),
+                        Some(out_extent),
+                        |x: i32,
+                         y: i32,
+                         pixel: ae::GenericPixel,
+                         out_pixel: ae::GenericPixelMut|
+                         -> Result<(), Error> {
+                            let in_ellipse = {
+                                let dy = (y as f32 - center.1) * downsample_y_inv;
+                                if dy > rad_y || dy < -rad_y || y < min_y || y > max_y {
                                     false
                                 } else {
-                                    // An ellipse centered at (0,0) has the equation:
-                                    // x^2 / a^2 + y^2 / b^2 = 1, where a is the width and b is the height of the ellipse
-                                    !(dx.powi(2) / rad_x_sqr + dy.powi(2) / rad_y_sqr >= 1.0)
+                                    let dx = (x as f32 - center.0) * downsample_x_inv * par;
+                                    // If the pixel is out of the visible x range covered by the circle
+                                    if dx > rad_x || dx < -rad_x || x < min_x || x > max_x {
+                                        false
+                                    } else {
+                                        // An ellipse centered at (0,0) has the equation:
+                                        // x^2 / a^2 + y^2 / b^2 = 1, where a is the width and b is the height of the ellipse
+                                        !(dx.powi(2) / rad_x_sqr + dy.powi(2) / rad_y_sqr >= 1.0)
+                                    }
                                 }
-                            }
-                        };
-                        match (pixel, out_pixel) {
-                            (ae::GenericPixel::Pixel8(pixel), ae::GenericPixelMut::Pixel8(out_pixel)) => {
-                                if in_ellipse {
-                                    *out_pixel = ae::Pixel8 { alpha: pixel.alpha, red: 0, green: ae::MAX_CHANNEL8 as u8, blue: 0 };
-                                } else {
-                                    *out_pixel = *pixel;
+                            };
+                            match (pixel, out_pixel) {
+                                (
+                                    ae::GenericPixel::Pixel8(pixel),
+                                    ae::GenericPixelMut::Pixel8(out_pixel),
+                                ) => {
+                                    if in_ellipse {
+                                        *out_pixel = ae::Pixel8 {
+                                            alpha: pixel.alpha,
+                                            red: 0,
+                                            green: ae::MAX_CHANNEL8 as u8,
+                                            blue: 0,
+                                        };
+                                    } else {
+                                        *out_pixel = *pixel;
+                                    }
                                 }
-                            }
-                            (ae::GenericPixel::Pixel16(pixel), ae::GenericPixelMut::Pixel16(out_pixel)) => {
-                                if in_ellipse {
-                                    *out_pixel = ae::Pixel16 { alpha: pixel.alpha, red: 0, green: ae::MAX_CHANNEL16 as u16, blue: 0 };
-                                } else {
-                                    *out_pixel = *pixel;
+                                (
+                                    ae::GenericPixel::Pixel16(pixel),
+                                    ae::GenericPixelMut::Pixel16(out_pixel),
+                                ) => {
+                                    if in_ellipse {
+                                        *out_pixel = ae::Pixel16 {
+                                            alpha: pixel.alpha,
+                                            red: 0,
+                                            green: ae::MAX_CHANNEL16 as u16,
+                                            blue: 0,
+                                        };
+                                    } else {
+                                        *out_pixel = *pixel;
+                                    }
                                 }
+                                _ => return Err(Error::BadCallbackParameter),
                             }
-                            _ => return Err(Error::BadCallbackParameter)
-                        }
-                        Ok(())
-                    })?;
+                            Ok(())
+                        },
+                    )?;
 
                     // Alternatively, you can loop manually through the data
                     /*unsafe {

--- a/examples/custom_comp_ui/src/ui.rs
+++ b/examples/custom_comp_ui/src/ui.rs
@@ -2,13 +2,13 @@ use super::*;
 
 // Calculates the points for an oval bounded by oval_frame
 fn calculate_oval(oval_frame: &ae::Rect) -> [ae::drawbot::PointF32; OVAL_PTS] {
-    let oval_width  = (oval_frame.right  - oval_frame.left) as f32 / 2.0;
-    let oval_height = (oval_frame.bottom - oval_frame.top) as f32  / 2.0;
+    let oval_width = (oval_frame.right - oval_frame.left) as f32 / 2.0;
+    let oval_height = (oval_frame.bottom - oval_frame.top) as f32 / 2.0;
 
     // Calculate center point for oval
     let center_point = ae::drawbot::PointF32 {
         x: oval_frame.left as f32 + oval_width,
-        y: oval_frame.top  as f32 + oval_height,
+        y: oval_frame.top as f32 + oval_height,
     };
 
     let mut poly_oval = [ae::drawbot::PointF32 { x: 0.0, y: 0.0 }; OVAL_PTS];
@@ -21,7 +21,7 @@ fn calculate_oval(oval_frame: &ae::Rect) -> [ae::drawbot::PointF32; OVAL_PTS] {
         poly_oval[i].y = rad.cos();
 
         // Transform the point on a unit circle to the corresponding point on the oval
-        poly_oval[i].x = poly_oval[i].x * oval_width  + center_point.x;
+        poly_oval[i].x = poly_oval[i].x * oval_width + center_point.x;
         poly_oval[i].y = poly_oval[i].y * oval_height + center_point.y;
     }
 
@@ -29,7 +29,11 @@ fn calculate_oval(oval_frame: &ae::Rect) -> [ae::drawbot::PointF32; OVAL_PTS] {
 }
 
 // Draws an oval
-fn draw_oval(in_data: &ae::InData, oval_frame: &ae::Rect, drawbot: &drawbot::Drawbot) -> Result<(), ae::Error> {
+fn draw_oval(
+    in_data: &ae::InData,
+    oval_frame: &ae::Rect,
+    drawbot: &drawbot::Drawbot,
+) -> Result<(), ae::Error> {
     let poly_oval = calculate_oval(oval_frame);
 
     let mut path = drawbot.supplier()?.new_path()?;
@@ -45,9 +49,9 @@ fn draw_oval(in_data: &ae::InData, oval_frame: &ae::Rect, drawbot: &drawbot::Dra
         ae::pf::suites::EffectCustomUIOverlayTheme::new()?.stroke_path(drawbot, &path, false)?;
     } else {
         let foreground_color = ae::drawbot::ColorRgba {
-            red:   0.9,
+            red: 0.9,
             green: 0.9,
-            blue:  0.9,
+            blue: 0.9,
             alpha: 1.0,
         };
         let pen = drawbot.supplier()?.new_pen(&foreground_color, 1.0)?;
@@ -58,69 +62,102 @@ fn draw_oval(in_data: &ae::InData, oval_frame: &ae::Rect, drawbot: &drawbot::Dra
 }
 
 // Calculates the frame in fixed coordinates based on the params passed in
-fn fixed_frame_from_params(in_data: &ae::InData, params: &ae::Parameters<Params>) -> Result<ae::sys::PF_FixedRect, Error> {
-    let x_rad   = params.get(Params::XRadius)?.as_float_slider()?.value() as f32;
-    let y_rad   = params.get(Params::YRadius)?.as_float_slider()?.value() as f32;
-    let center  = params.get(Params::Point)?.as_point()?.value();
+fn fixed_frame_from_params(
+    in_data: &ae::InData,
+    params: &ae::Parameters<Params>,
+) -> Result<ae::sys::PF_FixedRect, Error> {
+    let x_rad = params.get(Params::XRadius)?.as_float_slider()?.value() as f32;
+    let y_rad = params.get(Params::YRadius)?.as_float_slider()?.value() as f32;
+    let center = params.get(Params::Point)?.as_point()?.value();
     let par_inv = f32::from(in_data.pixel_aspect_ratio().inv());
 
     Ok(ae::sys::PF_FixedRect {
-        top   : ae::Fixed::from(center.1 - y_rad          ).as_fixed(),
-        bottom: ae::Fixed::from(center.1 + y_rad          ).as_fixed(),
-        left  : ae::Fixed::from(center.0 - x_rad * par_inv).as_fixed(),
-        right : ae::Fixed::from(center.0 + x_rad * par_inv).as_fixed(),
+        top: ae::Fixed::from(center.1 - y_rad).as_fixed(),
+        bottom: ae::Fixed::from(center.1 + y_rad).as_fixed(),
+        left: ae::Fixed::from(center.0 - x_rad * par_inv).as_fixed(),
+        right: ae::Fixed::from(center.0 + x_rad * par_inv).as_fixed(),
     })
 }
 
-fn frame_from_params(in_data: &ae::InData, params: &ae::Parameters<Params>) -> Result<ae::Rect, Error> {
-    let x_rad   = params.get(Params::XRadius)?.as_float_slider()?.value() as f32;
-    let y_rad   = params.get(Params::YRadius)?.as_float_slider()?.value() as f32;
-    let center  = params.get(Params::Point)?.as_point()?.value();
+fn frame_from_params(
+    in_data: &ae::InData,
+    params: &ae::Parameters<Params>,
+) -> Result<ae::Rect, Error> {
+    let x_rad = params.get(Params::XRadius)?.as_float_slider()?.value() as f32;
+    let y_rad = params.get(Params::YRadius)?.as_float_slider()?.value() as f32;
+    let center = params.get(Params::Point)?.as_point()?.value();
     let par_inv = f32::from(in_data.pixel_aspect_ratio().inv());
 
     Ok(ae::Rect {
-        top   : (center.1 - y_rad          ).round() as _,
-        bottom: (center.1 + y_rad          ).round() as _,
-        left  : (center.0 - x_rad * par_inv).round() as _,
-        right : (center.0 + x_rad * par_inv).round() as _,
+        top: (center.1 - y_rad).round() as _,
+        bottom: (center.1 + y_rad).round() as _,
+        left: (center.0 - x_rad * par_inv).round() as _,
+        right: (center.0 + x_rad * par_inv).round() as _,
     })
 }
 
-fn source_to_frame_rect(in_data: &ae::InData, event: &mut ae::EventExtra, fx_frame: &mut ae::sys::PF_FixedRect) -> Result<[ae::sys::PF_FixedPoint; 4], Error> {
+fn source_to_frame_rect(
+    in_data: &ae::InData,
+    event: &mut ae::EventExtra,
+    fx_frame: &mut ae::sys::PF_FixedRect,
+) -> Result<[ae::sys::PF_FixedPoint; 4], Error> {
     let mut bounding_box = [
-        ae::sys::PF_FixedPoint { x: fx_frame.left,  y: fx_frame.top },
-        ae::sys::PF_FixedPoint { x: fx_frame.right, y: fx_frame.top },
-        ae::sys::PF_FixedPoint { x: fx_frame.right, y: fx_frame.bottom },
-        ae::sys::PF_FixedPoint { x: fx_frame.left,  y: fx_frame.bottom },
+        ae::sys::PF_FixedPoint {
+            x: fx_frame.left,
+            y: fx_frame.top,
+        },
+        ae::sys::PF_FixedPoint {
+            x: fx_frame.right,
+            y: fx_frame.top,
+        },
+        ae::sys::PF_FixedPoint {
+            x: fx_frame.right,
+            y: fx_frame.bottom,
+        },
+        ae::sys::PF_FixedPoint {
+            x: fx_frame.left,
+            y: fx_frame.bottom,
+        },
     ];
 
     if event.window_type() == ae::WindowType::Comp {
         for i in 0..4 {
-            event.callbacks().layer_to_comp(in_data.current_time(), in_data.time_scale(), &mut bounding_box[i])?;
+            event.callbacks().layer_to_comp(
+                in_data.current_time(),
+                in_data.time_scale(),
+                &mut bounding_box[i],
+            )?;
         }
     }
     for j in 0..4 {
         event.callbacks().source_to_frame(&mut bounding_box[j])?;
     }
 
-    fx_frame.left   = bounding_box[0].x;
-    fx_frame.top    = bounding_box[0].y;
-    fx_frame.right  = bounding_box[1].x;
+    fx_frame.left = bounding_box[0].x;
+    fx_frame.top = bounding_box[0].y;
+    fx_frame.right = bounding_box[1].x;
     fx_frame.bottom = bounding_box[2].y;
 
     Ok(bounding_box)
 }
 
-fn comp_frame_to_layer(in_data: &ae::InData, event: &mut ae::EventExtra, frame_pt: ae::Point, lyr_pt: &mut ae::Point) -> Result<ae::sys::PF_FixedPoint, Error> {
+fn comp_frame_to_layer(
+    in_data: &ae::InData,
+    event: &mut ae::EventExtra,
+    frame_pt: ae::Point,
+    lyr_pt: &mut ae::Point,
+) -> Result<ae::sys::PF_FixedPoint, Error> {
     let mut fix_lyr = ae::sys::PF_FixedPoint {
         x: ae::Fixed::from_int(frame_pt.h).as_fixed(),
-        y: ae::Fixed::from_int(frame_pt.v).as_fixed()
+        y: ae::Fixed::from_int(frame_pt.v).as_fixed(),
     };
 
     event.callbacks().frame_to_source(&mut fix_lyr)?;
 
     // Now back into layer space
-    event.callbacks().comp_to_layer(in_data.current_time(), in_data.time_scale(), &mut fix_lyr)?;
+    event
+        .callbacks()
+        .comp_to_layer(in_data.current_time(), in_data.time_scale(), &mut fix_lyr)?;
 
     lyr_pt.h = fix_lyr.x;
     lyr_pt.v = fix_lyr.y;
@@ -128,13 +165,22 @@ fn comp_frame_to_layer(in_data: &ae::InData, event: &mut ae::EventExtra, frame_p
     Ok(fix_lyr)
 }
 
-fn layer_to_comp_frame(in_data: &ae::InData, event: &mut ae::EventExtra, layer_pt: ae::Point, frame_pt: &mut ae::Point) -> Result<ae::sys::PF_FixedPoint, Error> {
+fn layer_to_comp_frame(
+    in_data: &ae::InData,
+    event: &mut ae::EventExtra,
+    layer_pt: ae::Point,
+    frame_pt: &mut ae::Point,
+) -> Result<ae::sys::PF_FixedPoint, Error> {
     let mut fix_frame = ae::sys::PF_FixedPoint {
         x: ae::Fixed::from_int(layer_pt.h).as_fixed(),
-        y: ae::Fixed::from_int(layer_pt.v).as_fixed()
+        y: ae::Fixed::from_int(layer_pt.v).as_fixed(),
     };
 
-    event.callbacks().layer_to_comp(in_data.current_time(), in_data.time_scale(), &mut fix_frame)?;
+    event.callbacks().layer_to_comp(
+        in_data.current_time(),
+        in_data.time_scale(),
+        &mut fix_frame,
+    )?;
     event.callbacks().source_to_frame(&mut fix_frame)?;
 
     frame_pt.h = ae::Fixed::from_fixed(fix_frame.x).to_int();
@@ -143,10 +189,15 @@ fn layer_to_comp_frame(in_data: &ae::InData, event: &mut ae::EventExtra, layer_p
     Ok(fix_frame)
 }
 
-fn layer_frame_to_layer(_: &ae::InData, event: &mut ae::EventExtra, frame_pt: ae::Point, lyr_pt: &mut ae::Point) -> Result<ae::sys::PF_FixedPoint, Error> {
+fn layer_frame_to_layer(
+    _: &ae::InData,
+    event: &mut ae::EventExtra,
+    frame_pt: ae::Point,
+    lyr_pt: &mut ae::Point,
+) -> Result<ae::sys::PF_FixedPoint, Error> {
     let mut fix_lyr = ae::sys::PF_FixedPoint {
         x: ae::Fixed::from_int(frame_pt.h).to_int(),
-        y: ae::Fixed::from_int(frame_pt.v).to_int()
+        y: ae::Fixed::from_int(frame_pt.v).to_int(),
     };
 
     event.callbacks().frame_to_source(&mut fix_lyr)?;
@@ -157,10 +208,15 @@ fn layer_frame_to_layer(_: &ae::InData, event: &mut ae::EventExtra, frame_pt: ae
     Ok(fix_lyr)
 }
 
-fn layer_to_layer_frame(_: &ae::InData, event: &mut ae::EventExtra, layer_pt: ae::Point, frame_pt: &mut ae::Point) -> Result<ae::sys::PF_FixedPoint, Error> {
+fn layer_to_layer_frame(
+    _: &ae::InData,
+    event: &mut ae::EventExtra,
+    layer_pt: ae::Point,
+    frame_pt: &mut ae::Point,
+) -> Result<ae::sys::PF_FixedPoint, Error> {
     let mut fix_frame = ae::sys::PF_FixedPoint {
         x: ae::Fixed::from_int(layer_pt.h).as_fixed(),
-        y: ae::Fixed::from_int(layer_pt.v).as_fixed()
+        y: ae::Fixed::from_int(layer_pt.v).as_fixed(),
     };
 
     event.callbacks().source_to_frame(&mut fix_frame)?;
@@ -171,7 +227,11 @@ fn layer_to_layer_frame(_: &ae::InData, event: &mut ae::EventExtra, layer_pt: ae
     Ok(fix_frame)
 }
 
-pub fn draw(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &mut ae::EventExtra) -> Result<(), ae::Error> {
+pub fn draw(
+    in_data: &ae::InData,
+    params: &mut ae::Parameters<Params>,
+    event: &mut ae::EventExtra,
+) -> Result<(), ae::Error> {
     if event.window_type() == ae::WindowType::Layer || event.window_type() == ae::WindowType::Comp {
         let drawbot = event.context_handle().drawing_reference()?;
         let surface = drawbot.surface()?;
@@ -180,10 +240,10 @@ pub fn draw(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &m
         let _points = source_to_frame_rect(in_data, event, &mut fx_frame);
 
         let frame = ae::Rect {
-            top   : ae::Fixed::from_fixed(fx_frame.top).to_int_rounded(),
+            top: ae::Fixed::from_fixed(fx_frame.top).to_int_rounded(),
             bottom: ae::Fixed::from_fixed(fx_frame.bottom).to_int_rounded(),
-            left  : ae::Fixed::from_fixed(fx_frame.left).to_int_rounded(),
-            right : ae::Fixed::from_fixed(fx_frame.right).to_int_rounded(),
+            left: ae::Fixed::from_fixed(fx_frame.left).to_int_rounded(),
+            right: ae::Fixed::from_fixed(fx_frame.right).to_int_rounded(),
         };
 
         // Currently, EffectCustomUIOverlayThemeSuite is unsupported in Premiere Pro/Elements
@@ -192,9 +252,9 @@ pub fn draw(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &m
         } else {
             drawbot::ColorRgba {
                 alpha: 1.0,
-                blue:  0.9,
+                blue: 0.9,
                 green: 0.9,
-                red:   0.9,
+                red: 0.9,
             }
         };
 
@@ -202,25 +262,25 @@ pub fn draw(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &m
 
         let mut bbox = ae::drawbot::RectF32 {
             left: 0.0,
-            top:  0.0,
+            top: 0.0,
             width: 6.0,
             height: 6.0,
         };
 
-        bbox.top  = frame.top  as f32 - 3.0;
+        bbox.top = frame.top as f32 - 3.0;
         bbox.left = frame.left as f32 - 3.0;
         surface.paint_rect(&foreground_color, &bbox)?;
 
-        bbox.top  = frame.top   as f32 - 3.0;
+        bbox.top = frame.top as f32 - 3.0;
         bbox.left = frame.right as f32 - 3.0;
         surface.paint_rect(&foreground_color, &bbox)?;
 
-        bbox.top  = frame.bottom as f32 - 3.0;
-        bbox.left = frame.left   as f32 - 3.0;
+        bbox.top = frame.bottom as f32 - 3.0;
+        bbox.left = frame.left as f32 - 3.0;
         surface.paint_rect(&foreground_color, &bbox)?;
 
-        bbox.top  = frame.bottom as f32 - 3.0;
-        bbox.left = frame.right  as f32 - 3.0;
+        bbox.top = frame.bottom as f32 - 3.0;
+        bbox.left = frame.right as f32 - 3.0;
         surface.paint_rect(&foreground_color, &bbox)?;
 
         event.set_event_out_flags(ae::EventOutFlags::HANDLED_EVENT);
@@ -229,16 +289,39 @@ pub fn draw(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &m
     Ok(())
 }
 
-fn do_click_handles<F>(in_data: &ae::InData, frame: &ae::Rect, frame_func: F, event: &mut ae::EventExtra) -> Result<bool, ae::Error>
-where F: Fn(&ae::InData, &mut ae::EventExtra, ae::Point, &mut ae::Point) -> Result<ae::sys::PF_FixedPoint, Error> {
-
+fn do_click_handles<F>(
+    in_data: &ae::InData,
+    frame: &ae::Rect,
+    frame_func: F,
+    event: &mut ae::EventExtra,
+) -> Result<bool, ae::Error>
+where
+    F: Fn(
+        &ae::InData,
+        &mut ae::EventExtra,
+        ae::Point,
+        &mut ae::Point,
+    ) -> Result<ae::sys::PF_FixedPoint, Error>,
+{
     let mut done = false;
     let mouse_down_pt = event.screen_point();
     let mut corners = [
-        ae::Point { h: frame.left,  v: frame.top },
-        ae::Point { h: frame.right, v: frame.top },
-        ae::Point { h: frame.right, v: frame.bottom },
-        ae::Point { h: frame.left,  v: frame.bottom },
+        ae::Point {
+            h: frame.left,
+            v: frame.top,
+        },
+        ae::Point {
+            h: frame.right,
+            v: frame.top,
+        },
+        ae::Point {
+            h: frame.right,
+            v: frame.bottom,
+        },
+        ae::Point {
+            h: frame.left,
+            v: frame.bottom,
+        },
     ];
 
     // let mut hit = -1;
@@ -248,7 +331,7 @@ where F: Fn(&ae::InData, &mut ae::EventExtra, ae::Point, &mut ae::Point) -> Resu
         let mouse_layer = frame_func(in_data, event, corners[i], &mut corners[i])?;
 
         let mut slop = (corners[i].h - mouse_down_pt.h).abs();
-        slop        += (corners[i].v - mouse_down_pt.v).abs();
+        slop += (corners[i].v - mouse_down_pt.v).abs();
 
         if slop < CCU_SLOP {
             // hit = i as isize;
@@ -265,7 +348,11 @@ where F: Fn(&ae::InData, &mut ae::EventExtra, ae::Point, &mut ae::Point) -> Resu
     Ok(done)
 }
 
-pub fn click(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &mut ae::EventExtra) -> Result<(), ae::Error> {
+pub fn click(
+    in_data: &ae::InData,
+    params: &mut ae::Parameters<Params>,
+    event: &mut ae::EventExtra,
+) -> Result<(), ae::Error> {
     let frame = frame_from_params(in_data, params)?;
 
     if event.window_type() == ae::WindowType::Layer {
@@ -281,8 +368,20 @@ pub fn click(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &
     Ok(())
 }
 
-fn do_drag_handles<F>(in_data: &ae::InData, params: &mut ae::Parameters<Params>, frame_func: F, event: &mut ae::EventExtra) -> Result<(), ae::Error>
-where F: Fn(&ae::InData, &mut ae::EventExtra, ae::Point, &mut ae::Point) -> Result<ae::sys::PF_FixedPoint, Error> {
+fn do_drag_handles<F>(
+    in_data: &ae::InData,
+    params: &mut ae::Parameters<Params>,
+    frame_func: F,
+    event: &mut ae::EventExtra,
+) -> Result<(), ae::Error>
+where
+    F: Fn(
+        &ae::InData,
+        &mut ae::EventExtra,
+        ae::Point,
+        &mut ae::Point,
+    ) -> Result<ae::sys::PF_FixedPoint, Error>,
+{
     let mut mouse_down_pt = event.screen_point();
 
     // if event.in_flags().contains(ae::EventInFlags::DONT_DRAW) {
@@ -301,10 +400,16 @@ where F: Fn(&ae::InData, &mut ae::EventExtra, ae::Point, &mut ae::Point) -> Resu
 
     // Calculate new radius
     let new_x = (center.0 - ae::Fixed::from_fixed(mouse_layer.x).as_f32()) * par;
-    let new_y =  center.1 - ae::Fixed::from_fixed(mouse_layer.y).as_f32();
+    let new_y = center.1 - ae::Fixed::from_fixed(mouse_layer.y).as_f32();
 
-    params.get_mut(Params::XRadius)?.as_float_slider_mut()?.set_value(new_x.abs() as _);
-    params.get_mut(Params::YRadius)?.as_float_slider_mut()?.set_value(new_y.abs() as _);
+    params
+        .get_mut(Params::XRadius)?
+        .as_float_slider_mut()?
+        .set_value(new_x.abs() as _);
+    params
+        .get_mut(Params::YRadius)?
+        .as_float_slider_mut()?
+        .set_value(new_y.abs() as _);
 
     event.set_send_drag(true);
     event.set_continue_refcon(0, Ccu::Handles as _);
@@ -320,7 +425,11 @@ where F: Fn(&ae::InData, &mut ae::EventExtra, ae::Point, &mut ae::Point) -> Resu
     Ok(())
 }
 
-pub fn drag(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &mut ae::EventExtra) -> Result<(), ae::Error> {
+pub fn drag(
+    in_data: &ae::InData,
+    params: &mut ae::Parameters<Params>,
+    event: &mut ae::EventExtra,
+) -> Result<(), ae::Error> {
     // let mut frame = frame_from_params(in_data, params)?;
 
     if event.continue_refcon(0) == Ccu::Handles as ae::sys::A_intptr_t {

--- a/examples/custom_ecw_ui/src/events.rs
+++ b/examples/custom_ecw_ui/src/events.rs
@@ -1,17 +1,24 @@
 use super::*;
 
-pub fn draw(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &mut ae::EventExtra) -> Result<(), ae::Error> {
+pub fn draw(
+    in_data: &ae::InData,
+    params: &mut ae::Parameters<Params>,
+    event: &mut ae::EventExtra,
+) -> Result<(), ae::Error> {
     // Premiere Pro/Elements does not support a standard parameter type with custom UI (bug #1235407), so we can't use the color values.
     // Use arbitrary data instead
     let param_color: ae::Pixel8 = if !in_data.is_premiere() {
         params.get(Params::Color)?.as_color()?.value()
     } else {
-        *params.get(Params::Color)?.as_arbitrary()?.value::<ae::Pixel8>()?
+        *params
+            .get(Params::Color)?
+            .as_arbitrary()?
+            .value::<ae::Pixel8>()?
     };
     let drawbot_color = ae::drawbot::ColorRgba {
-        red:   param_color.red   as f32 / 255.0,
+        red: param_color.red as f32 / 255.0,
         green: param_color.green as f32 / 255.0,
-        blue:  param_color.blue  as f32 / 255.0,
+        blue: param_color.blue as f32 / 255.0,
         alpha: 1.0,
     };
 
@@ -27,10 +34,10 @@ pub fn draw(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &m
 
         // Add the rectangle to path
         path.add_rect(&ae::drawbot::RectF32 {
-            left:   current_frame.left   as f32 + 0.5, // Center of the pixel in new drawing model is (0.5, 0.5)
-            top:    current_frame.top    as f32 + 0.5,
-            width:  current_frame.right  as f32 - current_frame.left as f32,
-            height: current_frame.bottom as f32 - current_frame.top  as f32,
+            left: current_frame.left as f32 + 0.5, // Center of the pixel in new drawing model is (0.5, 0.5)
+            top: current_frame.top as f32 + 0.5,
+            width: current_frame.right as f32 - current_frame.left as f32,
+            height: current_frame.bottom as f32 - current_frame.top as f32,
         })?;
 
         // Fill the path with the brush created
@@ -40,9 +47,16 @@ pub fn draw(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &m
         static PNG: std::sync::OnceLock<PngImage> = std::sync::OnceLock::new();
         let png = PNG.get_or_init(|| PngImage::new(include_bytes!("../ferris.png")));
 
-        if let Ok(img) = supplier.new_image_from_buffer(png.width, png.height, png.line_size, drawbot::PixelLayout::Bgra32Straight, &png.data) {
+        if let Ok(img) = supplier.new_image_from_buffer(
+            png.width,
+            png.height,
+            png.line_size,
+            drawbot::PixelLayout::Bgra32Straight,
+            &png.data,
+        ) {
             let origin = drawbot::PointF32 {
-                x: current_frame.left as f32 + (current_frame.width() as f32 - png.width as f32) / 2.0,
+                x: current_frame.left as f32
+                    + (current_frame.width() as f32 - png.width as f32) / 2.0,
                 y: current_frame.top as f32,
             };
             surface.draw_image(&img, &origin, 1.0)?;
@@ -55,14 +69,27 @@ pub fn draw(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &m
         let font = supplier.new_default_font(default_font_size)?;
 
         // Draw string with white color
-        let string_brush = supplier.new_brush(&ae::drawbot::ColorRgba { red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0 })?;
+        let string_brush = supplier.new_brush(&ae::drawbot::ColorRgba {
+            red: 1.0,
+            green: 1.0,
+            blue: 1.0,
+            alpha: 1.0,
+        })?;
 
         let origin = ae::drawbot::PointF32 {
             x: current_frame.left as f32 + 5.0,
-            y: current_frame.top  as f32 + 100.0,
+            y: current_frame.top as f32 + 100.0,
         };
 
-        surface.draw_string(&string_brush, &font, CUSTOM_UI_STRING, &origin, ae::drawbot::TextAlignment::Left, ae::drawbot::TextTruncation::None, 0.0)?;
+        surface.draw_string(
+            &string_brush,
+            &font,
+            CUSTOM_UI_STRING,
+            &origin,
+            ae::drawbot::TextAlignment::Left,
+            ae::drawbot::TextTruncation::None,
+            0.0,
+        )?;
     }
 
     event.set_event_out_flags(ae::EventOutFlags::HANDLED_EVENT);
@@ -70,8 +97,14 @@ pub fn draw(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &m
     Ok(())
 }
 
-pub fn drag(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &mut ae::EventExtra) -> Result<(), ae::Error> {
-    let ae::Event::Drag(drag) = event.event() else { return Err(ae::Error::InvalidParms) };
+pub fn drag(
+    in_data: &ae::InData,
+    params: &mut ae::Parameters<Params>,
+    event: &mut ae::EventExtra,
+) -> Result<(), ae::Error> {
+    let ae::Event::Drag(drag) = event.event() else {
+        return Err(ae::Error::InvalidParms);
+    };
     let context = event.context_handle();
 
     if context.window_type() == ae::WindowType::Effect {
@@ -85,15 +118,17 @@ pub fn drag(in_data: &ae::InData, params: &mut ae::Parameters<Params>, event: &m
                 *param.as_arbitrary()?.value::<ae::Pixel8>()?
             };
             let new_color = ae::Pixel8 {
-                red:   (((mouse_down.h as u16) << 8) / UI_BOX_WIDTH) as u8,
-                blue:  (((mouse_down.v as u16) << 8) / UI_BOX_HEIGHT) as u8,
+                red: (((mouse_down.h as u16) << 8) / UI_BOX_WIDTH) as u8,
+                blue: (((mouse_down.v as u16) << 8) / UI_BOX_HEIGHT) as u8,
                 green: current_color.red.saturating_add(current_color.blue),
                 alpha: 0xFF,
             };
             if !in_data.is_premiere() {
                 param.as_color_mut()?.set_value(new_color);
             } else {
-                param.as_arbitrary_mut()?.set_value::<ae::Pixel8>(new_color)?;
+                param
+                    .as_arbitrary_mut()?
+                    .set_value::<ae::Pixel8>(new_color)?;
             }
         }
     }
@@ -146,10 +181,10 @@ impl PngImage {
             data,
         }
     }
+
     fn rgba_to_bgra(data: &mut [u8]) {
         for chunk in data.chunks_exact_mut(4) {
             chunk.swap(0, 2);
         }
     }
 }
-

--- a/examples/custom_ecw_ui/src/lib.rs
+++ b/examples/custom_ecw_ui/src/lib.rs
@@ -5,9 +5,9 @@ mod events;
 // This example uses ArbitraryData in Premiere, because it doesn't support custom UI with a Color parameter
 
 const CUSTOM_UI_STRING: &str = "Whoopee! A Custom UI!!!\nClick and drag here to\nchange the background color.\nHold down shift or cmd/ctrl\nfor different cursors!";
-const STR_FRANK       : &str = "Frank";
+const STR_FRANK: &str = "Frank";
 
-const UI_BOX_WIDTH : u16 = 200;
+const UI_BOX_WIDTH: u16 = 200;
 const UI_BOX_HEIGHT: u16 = 200;
 
 #[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
@@ -32,7 +32,12 @@ impl Default for Plugin {
 }
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, in_data: InData, _: OutData) -> Result<(), Error> {
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
         let param_cb = |param: &mut ae::ParamDef| {
             param.set_flags(ae::ParamFlag::SUPERVISE);
             param.set_ui_flags(ae::ParamUIFlags::CONTROL);
@@ -45,69 +50,109 @@ impl AdobePluginGlobal for Plugin {
         if !in_data.is_premiere() {
             params.add_customized(Params::Color, "Fill Color", ae::ColorDef::new(), param_cb)?;
         } else {
-            params.add_customized(Params::Color, "Fill Color", ae::ArbitraryDef::setup(|f| {
-                f.set_default::<ArbColor>(ArbColor::default()).unwrap();
-            }), param_cb)?;
+            params.add_customized(
+                Params::Color,
+                "Fill Color",
+                ae::ArbitraryDef::setup(|f| {
+                    f.set_default::<ArbColor>(ArbColor::default()).unwrap();
+                }),
+                param_cb,
+            )?;
         }
 
-        in_data.interact().register_ui(
-            CustomUIInfo::new()
-                .events(ae::CustomEventFlags::EFFECT)
-        )?;
+        in_data
+            .interact()
+            .register_ui(CustomUIInfo::new().events(ae::CustomEventFlags::EFFECT))?;
 
         Ok(())
     }
 
-    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 let personal_info = ae::suites::App::new()?.personal_info()?;
 
                 out_data.set_return_msg(&format!("Custom_ECW_UI, v3.2,\r{}\r{}\rExample using CustomUI in the effect control window.\rCopyright 2007-2023 Adobe Inc.", personal_info.name, personal_info.serial_str));
             }
-            ae::Command::Event { mut extra } => {
-                match extra.event() {
-                    ae::Event::Click(_) => { events::click(&in_data, &mut extra)?; }
-                    ae::Event::Drag(_)  => { events::drag(&in_data, params, &mut extra)?; }
-                    ae::Event::Draw(_)  => { events::draw(&in_data, params, &mut extra)?; }
-                    ae::Event::AdjustCursor(_) => { events::change_cursor(&mut extra)?; }
-                    _ => {}
+            ae::Command::Event { mut extra } => match extra.event() {
+                ae::Event::Click(_) => {
+                    events::click(&in_data, &mut extra)?;
                 }
-            }
+                ae::Event::Drag(_) => {
+                    events::drag(&in_data, params, &mut extra)?;
+                }
+                ae::Event::Draw(_) => {
+                    events::draw(&in_data, params, &mut extra)?;
+                }
+                ae::Event::AdjustCursor(_) => {
+                    events::change_cursor(&mut extra)?;
+                }
+                _ => {}
+            },
             ae::Command::ArbitraryCallback { mut extra } => {
                 extra.dispatch::<ArbColor, Params>(Params::Color)?;
             }
-            ae::Command::Render { in_layer, mut out_layer } => {
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
                 let color: ae::Pixel8 = if !in_data.is_premiere() {
                     params.get(Params::Color)?.as_color()?.value()
                 } else {
-                    *params.get(Params::Color)?.as_arbitrary()?.value::<ae::Pixel8>()?
+                    *params
+                        .get(Params::Color)?
+                        .as_arbitrary()?
+                        .value::<ae::Pixel8>()?
                 };
                 let color16 = ae::pixel8_to_16(color);
 
                 let extent_hint = in_data.extent_hint();
 
                 // iterate over image data.
-                in_layer.iterate_with(&mut out_layer, 0, extent_hint.height(), Some(extent_hint), |_x: i32, _y: i32, pixel: ae::GenericPixel, out_pixel: ae::GenericPixelMut| -> Result<(), Error> {
-                    match (pixel, out_pixel) {
-                        (ae::GenericPixel::Pixel8(pixel), ae::GenericPixelMut::Pixel8(out_pixel)) => {
-                            out_pixel.alpha = pixel.alpha as _;
-                            out_pixel.red   = ((pixel.red   as u16 + color.red   as u16) >> 1) as u8;
-                            out_pixel.green = ((pixel.green as u16 + color.green as u16) >> 1) as u8;
-                            out_pixel.blue  = ((pixel.blue  as u16 + color.blue  as u16) >> 1) as u8;
+                in_layer.iterate_with(
+                    &mut out_layer,
+                    0,
+                    extent_hint.height(),
+                    Some(extent_hint),
+                    |_x: i32,
+                     _y: i32,
+                     pixel: ae::GenericPixel,
+                     out_pixel: ae::GenericPixelMut|
+                     -> Result<(), Error> {
+                        match (pixel, out_pixel) {
+                            (
+                                ae::GenericPixel::Pixel8(pixel),
+                                ae::GenericPixelMut::Pixel8(out_pixel),
+                            ) => {
+                                out_pixel.alpha = pixel.alpha as _;
+                                out_pixel.red = ((pixel.red as u16 + color.red as u16) >> 1) as u8;
+                                out_pixel.green =
+                                    ((pixel.green as u16 + color.green as u16) >> 1) as u8;
+                                out_pixel.blue =
+                                    ((pixel.blue as u16 + color.blue as u16) >> 1) as u8;
+                            }
+                            (
+                                ae::GenericPixel::Pixel16(pixel),
+                                ae::GenericPixelMut::Pixel16(out_pixel),
+                            ) => {
+                                out_pixel.alpha = pixel.alpha as _;
+                                out_pixel.red = (pixel.red + color16.red) >> 1;
+                                out_pixel.green = (pixel.green + color16.green) >> 1;
+                                out_pixel.blue = (pixel.blue + color16.blue) >> 1;
+                            }
+                            _ => return Err(Error::BadCallbackParameter),
                         }
-                        (ae::GenericPixel::Pixel16(pixel), ae::GenericPixelMut::Pixel16(out_pixel)) => {
-                            out_pixel.alpha = pixel.alpha as _;
-                            out_pixel.red   = (pixel.red   + color16.red)   >> 1;
-                            out_pixel.green = (pixel.green + color16.green) >> 1;
-                            out_pixel.blue  = (pixel.blue  + color16.blue)  >> 1;
-                        }
-                        _ => return Err(Error::BadCallbackParameter)
-                    }
-                    Ok(())
-                })?;
+                        Ok(())
+                    },
+                )?;
             }
-            _ => { }
+            _ => {}
         }
         Ok(())
     }
@@ -117,22 +162,33 @@ impl AdobePluginGlobal for Plugin {
 
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, PartialOrd, Copy, Clone)]
 #[repr(C)]
-struct ArbColor { alpha: u8, red: u8, green: u8, blue: u8 }
+struct ArbColor {
+    alpha: u8,
+    red: u8,
+    green: u8,
+    blue: u8,
+}
 impl Default for ArbColor {
     fn default() -> Self {
-        Self { red: 255, green: 0, blue: 0, alpha: 255 }
+        Self {
+            red: 255,
+            green: 0,
+            blue: 0,
+            alpha: 255,
+        }
     }
 }
 impl ae::ArbitraryData<ArbColor> for ArbColor {
     fn interpolate(&self, other: &Self, v: f64) -> Self {
-        let interp = |c1: u8, c2: u8| -> u8 { ((1.0 - v) * c1 as f64 + v * c2 as f64).round() as u8 };
+        let interp =
+            |c1: u8, c2: u8| -> u8 { ((1.0 - v) * c1 as f64 + v * c2 as f64).round() as u8 };
         Self {
-            red:   interp(self.red,   other.red),
+            red: interp(self.red, other.red),
             green: interp(self.green, other.green),
-            blue:  interp(self.blue,  other.blue),
+            blue: interp(self.blue, other.blue),
             alpha: interp(self.alpha, other.alpha),
         }
     }
 }
-const _: () = assert!(std::mem::size_of::<ArbColor>()  == std::mem::size_of::<ae::Pixel8>());
+const _: () = assert!(std::mem::size_of::<ArbColor>() == std::mem::size_of::<ae::Pixel8>());
 const _: () = assert!(std::mem::align_of::<ArbColor>() == std::mem::align_of::<ae::Pixel8>());

--- a/examples/gamma_table/src/lib.rs
+++ b/examples/gamma_table/src/lib.rs
@@ -6,10 +6,10 @@ use after_effects as ae;
 //  - a Float Slider control
 //  - the Extent Hint rectangle (from the InData structure)
 
-const GAMMA_MIN:     f32 = 0.0;
-const GAMMA_MAX:     f32 = 2.0;
+const GAMMA_MIN: f32 = 0.0;
+const GAMMA_MAX: f32 = 2.0;
 const GAMMA_BIG_MAX: f32 = 2.0;
-const GAMMA_DFLT:    f64 = 1.0;
+const GAMMA_DFLT: f64 = 1.0;
 
 #[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
 enum Params {
@@ -17,7 +17,7 @@ enum Params {
 }
 
 #[derive(Default)]
-struct Plugin { }
+struct Plugin {}
 
 struct GammaTable {
     gamma_val: f32,
@@ -41,18 +41,33 @@ impl Default for GammaTable {
 }
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, _: InData, _: OutData) -> Result<(), Error> {
-        params.add(Params::Gamma, "Gamma", ae::FloatSliderDef::setup(|f| {
-            f.set_slider_min(GAMMA_MIN);
-            f.set_slider_max(GAMMA_MAX);
-            f.set_valid_min(GAMMA_MIN);
-            f.set_valid_max(GAMMA_BIG_MAX);
-            f.set_default(GAMMA_DFLT);
-            f.set_precision(1);
-        }))
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        params.add(
+            Params::Gamma,
+            "Gamma",
+            ae::FloatSliderDef::setup(|f| {
+                f.set_slider_min(GAMMA_MIN);
+                f.set_slider_max(GAMMA_MAX);
+                f.set_valid_min(GAMMA_MIN);
+                f.set_valid_max(GAMMA_BIG_MAX);
+                f.set_default(GAMMA_DFLT);
+                f.set_precision(1);
+            }),
+        )
     }
 
-    fn handle_command(&self, cmd: ae::Command, _in_data: InData, mut out_data: OutData, _params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        _in_data: InData,
+        mut out_data: OutData,
+        _params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Gamma_Table v2.1\rPerform simple image gamma correction. Copyright 1994-2023 Adobe Inc.");
@@ -69,6 +84,7 @@ impl AdobePluginInstance for GammaTable {
         data.extend_from_slice(&f32::to_le_bytes(self.gamma_val));
         Ok((1, data))
     }
+
     fn unflatten(_version: u16, bytes: &[u8]) -> Result<Self, Error> {
         if bytes.len() < 256 + 4 {
             return Ok(Self::default());
@@ -83,13 +99,22 @@ impl AdobePluginInstance for GammaTable {
         })
     }
 
-    fn render(&self, _: &mut PluginState, _: &Layer, _: &mut Layer) -> Result<(), ae::Error> { Ok(()) }
+    fn render(&self, _: &mut PluginState, _: &Layer, _: &mut Layer) -> Result<(), ae::Error> {
+        Ok(())
+    }
 
-    fn handle_command(&mut self, plugin: &mut PluginState, cmd: ae::Command) -> Result<(), ae::Error> {
+    fn handle_command(
+        &mut self,
+        plugin: &mut PluginState,
+        cmd: ae::Command,
+    ) -> Result<(), ae::Error> {
         let in_data = &plugin.in_data;
 
         match cmd {
-            ae::Command::Render { in_layer, mut out_layer } => {
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
                 let gamma = plugin.params.get(Params::Gamma)?.as_float_slider()?.value() as f32;
 
                 // If the gamma factor is exactly 1.0 just make a direct copy.
@@ -136,7 +161,7 @@ impl AdobePluginInstance for GammaTable {
                     })?;
                 }
             }
-            _ => { }
+            _ => {}
         }
         Ok(())
     }

--- a/examples/histo_grid/src/lib.rs
+++ b/examples/histo_grid/src/lib.rs
@@ -25,11 +25,11 @@ mod ui;
 //
 // Search for "EXAMPLE" in comments for locations modified in this source code to make that work.
 
-const UI_GRID_WIDTH : u16 = 203;
+const UI_GRID_WIDTH: u16 = 203;
 const UI_GRID_HEIGHT: u16 = UI_GRID_WIDTH;
 
-const BOXES_ACROSS  : usize = 10;
-const BOXES_DOWN    : usize = 10;
+const BOXES_ACROSS: usize = 10;
+const BOXES_DOWN: usize = 10;
 const BOXES_PER_GRID: usize = BOXES_ACROSS * BOXES_DOWN; // Ones based
 const CACHE_ELEMENTS: usize = BOXES_PER_GRID;
 
@@ -38,29 +38,31 @@ const CA_MAGIC: i32 = i32::from_be_bytes(*b"CAsd");
 static mut AEGP_PLUGIN_ID: ae::aegp::PluginId = 0;
 
 struct ColorCache {
-    color: [ae::PixelF32; CACHE_ELEMENTS]
+    color: [ae::PixelF32; CACHE_ELEMENTS],
 }
 
 impl ColorCache {
     pub fn new() -> Self {
         Self {
-            color: unsafe { std::mem::zeroed() }
+            color: unsafe { std::mem::zeroed() },
         }
     }
+
     pub fn assign_grid_cell_color8(px: &ae::Pixel8) -> ae::PixelF32 {
         ae::PixelF32 {
             alpha: px.alpha as f32 / ae::MAX_CHANNEL8 as f32,
-            red:   px.red   as f32 / ae::MAX_CHANNEL8 as f32,
+            red: px.red as f32 / ae::MAX_CHANNEL8 as f32,
             green: px.green as f32 / ae::MAX_CHANNEL8 as f32,
-            blue:  px.blue  as f32 / ae::MAX_CHANNEL8 as f32,
+            blue: px.blue as f32 / ae::MAX_CHANNEL8 as f32,
         }
     }
+
     pub fn assign_grid_cell_color16(px: &ae::Pixel16) -> ae::PixelF32 {
         ae::PixelF32 {
             alpha: px.alpha as f32 / ae::MAX_CHANNEL16 as f32,
-            red:   px.red   as f32 / ae::MAX_CHANNEL16 as f32,
+            red: px.red as f32 / ae::MAX_CHANNEL16 as f32,
             green: px.green as f32 / ae::MAX_CHANNEL16 as f32,
-            blue:  px.blue  as f32 / ae::MAX_CHANNEL16 as f32,
+            blue: px.blue as f32 / ae::MAX_CHANNEL16 as f32,
         }
     }
 
@@ -79,10 +81,16 @@ impl ColorCache {
                     // output
                     let position = row_box * BOXES_ACROSS + col_box;
                     match DEPTH {
-                        8  => self.color[position] = Self::assign_grid_cell_color8(input.as_pixel8(x, y)),
-                        16 => self.color[position] = Self::assign_grid_cell_color16(input.as_pixel16(x, y)),
+                        8 => {
+                            self.color[position] =
+                                Self::assign_grid_cell_color8(input.as_pixel8(x, y))
+                        }
+                        16 => {
+                            self.color[position] =
+                                Self::assign_grid_cell_color16(input.as_pixel16(x, y))
+                        }
                         32 => self.color[position] = *input.as_pixel32(x, y),
-                        _ => { }
+                        _ => {}
                     }
                 }
             }
@@ -91,7 +99,12 @@ impl ColorCache {
 
     pub fn clear(&mut self) {
         for i in 0..CACHE_ELEMENTS {
-            self.color[i] = ae::PixelF32 { alpha: 0.0, red: 0.0, green: 0.0, blue: 0.0 };
+            self.color[i] = ae::PixelF32 {
+                alpha: 0.0,
+                red: 0.0,
+                green: 0.0,
+                blue: 0.0,
+            };
         }
     }
 
@@ -104,9 +117,9 @@ impl ColorCache {
 
         match world.pixel_format()? {
             ae::PixelFormat::Argb128 => self.compute_grid_cell_colors::<32>(world),
-            ae::PixelFormat::Argb64  => self.compute_grid_cell_colors::<16>(world),
-            ae::PixelFormat::Argb32  => self.compute_grid_cell_colors::<8> (world),
-            _ => return Err(ae::Error::BadCallbackParameter)
+            ae::PixelFormat::Argb64 => self.compute_grid_cell_colors::<16>(world),
+            ae::PixelFormat::Argb32 => self.compute_grid_cell_colors::<8>(world),
+            _ => return Err(ae::Error::BadCallbackParameter),
         }
         Ok(())
     }
@@ -118,7 +131,7 @@ enum Params {
 }
 
 #[derive(Default)]
-struct Plugin { }
+struct Plugin {}
 
 struct Instance {
     _magic: i32,
@@ -139,7 +152,12 @@ impl Default for Instance {
 }
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, in_data: InData, _: OutData) -> Result<(), Error> {
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
         // EXAMPLE. the NULL is being used to reserve an area in the custom UI for drawing the preview
         // An example of using an ARB for this for storing persistant data is in the ColorGrid example
         params.add_customized(Params::GridUI, "Preview", ae::NullDef::new(), |param| {
@@ -150,15 +168,20 @@ impl AdobePluginGlobal for Plugin {
             -1
         })?;
 
-        in_data.interact().register_ui(
-            CustomUIInfo::new()
-                .events(ae::CustomEventFlags::EFFECT)
-        )?;
+        in_data
+            .interact()
+            .register_ui(CustomUIInfo::new().events(ae::CustomEventFlags::EFFECT))?;
 
         Ok(())
     }
 
-    fn handle_command(&self, cmd: ae::Command, _in_data: InData, mut out_data: OutData, _params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        _in_data: InData,
+        mut out_data: OutData,
+        _params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("\rCopyright 2015-2023 Adobe Inc.\rHistoGrid sample.");
@@ -177,18 +200,20 @@ impl AdobePluginGlobal for Plugin {
 }
 
 impl AdobePluginInstance for Instance {
-    fn flatten(&self) -> Result<(u16, Vec<u8>), Error> {
-        Ok((1, Vec::new()))
-    }
-    fn unflatten(_version: u16, _bytes: &[u8]) -> Result<Self, Error> {
-        Ok(Self::default())
-    }
+    fn flatten(&self) -> Result<(u16, Vec<u8>), Error> { Ok((1, Vec::new())) }
 
-    fn render(&self, plugin: &mut PluginState, in_layer: &Layer, out_layer: &mut Layer) -> Result<(), ae::Error> {
-        let mut box_across     = 0;
-        let mut box_down       = 0;
-        let mut progress_base  = 0;
-        let progress_final     = BOXES_PER_GRID;
+    fn unflatten(_version: u16, _bytes: &[u8]) -> Result<Self, Error> { Ok(Self::default()) }
+
+    fn render(
+        &self,
+        plugin: &mut PluginState,
+        in_layer: &Layer,
+        out_layer: &mut Layer,
+    ) -> Result<(), ae::Error> {
+        let mut box_across = 0;
+        let mut box_down = 0;
+        let mut progress_base = 0;
+        let progress_final = BOXES_PER_GRID;
         let in_data = &plugin.in_data;
 
         let origin = in_data.pre_effect_source_origin();
@@ -209,32 +234,46 @@ impl AdobePluginInstance for Instance {
                 box_across = 0;
             }
 
-            let current_rect = ui::histogrid_get_box_in_grid(&origin,
-                (in_data.width()  as f32 * f32::from(in_data.downsample_x())).round() as usize,
+            let current_rect = ui::histogrid_get_box_in_grid(
+                &origin,
+                (in_data.width() as f32 * f32::from(in_data.downsample_x())).round() as usize,
                 (in_data.height() as f32 * f32::from(in_data.downsample_y())).round() as usize,
                 box_across,
-                box_down
+                box_down,
             );
 
             let cur_color = &color_cache.color[current_color];
-            let color8_r  = (cur_color.red   * ae::MAX_CHANNEL8 as f32) as u16;
-            let color8_g  = (cur_color.green * ae::MAX_CHANNEL8 as f32) as u16;
-            let color8_b  = (cur_color.blue  * ae::MAX_CHANNEL8 as f32) as u16;
+            let color8_r = (cur_color.red * ae::MAX_CHANNEL8 as f32) as u16;
+            let color8_g = (cur_color.green * ae::MAX_CHANNEL8 as f32) as u16;
+            let color8_b = (cur_color.blue * ae::MAX_CHANNEL8 as f32) as u16;
 
             progress_base += 1;
 
-            in_layer.iterate_with(out_layer, progress_base, progress_final as _, Some(current_rect), |_x: i32, _y: i32, pixel: ae::GenericPixel, out_pixel: ae::GenericPixelMut| -> Result<(), Error> {
-                match (pixel, out_pixel) {
-                    (ae::GenericPixel::Pixel8(pixel), ae::GenericPixelMut::Pixel8(out_pixel)) => {
-                        out_pixel.alpha = pixel.alpha as _;
-                        out_pixel.red   = ((pixel.red   as u16 + color8_r) / 2) as u8;
-                        out_pixel.green = ((pixel.green as u16 + color8_g) / 2) as u8;
-                        out_pixel.blue  = ((pixel.blue  as u16 + color8_b) / 2) as u8;
+            in_layer.iterate_with(
+                out_layer,
+                progress_base,
+                progress_final as _,
+                Some(current_rect),
+                |_x: i32,
+                 _y: i32,
+                 pixel: ae::GenericPixel,
+                 out_pixel: ae::GenericPixelMut|
+                 -> Result<(), Error> {
+                    match (pixel, out_pixel) {
+                        (
+                            ae::GenericPixel::Pixel8(pixel),
+                            ae::GenericPixelMut::Pixel8(out_pixel),
+                        ) => {
+                            out_pixel.alpha = pixel.alpha as _;
+                            out_pixel.red = ((pixel.red as u16 + color8_r) / 2) as u8;
+                            out_pixel.green = ((pixel.green as u16 + color8_g) / 2) as u8;
+                            out_pixel.blue = ((pixel.blue as u16 + color8_b) / 2) as u8;
+                        }
+                        _ => return Err(Error::BadCallbackParameter),
                     }
-                    _ => return Err(Error::BadCallbackParameter)
-                }
-                Ok(())
-            })?;
+                    Ok(())
+                },
+            )?;
 
             current_color += 1;
             box_across += 1;
@@ -243,22 +282,33 @@ impl AdobePluginInstance for Instance {
         Ok(())
     }
 
-    fn handle_command(&mut self, plugin: &mut PluginState, cmd: ae::Command) -> Result<(), ae::Error> {
+    fn handle_command(
+        &mut self,
+        plugin: &mut PluginState,
+        cmd: ae::Command,
+    ) -> Result<(), ae::Error> {
         let in_data = &plugin.in_data;
 
         match cmd {
             ae::Command::SmartPreRender { mut extra } => {
                 let req = extra.output_request();
 
-                if let Ok(in_result) = extra.callbacks().checkout_layer(0, 0, &req, in_data.current_time(), in_data.time_step(), in_data.time_scale()) {
+                if let Ok(in_result) = extra.callbacks().checkout_layer(
+                    0,
+                    0,
+                    &req,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                ) {
                     let _ = extra.union_result_rect(in_result.result_rect.into());
                     let _ = extra.union_max_result_rect(in_result.max_result_rect.into());
                 }
             }
             ae::Command::SmartRender { extra } => {
                 let mut origin = ae::Point { h: 0, v: 0 };
-                let mut box_across    = 0;
-                let mut box_down      = 0;
+                let mut box_across = 0;
+                let mut box_down = 0;
                 let mut current_color = 0;
 
                 let cb = extra.callbacks();
@@ -275,52 +325,77 @@ impl AdobePluginInstance for Instance {
                         box_across = 0;
                     }
 
-                    let current_rect = ui::histogrid_get_box_in_grid(&origin,
-                        (in_data.width()  as f32 * f32::from(in_data.downsample_x())).round() as usize,
-                        (in_data.height() as f32 * f32::from(in_data.downsample_y())).round() as usize,
+                    let current_rect = ui::histogrid_get_box_in_grid(
+                        &origin,
+                        (in_data.width() as f32 * f32::from(in_data.downsample_x())).round()
+                            as usize,
+                        (in_data.height() as f32 * f32::from(in_data.downsample_y())).round()
+                            as usize,
                         box_across,
-                        box_down
+                        box_down,
                     );
 
                     let color32 = &color_cache.color[current_color];
 
-                    let color8_r  = (color32.red   * ae::MAX_CHANNEL8  as f32) as u16;
-                    let color8_g  = (color32.green * ae::MAX_CHANNEL8  as f32) as u16;
-                    let color8_b  = (color32.blue  * ae::MAX_CHANNEL8  as f32) as u16;
+                    let color8_r = (color32.red * ae::MAX_CHANNEL8 as f32) as u16;
+                    let color8_g = (color32.green * ae::MAX_CHANNEL8 as f32) as u16;
+                    let color8_b = (color32.blue * ae::MAX_CHANNEL8 as f32) as u16;
 
-                    let color16_r = (color32.red   * ae::MAX_CHANNEL16 as f32) as u32;
+                    let color16_r = (color32.red * ae::MAX_CHANNEL16 as f32) as u32;
                     let color16_g = (color32.green * ae::MAX_CHANNEL16 as f32) as u32;
-                    let color16_b = (color32.blue  * ae::MAX_CHANNEL16 as f32) as u32;
+                    let color16_b = (color32.blue * ae::MAX_CHANNEL16 as f32) as u32;
 
                     if let Ok(Some(mut output_world)) = cb.checkout_output() {
                         let progress_final = output_world.height() as _;
 
                         origin = in_data.output_origin();
 
-                        input_world.iterate_with(&mut output_world, 0, progress_final, Some(current_rect), |_x: i32, _y: i32, pixel: ae::GenericPixel, out_pixel: ae::GenericPixelMut| -> Result<(), Error> {
-                            match (pixel, out_pixel) {
-                                (ae::GenericPixel::Pixel8(pixel), ae::GenericPixelMut::Pixel8(out_pixel)) => {
-                                    out_pixel.alpha = pixel.alpha as _;
-                                    out_pixel.red   = ((pixel.red   as u16 + color8_r) / 2) as u8;
-                                    out_pixel.green = ((pixel.green as u16 + color8_g) / 2) as u8;
-                                    out_pixel.blue  = ((pixel.blue  as u16 + color8_b) / 2) as u8;
+                        input_world.iterate_with(
+                            &mut output_world,
+                            0,
+                            progress_final,
+                            Some(current_rect),
+                            |_x: i32,
+                             _y: i32,
+                             pixel: ae::GenericPixel,
+                             out_pixel: ae::GenericPixelMut|
+                             -> Result<(), Error> {
+                                match (pixel, out_pixel) {
+                                    (
+                                        ae::GenericPixel::Pixel8(pixel),
+                                        ae::GenericPixelMut::Pixel8(out_pixel),
+                                    ) => {
+                                        out_pixel.alpha = pixel.alpha as _;
+                                        out_pixel.red = ((pixel.red as u16 + color8_r) / 2) as u8;
+                                        out_pixel.green =
+                                            ((pixel.green as u16 + color8_g) / 2) as u8;
+                                        out_pixel.blue = ((pixel.blue as u16 + color8_b) / 2) as u8;
+                                    }
+                                    (
+                                        ae::GenericPixel::Pixel16(pixel),
+                                        ae::GenericPixelMut::Pixel16(out_pixel),
+                                    ) => {
+                                        out_pixel.alpha = pixel.alpha as _;
+                                        out_pixel.red = ((pixel.red as u32 + color16_r) / 2) as u16;
+                                        out_pixel.green =
+                                            ((pixel.green as u32 + color16_g) / 2) as u16;
+                                        out_pixel.blue =
+                                            ((pixel.blue as u32 + color16_b) / 2) as u16;
+                                    }
+                                    (
+                                        ae::GenericPixel::PixelF32(pixel),
+                                        ae::GenericPixelMut::PixelF32(out_pixel),
+                                    ) => {
+                                        out_pixel.alpha = pixel.alpha as _;
+                                        out_pixel.red = (pixel.red + color32.red) / 2.0;
+                                        out_pixel.green = (pixel.green + color32.green) / 2.0;
+                                        out_pixel.blue = (pixel.blue + color32.blue) / 2.0;
+                                    }
+                                    _ => return Err(Error::BadCallbackParameter),
                                 }
-                                (ae::GenericPixel::Pixel16(pixel), ae::GenericPixelMut::Pixel16(out_pixel)) => {
-                                    out_pixel.alpha = pixel.alpha as _;
-                                    out_pixel.red   = ((pixel.red   as u32 + color16_r) / 2) as u16;
-                                    out_pixel.green = ((pixel.green as u32 + color16_g) / 2) as u16;
-                                    out_pixel.blue  = ((pixel.blue  as u32 + color16_b) / 2) as u16;
-                                }
-                                (ae::GenericPixel::PixelF32(pixel), ae::GenericPixelMut::PixelF32(out_pixel)) => {
-                                    out_pixel.alpha = pixel.alpha as _;
-                                    out_pixel.red   = (pixel.red   + color32.red)   / 2.0;
-                                    out_pixel.green = (pixel.green + color32.green) / 2.0;
-                                    out_pixel.blue  = (pixel.blue  + color32.blue)  / 2.0;
-                                }
-                                _ => return Err(Error::BadCallbackParameter)
-                            }
-                            Ok(())
-                        })?;
+                                Ok(())
+                            },
+                        )?;
                     }
                     current_color += 1;
                     box_across += 1;
@@ -333,7 +408,7 @@ impl AdobePluginInstance for Instance {
                     ui::draw(self, &in_data, &mut extra)?;
                 }
             }
-            _ => { }
+            _ => {}
         }
         Ok(())
     }

--- a/examples/histo_grid/src/ui.rs
+++ b/examples/histo_grid/src/ui.rs
@@ -1,28 +1,34 @@
 use super::*;
 
-pub fn histogrid_get_box_in_grid(origin: &ae::Point, grid_width: usize, grid_height: usize, box_across: usize, box_down: usize) -> ae::Rect {
-    let box_width  = (grid_width  / BOXES_ACROSS) as usize;
-    let box_height = (grid_height / BOXES_DOWN)   as usize;
+pub fn histogrid_get_box_in_grid(
+    origin: &ae::Point,
+    grid_width: usize,
+    grid_height: usize,
+    box_across: usize,
+    box_down: usize,
+) -> ae::Rect {
+    let box_width = (grid_width / BOXES_ACROSS) as usize;
+    let box_height = (grid_height / BOXES_DOWN) as usize;
 
     // Given the grid h+w and the box coord (0,0 through BOXES_ACROSS,BOXES_DOWN) return the rect of the box
 
-    let left = (box_width  * box_across) as i32 + origin.h;
-    let top  = (box_height * box_down)   as i32 + origin.v;
+    let left = (box_width * box_across) as i32 + origin.h;
+    let top = (box_height * box_down) as i32 + origin.v;
 
     ae::Rect {
         left,
         top,
-        right:  left + box_width as i32,
-        bottom: top  + box_height as i32,
+        right: left + box_width as i32,
+        bottom: top + box_height as i32,
     }
 }
 
 pub fn pf_to_drawbot_rect(in_rect: &ae::Rect) -> ae::drawbot::RectF32 {
     ae::drawbot::RectF32 {
-        left:   in_rect.left as f32 + 0.5,
-        top:    in_rect.top  as f32 + 0.5,
-        width:  (in_rect.right - in_rect.left) as f32,
-        height: (in_rect.bottom - in_rect.top) as f32
+        left: in_rect.left as f32 + 0.5,
+        top: in_rect.top as f32 + 0.5,
+        width: (in_rect.right - in_rect.left) as f32,
+        height: (in_rect.bottom - in_rect.top) as f32,
     }
 }
 
@@ -31,23 +37,25 @@ pub fn qd_to_drawbot_color(c: &ae::sys::PF_App_Color) -> ae::drawbot::ColorRgba 
     let inv_sixty_five_k = 1.0 / MAX_SHORT_COLOR;
 
     ae::drawbot::ColorRgba {
-        red:   c.red   as f32 * inv_sixty_five_k,
+        red: c.red as f32 * inv_sixty_five_k,
         green: c.green as f32 * inv_sixty_five_k,
-        blue:  c.blue  as f32 * inv_sixty_five_k,
+        blue: c.blue as f32 * inv_sixty_five_k,
         alpha: 1.0,
     }
 }
 
 pub fn acquire_background_color() -> Result<ae::drawbot::ColorRgba, ae::Error> {
     Ok(qd_to_drawbot_color(
-        &ae::pf::suites::App::new()?
-            .bg_color()?
+        &ae::pf::suites::App::new()?.bg_color()?,
     ))
 }
 
 // EXAMPLE: This requests the upstream input frame for lightweight preview purposes, but highly downsampled for speed
 // The frame may not be immediately available. PF_Event_DRAW will get triggered again when async render completes
-pub fn request_async_frame_for_preview(in_data: &ae::InData, event: &ae::EventExtra) -> Result<ae::sys::AEGP_FrameReceiptH, ae::Error> {
+pub fn request_async_frame_for_preview(
+    in_data: &ae::InData,
+    event: &ae::EventExtra,
+) -> Result<ae::sys::AEGP_FrameReceiptH, ae::Error> {
     let aegp_plugin_id = unsafe { super::AEGP_PLUGIN_ID };
 
     // get render options description of upstream input frame to effect
@@ -67,12 +75,16 @@ pub fn request_async_frame_for_preview(in_data: &ae::InData, event: &ae::EventEx
     Ok(async_mgr.checkout_or_render_layer_frame_async_manager(PURPOSE1, layer_rops)?)
 }
 
-pub fn draw(seq: &mut Instance, in_data: &ae::InData, event: &mut ae::EventExtra) -> Result<(), ae::Error> {
+pub fn draw(
+    seq: &mut Instance,
+    in_data: &ae::InData,
+    event: &mut ae::EventExtra,
+) -> Result<(), ae::Error> {
     let mut origin = ae::Point { v: 0, h: 0 };
-    let mut grid_width  = 0;
+    let mut grid_width = 0;
     let mut grid_height = 0;
-    let mut box_across  = 0;
-    let mut box_down    = 0;
+    let mut box_across = 0;
+    let mut box_down = 0;
 
     let drawbot = event.context_handle().drawing_reference()?;
     let supplier = drawbot.supplier()?;
@@ -84,10 +96,10 @@ pub fn draw(seq: &mut Instance, in_data: &ae::InData, event: &mut ae::EventExtra
         let current_frame = event.current_frame();
         // Use to fill background with AE's BG color
         let onscreen_rect = ae::drawbot::RectF32 {
-            left:   current_frame.left   as f32,
-            top:    current_frame.top    as f32,
-            width:  current_frame.right  as f32 - current_frame.left as f32,
-            height: current_frame.bottom as f32 - current_frame.top  as f32 + 1.0,
+            left: current_frame.left as f32,
+            top: current_frame.top as f32,
+            width: current_frame.right as f32 - current_frame.left as f32,
+            height: current_frame.bottom as f32 - current_frame.top as f32 + 1.0,
         };
         origin = ae::Point {
             v: onscreen_rect.top as _,
@@ -96,7 +108,7 @@ pub fn draw(seq: &mut Instance, in_data: &ae::InData, event: &mut ae::EventExtra
 
         // Calculate the space taken up by the grid
         // Allow the width to scale horizontally, but not too much
-        grid_width  = onscreen_rect.width as _;
+        grid_width = onscreen_rect.width as _;
         grid_height = onscreen_rect.height as _;
         if (grid_width as f32) < UI_GRID_WIDTH as f32 / 1.5 {
             grid_width = (UI_GRID_WIDTH as f32 / 1.5) as _;
@@ -115,8 +127,12 @@ pub fn draw(seq: &mut Instance, in_data: &ae::InData, event: &mut ae::EventExtra
                 let r_suite = ae::aegp::suites::Render::new()?;
 
                 let world = r_suite.receipt_world(frame_receipt)?;
-                if !world.is_null() { // receipt could be valid but empty
-                    seq.color_cache.compute_color_grid_from_frame(&ae::Layer::from_aegp_world(in_data, world)?)?;
+                if !world.is_null() {
+                    // receipt could be valid but empty
+                    seq.color_cache
+                        .compute_color_grid_from_frame(&ae::Layer::from_aegp_world(
+                            in_data, world,
+                        )?)?;
                     seq.valid = true;
                 }
                 r_suite.checkin_frame(frame_receipt)?;
@@ -129,19 +145,21 @@ pub fn draw(seq: &mut Instance, in_data: &ae::InData, event: &mut ae::EventExtra
 
     // Draw the color grid using the cached color preview (if valid)
     if seq.valid {
-        let mut pixel_colr: [ae::drawbot::ColorRgba; CACHE_ELEMENTS] = unsafe { std::mem::zeroed() };
+        let mut pixel_colr: [ae::drawbot::ColorRgba; CACHE_ELEMENTS] =
+            unsafe { std::mem::zeroed() };
         let colors = &seq.color_cache.color;
 
         for i in 0..CACHE_ELEMENTS {
-            pixel_colr[i].red   = colors[i].red;
+            pixel_colr[i].red = colors[i].red;
             pixel_colr[i].green = colors[i].green;
-            pixel_colr[i].blue  = colors[i].blue;
+            pixel_colr[i].blue = colors[i].blue;
             pixel_colr[i].alpha = 1.0;
         }
 
         for i in 0..BOXES_PER_GRID {
             // Fill in our grid
-            let box_rect = histogrid_get_box_in_grid(&origin, grid_width, grid_height, box_across, box_down);
+            let box_rect =
+                histogrid_get_box_in_grid(&origin, grid_width, grid_height, box_across, box_down);
 
             let mut path = supplier.new_path()?;
             path.add_rounded_rect(&pf_to_drawbot_rect(&box_rect), 5.0)?;
@@ -158,13 +176,19 @@ pub fn draw(seq: &mut Instance, in_data: &ae::InData, event: &mut ae::EventExtra
         }
     }
 
-    let black_color = ae::drawbot::ColorRgba { red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0 };
+    let black_color = ae::drawbot::ColorRgba {
+        red: 0.0,
+        green: 0.0,
+        blue: 0.0,
+        alpha: 1.0,
+    };
     let pen = supplier.new_pen(&black_color, 1.0)?;
 
     // Draw the grid - outline
     for box_down in 0..BOXES_DOWN {
         for box_across in 0..BOXES_ACROSS {
-            let box_rect = histogrid_get_box_in_grid(&origin, grid_width, grid_height, box_across, box_down);
+            let box_rect =
+                histogrid_get_box_in_grid(&origin, grid_width, grid_height, box_across, box_down);
 
             let mut path = supplier.new_path()?;
             path.add_rounded_rect(&pf_to_drawbot_rect(&box_rect), 5.0)?;

--- a/examples/paramarama/src/lib.rs
+++ b/examples/paramarama/src/lib.rs
@@ -2,18 +2,18 @@ use after_effects as ae;
 
 // This sample exercises some of After Effects' image processing callback functions.
 
-const PARAMARAMA_AMOUNT_MIN:  i32 = 0;
-const PARAMARAMA_AMOUNT_MAX:  i32 = 100;
+const PARAMARAMA_AMOUNT_MIN: i32 = 0;
+const PARAMARAMA_AMOUNT_MAX: i32 = 100;
 const PARAMARAMA_AMOUNT_DFLT: i32 = 93;
-const DEFAULT_RED:            u8 = 111;
-const DEFAULT_GREEN:          u8 = 222;
-const DEFAULT_BLUE:           u8 = 33;
-const DEFAULT_FLOAT_VAL:      f64 = 27.62;
-const DEFAULT_ANGLE_VAL:      f32 = 35.5;
-const FLOAT_MIN:              f32 = 2.387;
-const FLOAT_MAX:              f32 = 987.653;
-const DEFAULT_POINT_VALS:     f64 = 50.0;
-const KERNEL_SIZE:            i32 = 3;
+const DEFAULT_RED: u8 = 111;
+const DEFAULT_GREEN: u8 = 222;
+const DEFAULT_BLUE: u8 = 33;
+const DEFAULT_FLOAT_VAL: f64 = 27.62;
+const DEFAULT_ANGLE_VAL: f32 = 35.5;
+const FLOAT_MIN: f32 = 2.387;
+const FLOAT_MAX: f32 = 987.653;
+const DEFAULT_POINT_VALS: f64 = 50.0;
+const KERNEL_SIZE: i32 = 3;
 const AEFX_AUDIO_DEFAULT_CURVE_TOLERANCE: f32 = 0.05;
 
 #[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
@@ -30,74 +30,119 @@ enum Params {
 }
 
 #[derive(Default)]
-struct Plugin { }
+struct Plugin {}
 
 ae::define_effect!(Plugin, (), Params);
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, in_data: InData, _: OutData) -> Result<(), Error> {
-        params.add(Params::Amount, "An obsolete slider", ae::SliderDef::setup(|f| {
-            f.set_valid_min(PARAMARAMA_AMOUNT_MIN);
-            f.set_valid_max(PARAMARAMA_AMOUNT_MAX);
-            f.set_slider_min(PARAMARAMA_AMOUNT_MIN);
-            f.set_slider_max(PARAMARAMA_AMOUNT_MAX);
-            f.set_default(PARAMARAMA_AMOUNT_DFLT);
-            f.set_value(f.default());
-        }))?;
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        params.add(
+            Params::Amount,
+            "An obsolete slider",
+            ae::SliderDef::setup(|f| {
+                f.set_valid_min(PARAMARAMA_AMOUNT_MIN);
+                f.set_valid_max(PARAMARAMA_AMOUNT_MAX);
+                f.set_slider_min(PARAMARAMA_AMOUNT_MIN);
+                f.set_slider_max(PARAMARAMA_AMOUNT_MAX);
+                f.set_default(PARAMARAMA_AMOUNT_DFLT);
+                f.set_value(f.default());
+            }),
+        )?;
 
-        params.add(Params::Color, "Color to mix", ae::ColorDef::setup(|f| {
-            f.set_default(ae::Pixel8 {
-                red:   DEFAULT_RED,
-                green: DEFAULT_GREEN,
-                blue:  DEFAULT_BLUE,
-                alpha: 255
-            });
-            f.set_value(f.default());
-        }))?;
+        params.add(
+            Params::Color,
+            "Color to mix",
+            ae::ColorDef::setup(|f| {
+                f.set_default(ae::Pixel8 {
+                    red: DEFAULT_RED,
+                    green: DEFAULT_GREEN,
+                    blue: DEFAULT_BLUE,
+                    alpha: 255,
+                });
+                f.set_value(f.default());
+            }),
+        )?;
 
-        params.add(Params::FloatVal, "Some float value", ae::FloatSliderDef::setup(|f| {
-            f.set_valid_min(FLOAT_MIN);
-            f.set_valid_max(FLOAT_MAX);
-            f.set_slider_min(FLOAT_MIN);
-            f.set_slider_max(FLOAT_MAX);
-            f.set_default(DEFAULT_FLOAT_VAL);
-            f.set_curve_tolerance(AEFX_AUDIO_DEFAULT_CURVE_TOLERANCE);
-            f.set_flags(ae::FSliderFlag::WANT_PHASE);
-            f.set_value(f.default());
-        }))?;
+        params.add(
+            Params::FloatVal,
+            "Some float value",
+            ae::FloatSliderDef::setup(|f| {
+                f.set_valid_min(FLOAT_MIN);
+                f.set_valid_max(FLOAT_MAX);
+                f.set_slider_min(FLOAT_MIN);
+                f.set_slider_max(FLOAT_MAX);
+                f.set_default(DEFAULT_FLOAT_VAL);
+                f.set_curve_tolerance(AEFX_AUDIO_DEFAULT_CURVE_TOLERANCE);
+                f.set_flags(ae::FSliderFlag::WANT_PHASE);
+                f.set_value(f.default());
+            }),
+        )?;
 
-        params.add(Params::Downsample, "Some checkbox", ae::CheckBoxDef::setup(|f| {
-            f.set_default(false);
-            f.set_label("(with comment!)");
-            f.set_value(f.default());
-        }))?;
+        params.add(
+            Params::Downsample,
+            "Some checkbox",
+            ae::CheckBoxDef::setup(|f| {
+                f.set_default(false);
+                f.set_label("(with comment!)");
+                f.set_value(f.default());
+            }),
+        )?;
 
-        params.add(Params::Angle, "An angle control", ae::AngleDef::setup(|f| {
-            f.set_default(DEFAULT_ANGLE_VAL);
-            f.set_value(f.default());
-        }))?;
+        params.add(
+            Params::Angle,
+            "An angle control",
+            ae::AngleDef::setup(|f| {
+                f.set_default(DEFAULT_ANGLE_VAL);
+                f.set_value(f.default());
+            }),
+        )?;
 
-        params.add(Params::Popup, "Pop-up param", ae::PopupDef::setup(|f| {
-            f.set_options(&["Make Slower", "Make Jaggy", "(-", "Plan A", "Plan B"]);
-            f.set_default(1);
-            f.set_value(f.default());
-        }))?;
+        params.add(
+            Params::Popup,
+            "Pop-up param",
+            ae::PopupDef::setup(|f| {
+                f.set_options(&["Make Slower", "Make Jaggy", "(-", "Plan A", "Plan B"]);
+                f.set_default(1);
+                f.set_value(f.default());
+            }),
+        )?;
 
         // Only add 3D point and button where supported, starting in AE CS5.5
-        if in_data.version().0 >= ae::sys::PF_AE105_PLUG_IN_VERSION as _ && in_data.version().1 >= ae::sys::PF_AE105_PLUG_IN_SUBVERS as _ {
+        if in_data.version().0 >= ae::sys::PF_AE105_PLUG_IN_VERSION as _
+            && in_data.version().1 >= ae::sys::PF_AE105_PLUG_IN_SUBVERS as _
+        {
             if in_data.application_id() == *b"FXTC" {
-                params.add(Params::Point3D, "3D Point", ae::Point3DDef::setup(|f| {
-                    f.set_default((DEFAULT_POINT_VALS, DEFAULT_POINT_VALS, DEFAULT_POINT_VALS));
-                    f.set_value(f.default());
-                }))?;
+                params.add(
+                    Params::Point3D,
+                    "3D Point",
+                    ae::Point3DDef::setup(|f| {
+                        f.set_default((DEFAULT_POINT_VALS, DEFAULT_POINT_VALS, DEFAULT_POINT_VALS));
+                        f.set_value(f.default());
+                    }),
+                )?;
             } else {
                 // Add a placeholder for hosts that don't support 3D points
-                params.add_with_flags(Params::Point3D, "3D Point", ae::ArbitraryDef::new(), ae::ParamFlag::empty(), ae::ParamUIFlags::NO_ECW_UI)?;
+                params.add_with_flags(
+                    Params::Point3D,
+                    "3D Point",
+                    ae::ArbitraryDef::new(),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::NO_ECW_UI,
+                )?;
             }
 
-            params.add(Params::Button, "Button", ae::ButtonDef::setup(|f| {
-                f.set_label("Button Label");
-            }))?;
+            params.add(
+                Params::Button,
+                "Button",
+                ae::ButtonDef::setup(|f| {
+                    f.set_label("Button Label");
+                }),
+            )?;
 
             params.add(Params::Layer, "Layer", ae::LayerDef::new())?;
         }
@@ -105,21 +150,43 @@ impl AdobePluginGlobal for Plugin {
         Ok(())
     }
 
-    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Paramarama, v2.1,\rParameter Party!\rExercising all parameter types.\rCopyright 2007-2023 Adobe Inc.");
             }
-            ae::Command::Render { in_layer, mut out_layer } => {
-                let sharpen = (params.get(Params::Amount)?.as_slider()?.value() as f32 / 16.0).ceil();
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
+                let sharpen =
+                    (params.get(Params::Amount)?.as_slider()?.value() as f32 / 16.0).ceil();
 
                 // If sharpen is set to 0, just copy the source to the destination
                 if sharpen == 0.0 {
                     // Premiere Pro/Elements doesn't support WorldTransformSuite1, but it does support many of the callbacks in utils
                     if in_data.quality() == ae::Quality::Hi && !in_data.is_premiere() {
-                        ae::pf::suites::WorldTransform::new()?.copy_hq(in_data.effect_ref(), in_layer, out_layer, None, None)?;
+                        ae::pf::suites::WorldTransform::new()?.copy_hq(
+                            in_data.effect_ref(),
+                            in_layer,
+                            out_layer,
+                            None,
+                            None,
+                        )?;
                     } else if !in_data.is_premiere() {
-                        ae::pf::suites::WorldTransform::new()?.copy(in_data.effect_ref(), in_layer, out_layer, None, None)?;
+                        ae::pf::suites::WorldTransform::new()?.copy(
+                            in_data.effect_ref(),
+                            in_layer,
+                            out_layer,
+                            None,
+                            None,
+                        )?;
                     } else {
                         out_layer.copy_from(&in_layer, None, None)?;
                     }
@@ -147,7 +214,7 @@ impl AdobePluginGlobal for Plugin {
                             kernel_ptr,
                             kernel_ptr,
                             kernel_ptr,
-                            &mut out_layer
+                            &mut out_layer,
                         )?;
                     } else {
                         in_data.utils().convolve(
@@ -159,7 +226,7 @@ impl AdobePluginGlobal for Plugin {
                             kernel_ptr,
                             kernel_ptr,
                             kernel_ptr,
-                            &mut out_layer
+                            &mut out_layer,
                         )?;
                     }
                 }

--- a/examples/persisto/src/lib.rs
+++ b/examples/persisto/src/lib.rs
@@ -161,13 +161,8 @@ fn demonstrate_persistence_features(
 
     log::debug!("Inserted string `Persisto Demo` into `name` --- retrieved: {string}");
 
-    let string = persistent_suite.string(
-        blob,
-        demo_section,
-        "utf-8",
-        "Error - Key should exist",
-        256,
-    )?;
+    let string =
+        persistent_suite.string(blob, demo_section, "utf-8", "Error - Key should exist", 256)?;
 
     log::debug!("Inserted string `utf-8 牛奶` into key `utf-8` --- retrieved: {string}");
 

--- a/examples/portable/src/lib.rs
+++ b/examples/portable/src/lib.rs
@@ -81,20 +81,35 @@ fn detect_host(in_data: ae::InData) -> String {
 }
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, _in_data: InData, _out_data: OutData) -> Result<(), Error> {
-        params.add(Params::MixChannels, "Mix channels", ae::FloatSliderDef::setup(|f| {
-            f.set_valid_min(0.0);
-            f.set_slider_min(0.0);
-            f.set_valid_max(200.0);
-            f.set_slider_max(200.0);
-            f.set_value(10.0);
-            f.set_default(10.0);
-            f.set_precision(1);
-            f.set_display_flags(ae::ValueDisplayFlag::PERCENT);
-        }))
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _in_data: InData,
+        _out_data: OutData,
+    ) -> Result<(), Error> {
+        params.add(
+            Params::MixChannels,
+            "Mix channels",
+            ae::FloatSliderDef::setup(|f| {
+                f.set_valid_min(0.0);
+                f.set_slider_min(0.0);
+                f.set_valid_max(200.0);
+                f.set_slider_max(200.0);
+                f.set_value(10.0);
+                f.set_default(10.0);
+                f.set_precision(1);
+                f.set_display_flags(ae::ValueDisplayFlag::PERCENT);
+            }),
+        )
     }
 
-    fn handle_command(&self, cmd: ae::Command, in_data: ae::InData, mut out_data: ae::OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        in_data: ae::InData,
+        mut out_data: ae::OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Portable, v3.3\rThis example shows how to detect and respond to different hosts.\rCopyright 2007-2023 Adobe Inc.");
@@ -102,8 +117,12 @@ impl AdobePluginGlobal for Plugin {
             ae::Command::SequenceSetup => {
                 out_data.set_return_msg(&detect_host(in_data));
             }
-            ae::Command::Render { in_layer, mut out_layer } => {
-                let slider_value = params.get(Params::MixChannels)?.as_float_slider()?.value() as f32;
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
+                let slider_value =
+                    params.get(Params::MixChannels)?.as_float_slider()?.value() as f32;
 
                 // If the slider is 0 just make a direct copy.
                 if slider_value < 0.001 {

--- a/examples/resizer/src/lib.rs
+++ b/examples/resizer/src/lib.rs
@@ -3,8 +3,8 @@ use after_effects as ae;
 // This sample shows how to resize the output buffer to prevent clipping the edges of an effect (or just to scale the source).
 // The resizing occurs during the response to PF_Cmd_FRAME_SETUP.
 
-const RESIZE_AMOUNT_MIN:  i32 = 0;
-const RESIZE_AMOUNT_MAX:  i32 = 100;
+const RESIZE_AMOUNT_MIN: i32 = 0;
+const RESIZE_AMOUNT_MAX: i32 = 100;
 const RESIZE_AMOUNT_DFLT: i32 = 50;
 
 #[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
@@ -16,50 +16,79 @@ enum Params {
 }
 
 #[derive(Default)]
-struct Plugin { }
+struct Plugin {}
 
 ae::define_effect!(Plugin, (), Params);
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, in_data: InData, _: OutData) -> Result<(), Error> {
-        params.add(Params::Amount, "Resizer", ae::SliderDef::setup(|f| {
-            f.set_valid_min(RESIZE_AMOUNT_MIN);
-            f.set_valid_max(RESIZE_AMOUNT_MAX);
-            f.set_slider_min(RESIZE_AMOUNT_MIN);
-            f.set_slider_max(RESIZE_AMOUNT_MAX);
-            f.set_default(RESIZE_AMOUNT_DFLT);
-            f.set_value(f.default());
-        }))?;
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        params.add(
+            Params::Amount,
+            "Resizer",
+            ae::SliderDef::setup(|f| {
+                f.set_valid_min(RESIZE_AMOUNT_MIN);
+                f.set_valid_max(RESIZE_AMOUNT_MAX);
+                f.set_slider_min(RESIZE_AMOUNT_MIN);
+                f.set_slider_max(RESIZE_AMOUNT_MAX);
+                f.set_default(RESIZE_AMOUNT_DFLT);
+                f.set_value(f.default());
+            }),
+        )?;
 
-        params.add(Params::Color, "Resized Area Color", ae::ColorDef::setup(|f| {
-            f.set_default(ae::Pixel8 {
-                red:   128,
-                green: 255,
-                blue:  255,
-                alpha: 255
-            });
-            f.set_value(f.default());
-        }))?;
+        params.add(
+            Params::Color,
+            "Resized Area Color",
+            ae::ColorDef::setup(|f| {
+                f.set_default(ae::Pixel8 {
+                    red: 128,
+                    green: 255,
+                    blue: 255,
+                    alpha: 255,
+                });
+                f.set_value(f.default());
+            }),
+        )?;
 
-        params.add_with_flags(Params::Downsample, "Use Downsample Factors", ae::CheckBoxDef::setup(|f| {
-            f.set_default(true);
-            f.set_label("Correct at all resolutions");
-            f.set_value(false); // value for legacy projects which did not have this param
-        }), ae::ParamFlag::USE_VALUE_FOR_OLD_PROJECTS, ae::ParamUIFlags::empty())?;
+        params.add_with_flags(
+            Params::Downsample,
+            "Use Downsample Factors",
+            ae::CheckBoxDef::setup(|f| {
+                f.set_default(true);
+                f.set_label("Correct at all resolutions");
+                f.set_value(false); // value for legacy projects which did not have this param
+            }),
+            ae::ParamFlag::USE_VALUE_FOR_OLD_PROJECTS,
+            ae::ParamUIFlags::empty(),
+        )?;
 
         // Don't expose 3D capabilities in PPro, since they are unsupported
         if !in_data.is_premiere() {
-            params.add(Params::Use3D, "Use lights and cameras", ae::CheckBoxDef::setup(|f| {
-                f.set_default(false);
-                f.set_label("(new in 5.0!)");
-                f.set_value(false);
-            }))?;
+            params.add(
+                Params::Use3D,
+                "Use lights and cameras",
+                ae::CheckBoxDef::setup(|f| {
+                    f.set_default(false);
+                    f.set_label("(new in 5.0!)");
+                    f.set_value(false);
+                }),
+            )?;
         }
 
         Ok(())
     }
 
-    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Resizer, v2.4,\rDemonstrate Output Buffer Resizing.\rCopyright 1994-2023 Adobe Inc.");
@@ -68,27 +97,31 @@ impl AdobePluginGlobal for Plugin {
                 // Output buffer resizing may only occur during PF_Cmd_FRAME_SETUP.
                 let border = params.get(Params::Amount)?.as_slider()?.value() as f32;
 
-                let (border_x, border_y) = if params.get(Params::Downsample)?.as_checkbox()?.value() {
+                let (border_x, border_y) = if params.get(Params::Downsample)?.as_checkbox()?.value()
+                {
                     // shrink the border to accomodate decreased resolutions.
                     (
                         border * f32::from(in_data.downsample_x()),
-                        border * f32::from(in_data.downsample_y())
+                        border * f32::from(in_data.downsample_y()),
                     )
                 } else {
                     (border, border)
                 };
 
                 // add 2 times the border width and height to the input width and height to get the output size.
-                out_data.set_width( (2.0 * border_x + in_layer.width()  as f32).round() as _);
+                out_data.set_width((2.0 * border_x + in_layer.width() as f32).round() as _);
                 out_data.set_height((2.0 * border_y + in_layer.height() as f32).round() as _);
 
                 // The origin of the input buffer corresponds to the (border_x, border_y) pixel in the output buffer.
                 out_data.set_origin(ae::Point {
                     h: border_x as _,
-                    v: border_y as _
+                    v: border_y as _,
                 });
-            },
-            ae::Command::Render { in_layer, mut out_layer } => {
+            }
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
                 let border = params.get(Params::Amount)?.as_slider()?.value() as f32;
 
                 let origin_pt = in_data.output_origin();
@@ -99,17 +132,31 @@ impl AdobePluginGlobal for Plugin {
                 if !in_data.is_premiere() && params.get(Params::Use3D)?.as_checkbox()?.value() {
                     // if we're paying attention to the camera
                     let effect = in_data.effect();
-                    let comp_time = effect.comp_time(in_data.current_time(), in_data.time_scale())?;
+                    let comp_time =
+                        effect.comp_time(in_data.current_time(), in_data.time_scale())?;
 
                     let camera_layer = effect.camera(comp_time)?;
                     if let Some(camera_layer) = camera_layer {
-                        log::info!("camera matrix: {:?}", camera_layer.to_world_xform(comp_time));
+                        log::info!(
+                            "camera matrix: {:?}",
+                            camera_layer.to_world_xform(comp_time)
+                        );
 
-                        if let Ok(stream_val) = camera_layer.layer_stream_value(aegp::LayerStream::Zoom, aegp::TimeMode::CompTime, comp_time, false) {
+                        if let Ok(stream_val) = camera_layer.layer_stream_value(
+                            aegp::LayerStream::Zoom,
+                            aegp::TimeMode::CompTime,
+                            comp_time,
+                            false,
+                        ) {
                             let focal_length: f64 = stream_val.try_into().unwrap();
                             log::info!("focal_length: {focal_length}");
                         }
-                        if let Ok(aperture) = camera_layer.layer_stream_value(aegp::LayerStream::Aperture, aegp::TimeMode::CompTime, comp_time, false) {
+                        if let Ok(aperture) = camera_layer.layer_stream_value(
+                            aegp::LayerStream::Aperture,
+                            aegp::TimeMode::CompTime,
+                            comp_time,
+                            false,
+                        ) {
                             log::info!("aperture: {aperture:?}");
                         }
                         if let Ok(effect_layer) = effect.layer() {
@@ -130,11 +177,12 @@ impl AdobePluginGlobal for Plugin {
                 }
 
                 // For PPro, since effects operate on the sequence rectangle, not the clip rectangle, we need to take care to color the proper area
-                let (border_x, border_y) = if params.get(Params::Downsample)?.as_checkbox()?.value() {
+                let (border_x, border_y) = if params.get(Params::Downsample)?.as_checkbox()?.value()
+                {
                     // shrink the border to accomodate decreased resolutions.
                     (
                         border * f32::from(in_data.downsample_x()),
-                        border * f32::from(in_data.downsample_y())
+                        border * f32::from(in_data.downsample_y()),
                     )
                 } else {
                     (border, border)
@@ -144,65 +192,75 @@ impl AdobePluginGlobal for Plugin {
 
                 let rect = if in_data.is_premiere() {
                     Some(ae::Rect {
-                        left:   pre_effect_origin.h,
-                        top:    pre_effect_origin.v,
-                        right:  pre_effect_origin.h + in_data.width()  + 2 * border_x as i32,
-                        bottom: pre_effect_origin.v + in_data.height() + 2 * border_y as i32
+                        left: pre_effect_origin.h,
+                        top: pre_effect_origin.v,
+                        right: pre_effect_origin.h + in_data.width() + 2 * border_x as i32,
+                        bottom: pre_effect_origin.v + in_data.height() + 2 * border_y as i32,
                     })
                 } else {
                     None
                 };
 
                 match out_layer.bit_depth() {
-                    8  => out_layer.fill(Some(color), rect)?,
+                    8 => out_layer.fill(Some(color), rect)?,
                     16 => out_layer.fill16(Some(ae::pixel8_to_16(color)), rect)?,
                     _ => {}
                 }
 
                 // Now, copy the input frame
                 let dst_rect = ae::Rect {
-                    left:   origin_pt.h,
-                    top:    origin_pt.v,
-                    right:  origin_pt.h + in_layer.width()  as i32,
-                    bottom: origin_pt.v + in_layer.height() as i32
+                    left: origin_pt.h,
+                    top: origin_pt.v,
+                    right: origin_pt.h + in_layer.width() as i32,
+                    bottom: origin_pt.v + in_layer.height() as i32,
                 };
 
                 // The suite functions do not automatically detect the requested output quality. Call different functions based on the current quality state.
                 if in_data.quality() == ae::Quality::Hi && !in_data.is_premiere() {
-                    ae::pf::suites::WorldTransform::new()?.copy_hq(in_data.effect_ref(), in_layer, out_layer, None, Some(dst_rect))?;
+                    ae::pf::suites::WorldTransform::new()?.copy_hq(
+                        in_data.effect_ref(),
+                        in_layer,
+                        out_layer,
+                        None,
+                        Some(dst_rect),
+                    )?;
                 } else if !in_data.is_premiere() {
-                    ae::pf::suites::WorldTransform::new()?.copy(in_data.effect_ref(), in_layer, out_layer, None, Some(dst_rect))?;
+                    ae::pf::suites::WorldTransform::new()?.copy(
+                        in_data.effect_ref(),
+                        in_layer,
+                        out_layer,
+                        None,
+                        Some(dst_rect),
+                    )?;
                 } else {
                     let src_rect = ae::Rect {
-                        left:   pre_effect_origin.h,
-                        top:    pre_effect_origin.v,
-                        right:  pre_effect_origin.h + in_data.width() ,
-                        bottom: pre_effect_origin.v + in_data.height()
+                        left: pre_effect_origin.h,
+                        top: pre_effect_origin.v,
+                        right: pre_effect_origin.h + in_data.width(),
+                        bottom: pre_effect_origin.v + in_data.height(),
                     };
 
                     let dst_rect = ae::Rect {
-                        left:   pre_effect_origin.h + border_x as i32,
-                        top:    pre_effect_origin.v + border_y as i32,
-                        right:  pre_effect_origin.h + in_data.width()  + border_x as i32,
-                        bottom: pre_effect_origin.v + in_data.height() + border_y as i32
+                        left: pre_effect_origin.h + border_x as i32,
+                        top: pre_effect_origin.v + border_y as i32,
+                        right: pre_effect_origin.h + in_data.width() + border_x as i32,
+                        bottom: pre_effect_origin.v + in_data.height() + border_y as i32,
                     };
 
                     out_layer.copy_from(&in_layer, Some(src_rect), Some(dst_rect))?;
                 }
             }
-            ae::Command::GetExternalDependencies { mut extra } => {
-                match extra.check_type() {
-                    ae::DepCheckType::AllDependencies => {
-                        extra.set_dependencies_str("All Dependencies requested.")?;
-                    }
-                    ae::DepCheckType::MissingDependencies => {
-                        extra.set_dependencies_str("Missing Dependencies requested.")?;
-                    }
-                    _ => {
-                        extra.set_dependencies_str("None")?;
-                    }
+            ae::Command::GetExternalDependencies { mut extra } => match extra.check_type() {
+                ae::DepCheckType::AllDependencies => {
+                    extra.set_dependencies_str("All Dependencies requested.")?;
                 }
-            }
+                ae::DepCheckType::MissingDependencies => {
+                    extra.set_dependencies_str("Missing Dependencies requested.")?;
+                }
+                _ => {
+                    extra.set_dependencies_str("None")?;
+                }
+            },
             ae::Command::QueryDynamicFlags => {
                 // The parameter array passed with PF_Cmd_QUERY_DYNAMIC_FLAGS contains invalid values; use PF_CHECKOUT_PARAM() to obtain valid values.
                 let use_3d = params.checkout(Params::Use3D)?.as_checkbox()?.value();
@@ -217,24 +275,32 @@ impl AdobePluginGlobal for Plugin {
                 // Output buffer resizing may only occur during PF_Cmd_FRAME_SETUP.
                 let border = params.get(Params::Amount)?.as_slider()?.value() as f32;
 
-                let (border_x, border_y) = if params.get(Params::Downsample)?.as_checkbox()?.value() {
+                let (border_x, border_y) = if params.get(Params::Downsample)?.as_checkbox()?.value()
+                {
                     // shrink the border to accomodate decreased resolutions.
                     (
                         border * f32::from(in_data.downsample_x()),
-                        border * f32::from(in_data.downsample_y())
+                        border * f32::from(in_data.downsample_y()),
                     )
                 } else {
                     (border, border)
                 };
 
-                if let Ok(in_result) = extra.callbacks().checkout_layer(0, 0, &req, in_data.current_time(), in_data.time_step(), in_data.time_scale()) {
+                if let Ok(in_result) = extra.callbacks().checkout_layer(
+                    0,
+                    0,
+                    &req,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                ) {
                     let mut res_rect = ae::Rect::from(in_result.result_rect);
                     res_rect.set_origin(ae::Point {
                         h: -border_x as _,
-                        v: -border_y as _
+                        v: -border_y as _,
                     });
 
-                    res_rect.set_width( (border_x + res_rect.width()  as f32).round() as _);
+                    res_rect.set_width((border_x + res_rect.width() as f32).round() as _);
                     res_rect.set_height((border_y + res_rect.height() as f32).round() as _);
 
                     let _ = extra.union_result_rect(res_rect);
@@ -255,66 +321,79 @@ impl AdobePluginGlobal for Plugin {
                     let color = params.get(Params::Color)?.as_color()?.value();
 
                     // For PPro, since effects operate on the sequence rectangle, not the clip rectangle, we need to take care to color the proper area
-                    let (border_x, border_y) = if params.get(Params::Downsample)?.as_checkbox()?.value() {
-                        // shrink the border to accomodate decreased resolutions.
-                        (
-                            border * f32::from(in_data.downsample_x()),
-                            border * f32::from(in_data.downsample_y())
-                        )
-                    } else {
-                        (border, border)
-                    };
+                    let (border_x, border_y) =
+                        if params.get(Params::Downsample)?.as_checkbox()?.value() {
+                            // shrink the border to accomodate decreased resolutions.
+                            (
+                                border * f32::from(in_data.downsample_x()),
+                                border * f32::from(in_data.downsample_y()),
+                            )
+                        } else {
+                            (border, border)
+                        };
 
                     let origin_pt = ae::Point {
                         h: border_x as _,
-                        v: border_y as _
+                        v: border_y as _,
                     };
 
                     let pre_effect_origin = in_data.pre_effect_source_origin();
 
                     let rect = if in_data.is_premiere() {
                         Some(ae::Rect {
-                            left:   pre_effect_origin.h,
-                            top:    pre_effect_origin.v,
-                            right:  pre_effect_origin.h + in_data.width()  + 2 * border_x as i32,
-                            bottom: pre_effect_origin.v + in_data.height() + 2 * border_y as i32
+                            left: pre_effect_origin.h,
+                            top: pre_effect_origin.v,
+                            right: pre_effect_origin.h + in_data.width() + 2 * border_x as i32,
+                            bottom: pre_effect_origin.v + in_data.height() + 2 * border_y as i32,
                         })
                     } else {
                         None
                     };
 
                     match out_layer.bit_depth() {
-                        8  => out_layer.fill(Some(color), rect)?,
+                        8 => out_layer.fill(Some(color), rect)?,
                         16 => out_layer.fill16(Some(ae::pixel8_to_16(color)), rect)?,
                         _ => {}
                     }
 
                     // Now, copy the input frame
                     let dst_rect = ae::Rect {
-                        left:   origin_pt.h,
-                        top:    origin_pt.v,
-                        right:  origin_pt.h + in_layer.width()  as i32,
-                        bottom: origin_pt.v + in_layer.height() as i32
+                        left: origin_pt.h,
+                        top: origin_pt.v,
+                        right: origin_pt.h + in_layer.width() as i32,
+                        bottom: origin_pt.v + in_layer.height() as i32,
                     };
 
                     // The suite functions do not automatically detect the requested output quality. Call different functions based on the current quality state.
                     if in_data.quality() == ae::Quality::Hi && !in_data.is_premiere() {
-                        ae::pf::suites::WorldTransform::new()?.copy_hq(in_data.effect_ref(), in_layer, out_layer, None, Some(dst_rect))?;
+                        ae::pf::suites::WorldTransform::new()?.copy_hq(
+                            in_data.effect_ref(),
+                            in_layer,
+                            out_layer,
+                            None,
+                            Some(dst_rect),
+                        )?;
                     } else if !in_data.is_premiere() {
-                        ae::pf::suites::WorldTransform::new()?.copy(in_data.effect_ref(), in_layer, out_layer, None, Some(dst_rect))?;
+                        ae::pf::suites::WorldTransform::new()?.copy(
+                            in_data.effect_ref(),
+                            in_layer,
+                            out_layer,
+                            None,
+                            Some(dst_rect),
+                        )?;
                     } else {
                         let src_rect = ae::Rect {
-                            left:   pre_effect_origin.h,
-                            top:    pre_effect_origin.v,
-                            right:  pre_effect_origin.h + in_data.width() ,
-                            bottom: pre_effect_origin.v + in_data.height()
+                            left: pre_effect_origin.h,
+                            top: pre_effect_origin.v,
+                            right: pre_effect_origin.h + in_data.width(),
+                            bottom: pre_effect_origin.v + in_data.height(),
                         };
 
                         let dst_rect = ae::Rect {
-                            left:   pre_effect_origin.h + border_x as i32,
-                            top:    pre_effect_origin.v + border_y as i32,
-                            right:  pre_effect_origin.h + in_data.width()  + border_x as i32,
-                            bottom: pre_effect_origin.v + in_data.height() + border_y as i32
+                            left: pre_effect_origin.h + border_x as i32,
+                            top: pre_effect_origin.v + border_y as i32,
+                            right: pre_effect_origin.h + in_data.width() + border_x as i32,
+                            bottom: pre_effect_origin.v + in_data.height() + border_y as i32,
                         };
 
                         out_layer.copy_from(&in_layer, Some(src_rect), Some(dst_rect))?;

--- a/examples/rust_gpu/src/lib.rs
+++ b/examples/rust_gpu/src/lib.rs
@@ -31,21 +31,21 @@ impl KernelParams {
     fn from_params(params: &mut ae::Parameters<Params>) -> Result<Self, ae::Error> {
         Ok(Self {
             param_mirror: params.get(Params::Mirror)?.as_checkbox()?.value() as u8 as _,
-            param_r: params.get(Params::Red)?  .as_float_slider()?.value() as f32 / 100.0,
+            param_r: params.get(Params::Red)?.as_float_slider()?.value() as f32 / 100.0,
             param_g: params.get(Params::Green)?.as_float_slider()?.value() as f32 / 100.0,
-            param_b: params.get(Params::Blue)? .as_float_slider()?.value() as f32 / 100.0,
+            param_b: params.get(Params::Blue)?.as_float_slider()?.value() as f32 / 100.0,
         })
     }
 }
 
 struct Plugin {
-    wgpu: wgpu_proc::WgpuProcessing<KernelParams>
+    wgpu: wgpu_proc::WgpuProcessing<KernelParams>,
 }
 impl Default for Plugin {
     fn default() -> Self {
         Self {
             // wgpu: WgpuProcessing::new(ProcShaderSource::Wgsl(include_str!("../shader.wgsl")))
-            wgpu: WgpuProcessing::new(ProcShaderSource::SpirV(include_bytes!("../shader.spv")))
+            wgpu: WgpuProcessing::new(ProcShaderSource::SpirV(include_bytes!("../shader.spv"))),
         }
     }
 }
@@ -53,7 +53,12 @@ impl Default for Plugin {
 ae::define_effect!(Plugin, (), Params);
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, _: InData, _: OutData) -> Result<(), Error> {
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
         fn setup(f: &mut ae::FloatSliderDef) {
             f.set_slider_min(0.0);
             f.set_slider_max(100.0);
@@ -63,44 +68,80 @@ impl AdobePluginGlobal for Plugin {
             f.set_precision(1);
             f.set_display_flags(ae::ValueDisplayFlag::PERCENT);
         }
-        params.add(Params::Red,   "Red",   ae::FloatSliderDef::setup(setup))?;
+        params.add(Params::Red, "Red", ae::FloatSliderDef::setup(setup))?;
         params.add(Params::Green, "Green", ae::FloatSliderDef::setup(setup))?;
-        params.add(Params::Blue,  "Blue",  ae::FloatSliderDef::setup(setup))?;
-        params.add(Params::Mirror, "",     ae::CheckBoxDef::setup(|f| {
-            f.set_label("Mirror");
-            f.set_default(true);
-        }))?;
+        params.add(Params::Blue, "Blue", ae::FloatSliderDef::setup(setup))?;
+        params.add(
+            Params::Mirror,
+            "",
+            ae::CheckBoxDef::setup(|f| {
+                f.set_label("Mirror");
+                f.set_default(true);
+            }),
+        )?;
 
         Ok(())
     }
 
-    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Rust GPU v0.1\rProcess pixels on the GPU using shader written in Rust and compiled to SPIR-V");
             }
             ae::Command::FrameSetup { .. } => {
                 out_data.set_frame_data::<KernelParams>(KernelParams::from_params(params)?);
-            },
+            }
             ae::Command::FrameSetdown { .. } => {
                 in_data.destroy_frame_data::<KernelParams>();
-            },
-            ae::Command::Render { in_layer, mut out_layer } => {
-                let in_size  = (in_layer.width()  as usize, in_layer.height()  as usize, in_layer.buffer_stride());
-                let out_size = (out_layer.width() as usize, out_layer.height() as usize, out_layer.buffer_stride());
+            }
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
+                let in_size = (
+                    in_layer.width() as usize,
+                    in_layer.height() as usize,
+                    in_layer.buffer_stride(),
+                );
+                let out_size = (
+                    out_layer.width() as usize,
+                    out_layer.height() as usize,
+                    out_layer.buffer_stride(),
+                );
 
                 let _time = std::time::Instant::now();
 
                 let params = in_data.frame_data::<KernelParams>().unwrap();
-                self.wgpu.run_compute(&params, in_size, out_size, in_layer.buffer(), out_layer.buffer_mut());
+                self.wgpu.run_compute(
+                    &params,
+                    in_size,
+                    out_size,
+                    in_layer.buffer(),
+                    out_layer.buffer_mut(),
+                );
 
-                log::warn!("Render time: {:.3} ms", _time.elapsed().as_micros() as f64 / 1000.0);
-
-            },
+                log::warn!(
+                    "Render time: {:.3} ms",
+                    _time.elapsed().as_micros() as f64 / 1000.0
+                );
+            }
             ae::Command::SmartPreRender { mut extra } => {
                 let req = extra.output_request();
 
-                if let Ok(in_result) = extra.callbacks().checkout_layer(0, 0, &req, in_data.current_time(), in_data.time_step(), in_data.time_scale()) {
+                if let Ok(in_result) = extra.callbacks().checkout_layer(
+                    0,
+                    0,
+                    &req,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                ) {
                     let _ = extra.union_result_rect(in_result.result_rect.into());
                     let _ = extra.union_max_result_rect(in_result.max_result_rect.into());
 
@@ -114,20 +155,37 @@ impl AdobePluginGlobal for Plugin {
                 };
 
                 if let Ok(Some(mut out_layer)) = cb.checkout_output() {
-                    let in_size  = (in_layer.width()  as usize, in_layer.height()  as usize, in_layer.buffer_stride());
-                    let out_size = (out_layer.width() as usize, out_layer.height() as usize, out_layer.buffer_stride());
+                    let in_size = (
+                        in_layer.width() as usize,
+                        in_layer.height() as usize,
+                        in_layer.buffer_stride(),
+                    );
+                    let out_size = (
+                        out_layer.width() as usize,
+                        out_layer.height() as usize,
+                        out_layer.buffer_stride(),
+                    );
 
                     let _time = std::time::Instant::now();
 
                     let params = extra.pre_render_data::<KernelParams>().unwrap();
-                    self.wgpu.run_compute(&params, in_size, out_size, in_layer.buffer(), out_layer.buffer_mut());
+                    self.wgpu.run_compute(
+                        &params,
+                        in_size,
+                        out_size,
+                        in_layer.buffer(),
+                        out_layer.buffer_mut(),
+                    );
 
-                    log::warn!("Smart render time: {:.3} ms", _time.elapsed().as_micros() as f64 / 1000.0);
+                    log::warn!(
+                        "Smart render time: {:.3} ms",
+                        _time.elapsed().as_micros() as f64 / 1000.0
+                    );
                 }
 
                 cb.checkin_layer_pixels(0)?;
             }
-            _ => { }
+            _ => {}
         }
         Ok(())
     }

--- a/examples/rust_gpu/src/wgpu_proc.rs
+++ b/examples/rust_gpu/src/wgpu_proc.rs
@@ -1,7 +1,7 @@
-use wgpu::*;
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::sync::atomic::AtomicUsize;
+use wgpu::*;
 
 pub struct BufferState {
     pub in_size: (usize, usize, usize),
@@ -12,7 +12,7 @@ pub struct BufferState {
     pub params: Buffer,
     pub staging_buffer: Buffer,
     pub padded_out_stride: u32,
-    pub last_access: AtomicUsize
+    pub last_access: AtomicUsize,
 }
 
 pub struct WgpuProcessing<T: Sized> {
@@ -27,53 +27,97 @@ pub struct WgpuProcessing<T: Sized> {
 #[allow(dead_code)]
 pub enum ProcShaderSource<'a> {
     Wgsl(&'a str),
-    SpirV(&'a [u8])
+    SpirV(&'a [u8]),
 }
 
 impl<T: Sized> WgpuProcessing<T> {
     pub fn new(shader: ProcShaderSource) -> Self {
-        let power_preference = wgpu::PowerPreference::from_env().unwrap_or(PowerPreference::HighPerformance);
+        let power_preference =
+            wgpu::PowerPreference::from_env().unwrap_or(PowerPreference::HighPerformance);
         let mut instance_desc = InstanceDescriptor::new_without_display_handle();
 
         // We can't use the DX12 backend with validation turned on, otherwise it
         // will remove AE's internal D3D12 device:
         // https://learn.microsoft.com/en-us/windows/win32/api/d3d12sdklayers/nf-d3d12sdklayers-id3d12debug-enabledebuglayer
-        if instance_desc.backends.contains(Backends::DX12) && instance_desc.flags.contains(InstanceFlags::VALIDATION) {
+        if instance_desc.backends.contains(Backends::DX12)
+            && instance_desc.flags.contains(InstanceFlags::VALIDATION)
+        {
             instance_desc.backends.remove(Backends::DX12);
-            log::info!("Disabling {:?} because {:?} is on", Backends::DX12, InstanceFlags::VALIDATION);
+            log::info!(
+                "Disabling {:?} because {:?} is on",
+                Backends::DX12,
+                InstanceFlags::VALIDATION
+            );
         }
 
         let instance = Instance::new(instance_desc);
 
-        let adapter = pollster::block_on(instance.request_adapter(&RequestAdapterOptions { power_preference, ..Default::default() })).unwrap();
+        let adapter = pollster::block_on(instance.request_adapter(&RequestAdapterOptions {
+            power_preference,
+            ..Default::default()
+        }))
+        .unwrap();
 
-        let (device, queue) = pollster::block_on(
-            adapter.request_device(&DeviceDescriptor {
-                label: None,
-                required_features: adapter.features(),
-                required_limits: adapter.limits(),
-                memory_hints: wgpu::MemoryHints::Performance,
-                trace: wgpu::Trace::Off,
-                experimental_features: unsafe { wgpu::ExperimentalFeatures::enabled() },
-            })
-        ).unwrap();
+        let (device, queue) = pollster::block_on(adapter.request_device(&DeviceDescriptor {
+            label: None,
+            required_features: adapter.features(),
+            required_limits: adapter.limits(),
+            memory_hints: wgpu::MemoryHints::Performance,
+            trace: wgpu::Trace::Off,
+            experimental_features: unsafe { wgpu::ExperimentalFeatures::enabled() },
+        }))
+        .unwrap();
 
         let info = adapter.get_info();
-        log::info!("Using {} ({}) - {:#?}.", info.name, info.device, info.backend);
+        log::info!(
+            "Using {} ({}) - {:#?}.",
+            info.name,
+            info.device,
+            info.backend
+        );
 
         let shader = device.create_shader_module(ShaderModuleDescriptor {
             label: None,
             source: match shader {
                 ProcShaderSource::SpirV(bytes) => util::make_spirv(&bytes),
-                ProcShaderSource::Wgsl(wgsl)   => ShaderSource::Wgsl(std::borrow::Cow::Borrowed(wgsl)),
-            }
+                ProcShaderSource::Wgsl(wgsl) => {
+                    ShaderSource::Wgsl(std::borrow::Cow::Borrowed(wgsl))
+                }
+            },
         });
 
         let layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
             entries: &[
-                BindGroupLayoutEntry { binding: 0, visibility: ShaderStages::COMPUTE, ty: BindingType::Buffer { ty: BufferBindingType::Uniform, has_dynamic_offset: false, min_binding_size: BufferSize::new(std::mem::size_of::<T>() as _) }, count: None },
-                BindGroupLayoutEntry { binding: 1, visibility: ShaderStages::COMPUTE, ty: BindingType::Texture { sample_type: TextureSampleType::Uint, view_dimension: TextureViewDimension::D2, multisampled: false }, count: None },
-                BindGroupLayoutEntry { binding: 2, visibility: ShaderStages::COMPUTE, ty: BindingType::StorageTexture { access: StorageTextureAccess::ReadWrite, format: TextureFormat::Rgba8Uint, view_dimension: TextureViewDimension::D2 }, count: None },
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: BufferSize::new(std::mem::size_of::<T>() as _),
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Texture {
+                        sample_type: TextureSampleType::Uint,
+                        view_dimension: TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::StorageTexture {
+                        access: StorageTextureAccess::ReadWrite,
+                        format: TextureFormat::Rgba8Uint,
+                        view_dimension: TextureViewDimension::D2,
+                    },
+                    count: None,
+                },
             ],
             label: None,
         });
@@ -90,7 +134,7 @@ impl<T: Sized> WgpuProcessing<T> {
             label: None,
             layout: Some(&pipeline_layout),
             compilation_options: Default::default(),
-            cache: Default::default()
+            cache: Default::default(),
         });
 
         Self {
@@ -103,8 +147,12 @@ impl<T: Sized> WgpuProcessing<T> {
         }
     }
 
-    pub fn create_buffers(&self, in_size: (usize, usize, usize), out_size: (usize, usize, usize)) -> BufferState {
-        let (iw, ih, _)  = (in_size.0  as u32, in_size.1  as u32, in_size.2  as u32);
+    pub fn create_buffers(
+        &self,
+        in_size: (usize, usize, usize),
+        out_size: (usize, usize, usize),
+    ) -> BufferState {
+        let (iw, ih, _) = (in_size.0 as u32, in_size.1 as u32, in_size.2 as u32);
         let (ow, oh, os) = (out_size.0 as u32, out_size.1 as u32, out_size.2 as u32);
 
         let align = COPY_BYTES_PER_ROW_ALIGNMENT as u32;
@@ -114,23 +162,31 @@ impl<T: Sized> WgpuProcessing<T> {
 
         let in_desc = TextureDescriptor {
             label: None,
-            size: Extent3d { width: iw, height: ih, depth_or_array_layers: 1 },
+            size: Extent3d {
+                width: iw,
+                height: ih,
+                depth_or_array_layers: 1,
+            },
             mip_level_count: 1,
             sample_count: 1,
             dimension: TextureDimension::D2,
             format: TextureFormat::Rgba8Uint,
             usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
-            view_formats: &[]
+            view_formats: &[],
         };
         let out_desc = TextureDescriptor {
             label: None,
-            size: Extent3d { width: ow, height: oh, depth_or_array_layers: 1 },
+            size: Extent3d {
+                width: ow,
+                height: oh,
+                depth_or_array_layers: 1,
+            },
             mip_level_count: 1,
             sample_count: 1,
             dimension: TextureDimension::D2,
             format: TextureFormat::Rgba8Uint,
             usage: TextureUsages::STORAGE_BINDING | TextureUsages::COPY_SRC,
-            view_formats: &[]
+            view_formats: &[],
         };
 
         let in_texture = self.device.create_texture(&in_desc);
@@ -139,7 +195,7 @@ impl<T: Sized> WgpuProcessing<T> {
             size: staging_size as u64,
             usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
             label: None,
-            mapped_at_creation: false
+            mapped_at_creation: false,
         });
 
         let in_view = in_texture.create_view(&TextureViewDescriptor::default());
@@ -149,20 +205,32 @@ impl<T: Sized> WgpuProcessing<T> {
             size: std::mem::size_of::<T>() as u64,
             usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
             label: None,
-            mapped_at_creation: false
+            mapped_at_creation: false,
         });
 
         let bind_group = self.device.create_bind_group(&BindGroupDescriptor {
             label: None,
             layout: &self.pipeline.get_bind_group_layout(0),
             entries: &[
-                BindGroupEntry { binding: 0, resource: params.as_entire_binding() },
-                BindGroupEntry { binding: 1, resource: BindingResource::TextureView(&in_view) },
-                BindGroupEntry { binding: 2, resource: BindingResource::TextureView(&out_view) },
+                BindGroupEntry {
+                    binding: 0,
+                    resource: params.as_entire_binding(),
+                },
+                BindGroupEntry {
+                    binding: 1,
+                    resource: BindingResource::TextureView(&in_view),
+                },
+                BindGroupEntry {
+                    binding: 2,
+                    resource: BindingResource::TextureView(&out_view),
+                },
             ],
         });
 
-        log::info!("Creating buffers {in_size:?} {out_size:?}, thread: {:?}", std::thread::current().id());
+        log::info!(
+            "Creating buffers {in_size:?} {out_size:?}, thread: {:?}",
+            std::thread::current().id()
+        );
 
         BufferState {
             in_size,
@@ -178,10 +246,21 @@ impl<T: Sized> WgpuProcessing<T> {
     }
 
     fn timestamp() -> usize {
-        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis() as usize
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as usize
     }
 
-    fn get_buffer_for_thread(&self, in_size: (usize, usize, usize), out_size: (usize, usize, usize)) -> parking_lot::lock_api::RwLockUpgradableReadGuard<'_, parking_lot::RawRwLock, HashMap<std::thread::ThreadId, BufferState>> {
+    fn get_buffer_for_thread(
+        &self,
+        in_size: (usize, usize, usize),
+        out_size: (usize, usize, usize),
+    ) -> parking_lot::lock_api::RwLockUpgradableReadGuard<
+        '_,
+        parking_lot::RawRwLock,
+        HashMap<std::thread::ThreadId, BufferState>,
+    > {
         let mut lock = self.state.upgradable_read();
         let mut state = lock.get(&std::thread::current().id());
         if state.map(|x| (x.in_size, x.out_size)) != Some((in_size, out_size)) {
@@ -190,59 +269,107 @@ impl<T: Sized> WgpuProcessing<T> {
                 let max = num_cpus::get() - 1;
                 if x.len() > max {
                     // Remove least recently used buffers
-                    let mut keys = x.iter().map(|(k, v)| (*k, v.last_access.load(std::sync::atomic::Ordering::Relaxed))).collect::<Vec<_>>();
+                    let mut keys = x
+                        .iter()
+                        .map(|(k, v)| {
+                            (*k, v.last_access.load(std::sync::atomic::Ordering::Relaxed))
+                        })
+                        .collect::<Vec<_>>();
                     keys.sort_by(|a, b| a.1.cmp(&b.1));
                     for (k, _) in keys.iter().take(x.len() - max) {
                         log::info!("Removing {k:?}");
                         x.remove(k);
                     }
                 }
-                x.insert(std::thread::current().id(), self.create_buffers(in_size, out_size));
+                x.insert(
+                    std::thread::current().id(),
+                    self.create_buffers(in_size, out_size),
+                );
             });
             state = lock.get(&std::thread::current().id());
         }
         let state = state.unwrap();
-        state.last_access.store(Self::timestamp(), std::sync::atomic::Ordering::Relaxed);
+        state
+            .last_access
+            .store(Self::timestamp(), std::sync::atomic::Ordering::Relaxed);
         lock
     }
 
-    pub fn run_compute(&self, params: &T, in_size: (usize, usize, usize), out_size: (usize, usize, usize), in_buffer: &[u8], out_buffer: &mut [u8]) -> bool {
+    pub fn run_compute(
+        &self,
+        params: &T,
+        in_size: (usize, usize, usize),
+        out_size: (usize, usize, usize),
+        in_buffer: &[u8],
+        out_buffer: &mut [u8],
+    ) -> bool {
         let lock = self.get_buffer_for_thread(in_size, out_size);
         let state = lock.get(&std::thread::current().id()).unwrap();
 
         let width = out_size.0 as u32;
         let height = out_size.1 as u32;
 
-        let mut encoder = self.device.create_command_encoder(&CommandEncoderDescriptor { label: None });
+        let mut encoder = self
+            .device
+            .create_command_encoder(&CommandEncoderDescriptor { label: None });
 
         // Write params uniform
-        self.queue.write_buffer(
-            &state.params,
-            0,
-            unsafe { std::slice::from_raw_parts(params as *const _ as _, std::mem::size_of::<T>() ) }
-        );
+        self.queue.write_buffer(&state.params, 0, unsafe {
+            std::slice::from_raw_parts(params as *const _ as _, std::mem::size_of::<T>())
+        });
 
         // Write input texture
         self.queue.write_texture(
             state.in_texture.as_image_copy(),
             in_buffer,
-            TexelCopyBufferLayout { offset: 0, bytes_per_row: Some(in_size.2 as u32), rows_per_image: None },
-            Extent3d { width: in_size.0 as u32, height: in_size.1 as u32, depth_or_array_layers: 1 },
+            TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(in_size.2 as u32),
+                rows_per_image: None,
+            },
+            Extent3d {
+                width: in_size.0 as u32,
+                height: in_size.1 as u32,
+                depth_or_array_layers: 1,
+            },
         );
 
         // Run the compute pass
         {
-            let mut cpass = encoder.begin_compute_pass(&ComputePassDescriptor { label: None, timestamp_writes: None });
+            let mut cpass = encoder.begin_compute_pass(&ComputePassDescriptor {
+                label: None,
+                timestamp_writes: None,
+            });
             cpass.set_pipeline(&self.pipeline);
             cpass.set_bind_group(0, &state.bind_group, &[]);
-            cpass.dispatch_workgroups((width as f32 / 16.0).ceil() as u32, (height as f32 / 16.0).ceil() as u32, 1);
+            cpass.dispatch_workgroups(
+                (width as f32 / 16.0).ceil() as u32,
+                (height as f32 / 16.0).ceil() as u32,
+                1,
+            );
         }
 
         // Copy output texture to buffer that we can read
         encoder.copy_texture_to_buffer(
-            TexelCopyTextureInfo { texture: &state.out_texture, mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
-            TexelCopyBufferInfo { buffer: &state.staging_buffer, layout: TexelCopyBufferLayout { offset: 0, bytes_per_row: Some(state.padded_out_stride), rows_per_image: None } },
-            Extent3d { width: width as u32, height: height as u32, depth_or_array_layers: 1 }
+            TexelCopyTextureInfo {
+                texture: &state.out_texture,
+                mip_level: 0,
+                origin: Origin3d::ZERO,
+                aspect: TextureAspect::All,
+            },
+            TexelCopyBufferInfo {
+                buffer: &state.staging_buffer,
+                layout: TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(state.padded_out_stride),
+                    rows_per_image: None,
+                },
+            },
+            Extent3d {
+                width: width as u32,
+                height: height as u32,
+                depth_or_array_layers: 1,
+            },
         );
 
         self.queue.submit(Some(encoder.finish()));
@@ -252,7 +379,10 @@ impl<T: Sized> WgpuProcessing<T> {
         let (sender, receiver) = futures_intrusive::channel::shared::oneshot_channel();
         buffer_slice.map_async(MapMode::Read, move |v| sender.send(v).unwrap());
 
-        let _ = self.device.poll(wgpu::PollType::Wait { submission_index: None, timeout: None });
+        let _ = self.device.poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        });
 
         if let Some(Ok(())) = pollster::block_on(receiver.receive()) {
             let out_stride = out_size.2;

--- a/examples/sdk_noise/src/lib.rs
+++ b/examples/sdk_noise/src/lib.rs
@@ -8,32 +8,73 @@ enum Params {
 }
 
 #[derive(Default)]
-struct Plugin { }
+struct Plugin {}
 
 ae::define_effect!(Plugin, (), Params);
 
-#[repr(C)] struct PixelBGRA8u { blue: u8, green: u8, red: u8, alpha: u8 }
-#[repr(C)] struct PixelVUYA8u { pr: u8, pb: u8, luma: u8, alpha: u8 }
-#[repr(C)] struct PixelBGRA32f { blue: f32, green: f32, red: f32, alpha: f32 }
-#[repr(C)] struct PixelVUYA32f { pr: f32, pb: f32, luma: f32, alpha: f32 }
+#[repr(C)]
+struct PixelBGRA8u {
+    blue: u8,
+    green: u8,
+    red: u8,
+    alpha: u8,
+}
+#[repr(C)]
+struct PixelVUYA8u {
+    pr: u8,
+    pb: u8,
+    luma: u8,
+    alpha: u8,
+}
+#[repr(C)]
+struct PixelBGRA32f {
+    blue: f32,
+    green: f32,
+    red: f32,
+    alpha: f32,
+}
+#[repr(C)]
+struct PixelVUYA32f {
+    pr: f32,
+    pb: f32,
+    luma: f32,
+    alpha: f32,
+}
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, _in_data: InData, _: OutData) -> Result<(), Error> {
-        params.add(Params::Noise, "Noise variation", ae::FloatSliderDef::setup(|f| {
-            f.set_slider_min(0.0);
-            f.set_slider_max(100.0);
-            f.set_valid_min(0.0);
-            f.set_valid_max(1000.0);
-            f.set_default(10.0);
-            f.set_precision(1);
-            f.set_display_flags(ae::ValueDisplayFlag::PERCENT);
-        }))
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        params.add(
+            Params::Noise,
+            "Noise variation",
+            ae::FloatSliderDef::setup(|f| {
+                f.set_slider_min(0.0);
+                f.set_slider_max(100.0);
+                f.set_valid_min(0.0);
+                f.set_valid_max(1000.0);
+                f.set_default(10.0);
+                f.set_precision(1);
+                f.set_display_flags(ae::ValueDisplayFlag::PERCENT);
+            }),
+        )
     }
 
-    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
-                out_data.set_return_msg("SDK_Noise v5.6\rCopyright 2007-2023 Adobe Inc.\rSimple noise effect.");
+                out_data.set_return_msg(
+                    "SDK_Noise v5.6\rCopyright 2007-2023 Adobe Inc.\rSimple noise effect.",
+                );
             }
             ae::Command::GlobalSetup => {
                 // For Premiere - declare supported pixel formats
@@ -46,14 +87,17 @@ impl AdobePluginGlobal for Plugin {
                         ae::pr::PixelFormat::Vuya4444_32f,
                         ae::pr::PixelFormat::Bgra4444_32f,
                         ae::pr::PixelFormat::Vuya4444_8u,
-                        ae::pr::PixelFormat::Bgra4444_8u
+                        ae::pr::PixelFormat::Bgra4444_8u,
                     ];
                     for x in formats {
                         suite.add_supported_pixel_format(in_data.effect_ref(), x)?;
                     }
                 }
             }
-            ae::Command::Render { in_layer, mut out_layer } => {
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
                 let value = params.get(Params::Noise)?.as_float_slider()?.value() as f32 / 100.0;
 
                 let progress_final = out_layer.height() as _;
@@ -64,88 +108,145 @@ impl AdobePluginGlobal for Plugin {
 
                     let out_pixel_format = out_layer.pr_pixel_format()?;
                     let bytes_per_pixel = match out_pixel_format {
-                        pr::PixelFormat::Bgra4444_8u  => std::mem::size_of::<PixelBGRA8u>(),
-                        pr::PixelFormat::Vuya4444_8u  => std::mem::size_of::<PixelVUYA8u>(),
+                        pr::PixelFormat::Bgra4444_8u => std::mem::size_of::<PixelBGRA8u>(),
+                        pr::PixelFormat::Vuya4444_8u => std::mem::size_of::<PixelVUYA8u>(),
                         pr::PixelFormat::Bgra4444_32f => std::mem::size_of::<PixelBGRA32f>(),
                         pr::PixelFormat::Vuya4444_32f => std::mem::size_of::<PixelVUYA32f>(),
-                        _ => return Err(Error::InvalidParms)
+                        _ => return Err(Error::InvalidParms),
                     };
 
                     log::info!("Iterating {out_pixel_format:?}, pixel size: {bytes_per_pixel}");
 
-                    let in_stride  = in_layer.buffer_stride();
-                    let in_data    = in_layer.buffer();
+                    let in_stride = in_layer.buffer_stride();
+                    let in_data = in_layer.buffer();
                     let out_stride = out_layer.buffer_stride();
-                    let out_data   = out_layer.buffer_mut();
-                    out_data.par_chunks_mut(out_stride).enumerate().for_each(|(y, row_bytes)| { // Parallel iterator over buffer rows
-                        row_bytes.chunks_mut(bytes_per_pixel).enumerate().for_each(|(x, pix_chunk)| { // iterator over row pixels
-                            match out_pixel_format {
-                                pr::PixelFormat::Bgra4444_8u => {
-                                    let pixel = unsafe { &mut *(in_data.as_ptr().add(y as usize * in_stride) as *mut PixelBGRA8u).add(x) };
-                                    let out_pixel = unsafe { &mut *(pix_chunk as *mut _ as *mut PixelBGRA8u) };
+                    let out_data = out_layer.buffer_mut();
+                    out_data
+                        .par_chunks_mut(out_stride)
+                        .enumerate()
+                        .for_each(|(y, row_bytes)| {
+                            // Parallel iterator over buffer rows
+                            row_bytes.chunks_mut(bytes_per_pixel).enumerate().for_each(
+                                |(x, pix_chunk)| {
+                                    // iterator over row pixels
+                                    match out_pixel_format {
+                                        pr::PixelFormat::Bgra4444_8u => {
+                                            let pixel = unsafe {
+                                                &mut *(in_data.as_ptr().add(y as usize * in_stride)
+                                                    as *mut PixelBGRA8u)
+                                                    .add(x)
+                                            };
+                                            let out_pixel = unsafe {
+                                                &mut *(pix_chunk as *mut _ as *mut PixelBGRA8u)
+                                            };
 
-                                    let temp = (fastrand::u8(..) as f32 * value) as u8;
-                                    out_pixel.alpha = pixel.alpha as _;
-                                    out_pixel.red   = (pixel.red  .saturating_add(temp)).min(ae::MAX_CHANNEL8 as u8);
-                                    out_pixel.green = (pixel.green.saturating_add(temp)).min(ae::MAX_CHANNEL8 as u8);
-                                    out_pixel.blue  = (pixel.blue .saturating_add(temp)).min(ae::MAX_CHANNEL8 as u8);
-                                },
-                                pr::PixelFormat::Vuya4444_8u => {
-                                    let pixel = unsafe { &mut *(in_data.as_ptr().add(y as usize * in_stride) as *mut PixelVUYA8u).add(x) };
-                                    let out_pixel = unsafe { &mut *(pix_chunk as *mut _ as *mut PixelVUYA8u) };
+                                            let temp = (fastrand::u8(..) as f32 * value) as u8;
+                                            out_pixel.alpha = pixel.alpha as _;
+                                            out_pixel.red = (pixel.red.saturating_add(temp))
+                                                .min(ae::MAX_CHANNEL8 as u8);
+                                            out_pixel.green = (pixel.green.saturating_add(temp))
+                                                .min(ae::MAX_CHANNEL8 as u8);
+                                            out_pixel.blue = (pixel.blue.saturating_add(temp))
+                                                .min(ae::MAX_CHANNEL8 as u8);
+                                        }
+                                        pr::PixelFormat::Vuya4444_8u => {
+                                            let pixel = unsafe {
+                                                &mut *(in_data.as_ptr().add(y as usize * in_stride)
+                                                    as *mut PixelVUYA8u)
+                                                    .add(x)
+                                            };
+                                            let out_pixel = unsafe {
+                                                &mut *(pix_chunk as *mut _ as *mut PixelVUYA8u)
+                                            };
 
-                                    let temp = (fastrand::u8(..) as f32 * value) as u8;
-                                    out_pixel.alpha = pixel.alpha as _;
-                                    out_pixel.pb = pixel.pb as _;
-                                    out_pixel.pr = pixel.pr as _;
-                                    out_pixel.luma = (pixel.luma.saturating_add(temp)).min(ae::MAX_CHANNEL8 as u8);
-                                },
-                                pr::PixelFormat::Bgra4444_32f => {
-                                    let pixel = unsafe { &mut *(in_data.as_ptr().add(y as usize * in_stride) as *mut PixelBGRA32f).add(x) };
-                                    let out_pixel = unsafe { &mut *(pix_chunk as *mut _ as *mut PixelBGRA32f) };
+                                            let temp = (fastrand::u8(..) as f32 * value) as u8;
+                                            out_pixel.alpha = pixel.alpha as _;
+                                            out_pixel.pb = pixel.pb as _;
+                                            out_pixel.pr = pixel.pr as _;
+                                            out_pixel.luma = (pixel.luma.saturating_add(temp))
+                                                .min(ae::MAX_CHANNEL8 as u8);
+                                        }
+                                        pr::PixelFormat::Bgra4444_32f => {
+                                            let pixel = unsafe {
+                                                &mut *(in_data.as_ptr().add(y as usize * in_stride)
+                                                    as *mut PixelBGRA32f)
+                                                    .add(x)
+                                            };
+                                            let out_pixel = unsafe {
+                                                &mut *(pix_chunk as *mut _ as *mut PixelBGRA32f)
+                                            };
 
-                                    let temp = fastrand::f32() * value;
-                                    out_pixel.alpha = pixel.alpha as _;
-                                    out_pixel.red   = (pixel.red   + temp).min(1.0);
-                                    out_pixel.green = (pixel.green + temp).min(1.0);
-                                    out_pixel.blue  = (pixel.blue  + temp).min(1.0);
-                                },
-                                pr::PixelFormat::Vuya4444_32f => {
-                                    let pixel = unsafe { &mut *(in_data.as_ptr().add(y as usize * in_stride) as *mut PixelVUYA32f).add(x) };
-                                    let out_pixel = unsafe { &mut *(pix_chunk as *mut _ as *mut PixelVUYA32f) };
+                                            let temp = fastrand::f32() * value;
+                                            out_pixel.alpha = pixel.alpha as _;
+                                            out_pixel.red = (pixel.red + temp).min(1.0);
+                                            out_pixel.green = (pixel.green + temp).min(1.0);
+                                            out_pixel.blue = (pixel.blue + temp).min(1.0);
+                                        }
+                                        pr::PixelFormat::Vuya4444_32f => {
+                                            let pixel = unsafe {
+                                                &mut *(in_data.as_ptr().add(y as usize * in_stride)
+                                                    as *mut PixelVUYA32f)
+                                                    .add(x)
+                                            };
+                                            let out_pixel = unsafe {
+                                                &mut *(pix_chunk as *mut _ as *mut PixelVUYA32f)
+                                            };
 
-                                    let temp = fastrand::f32() * value;
-                                    out_pixel.alpha = pixel.alpha as _;
-                                    out_pixel.pb = pixel.pb as _;
-                                    out_pixel.pr = pixel.pr as _;
-                                    out_pixel.luma = (pixel.luma + temp).min(1.0);
+                                            let temp = fastrand::f32() * value;
+                                            out_pixel.alpha = pixel.alpha as _;
+                                            out_pixel.pb = pixel.pb as _;
+                                            out_pixel.pr = pixel.pr as _;
+                                            out_pixel.luma = (pixel.luma + temp).min(1.0);
+                                        }
+                                        _ => {}
+                                    }
                                 },
-                                _ => { }
-                            }
+                            );
                         });
-                    });
                 } else if value == 0.0 {
                     out_layer.copy_from(&in_layer, None, None)?;
                 } else {
-                    in_layer.iterate_with(&mut out_layer, 0, progress_final, None, |_x: i32, _y: i32, pixel: ae::GenericPixel, out_pixel: ae::GenericPixelMut| -> Result<(), Error> {
-                        let temp = (fastrand::u8(..) as f32 * value).round() as u8;
-                        match (pixel, out_pixel) {
-                            (ae::GenericPixel::Pixel8(pixel), ae::GenericPixelMut::Pixel8(out_pixel)) => {
-                                out_pixel.alpha = pixel.alpha as _;
-                                out_pixel.red   = (pixel.red   + temp).min(ae::MAX_CHANNEL8 as u8);
-                                out_pixel.green = (pixel.green + temp).min(ae::MAX_CHANNEL8 as u8);
-                                out_pixel.blue  = (pixel.blue  + temp).min(ae::MAX_CHANNEL8 as u8);
+                    in_layer.iterate_with(
+                        &mut out_layer,
+                        0,
+                        progress_final,
+                        None,
+                        |_x: i32,
+                         _y: i32,
+                         pixel: ae::GenericPixel,
+                         out_pixel: ae::GenericPixelMut|
+                         -> Result<(), Error> {
+                            let temp = (fastrand::u8(..) as f32 * value).round() as u8;
+                            match (pixel, out_pixel) {
+                                (
+                                    ae::GenericPixel::Pixel8(pixel),
+                                    ae::GenericPixelMut::Pixel8(out_pixel),
+                                ) => {
+                                    out_pixel.alpha = pixel.alpha as _;
+                                    out_pixel.red = (pixel.red + temp).min(ae::MAX_CHANNEL8 as u8);
+                                    out_pixel.green =
+                                        (pixel.green + temp).min(ae::MAX_CHANNEL8 as u8);
+                                    out_pixel.blue =
+                                        (pixel.blue + temp).min(ae::MAX_CHANNEL8 as u8);
+                                }
+                                _ => return Err(Error::BadCallbackParameter),
                             }
-                            _ => return Err(Error::BadCallbackParameter)
-                        }
-                        Ok(())
-                    })?;
+                            Ok(())
+                        },
+                    )?;
                 }
             }
             ae::Command::SmartPreRender { mut extra } => {
                 let req = extra.output_request();
 
-                if let Ok(in_result) = extra.callbacks().checkout_layer(0, 0, &req, in_data.current_time(), in_data.time_step(), in_data.time_scale()) {
+                if let Ok(in_result) = extra.callbacks().checkout_layer(
+                    0,
+                    0,
+                    &req,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                ) {
                     let _ = extra.union_result_rect(in_result.result_rect.into());
                     let _ = extra.union_max_result_rect(in_result.max_result_rect.into());
                 }
@@ -159,41 +260,80 @@ impl AdobePluginGlobal for Plugin {
                 if let Ok(Some(mut output_world)) = cb.checkout_output() {
                     let progress_final = output_world.height() as _;
 
-                    let value = params.get(Params::Noise)?.as_float_slider()?.value() as f32 / 100.0;
+                    let value =
+                        params.get(Params::Noise)?.as_float_slider()?.value() as f32 / 100.0;
 
                     if value == 0.0 {
                         output_world.copy_from(&input_world, None, None)?;
                     } else {
-                        input_world.iterate_with(&mut output_world, 0, progress_final, None, |_x: i32, _y: i32, pixel: ae::GenericPixel, out_pixel: ae::GenericPixelMut| -> Result<(), Error> {
-                            match (pixel, out_pixel) {
-                                (ae::GenericPixel::Pixel8(pixel), ae::GenericPixelMut::Pixel8(out_pixel)) => {
-                                    let temp8 = (fastrand::u8(..) as f32 * value).round() as u8;
+                        input_world.iterate_with(
+                            &mut output_world,
+                            0,
+                            progress_final,
+                            None,
+                            |_x: i32,
+                             _y: i32,
+                             pixel: ae::GenericPixel,
+                             out_pixel: ae::GenericPixelMut|
+                             -> Result<(), Error> {
+                                match (pixel, out_pixel) {
+                                    (
+                                        ae::GenericPixel::Pixel8(pixel),
+                                        ae::GenericPixelMut::Pixel8(out_pixel),
+                                    ) => {
+                                        let temp8 = (fastrand::u8(..) as f32 * value).round() as u8;
 
-                                    out_pixel.alpha = pixel.alpha as _;
-                                    out_pixel.red   = pixel.red  .saturating_add(temp8).min(ae::MAX_CHANNEL8 as u8);
-                                    out_pixel.green = pixel.green.saturating_add(temp8).min(ae::MAX_CHANNEL8 as u8);
-                                    out_pixel.blue  = pixel.blue .saturating_add(temp8).min(ae::MAX_CHANNEL8 as u8);
-                                }
-                                (ae::GenericPixel::Pixel16(pixel), ae::GenericPixelMut::Pixel16(out_pixel)) => {
-                                    let temp16 = (fastrand::u16(..32768) as f32 * value).round() as u16;
+                                        out_pixel.alpha = pixel.alpha as _;
+                                        out_pixel.red = pixel
+                                            .red
+                                            .saturating_add(temp8)
+                                            .min(ae::MAX_CHANNEL8 as u8);
+                                        out_pixel.green = pixel
+                                            .green
+                                            .saturating_add(temp8)
+                                            .min(ae::MAX_CHANNEL8 as u8);
+                                        out_pixel.blue = pixel
+                                            .blue
+                                            .saturating_add(temp8)
+                                            .min(ae::MAX_CHANNEL8 as u8);
+                                    }
+                                    (
+                                        ae::GenericPixel::Pixel16(pixel),
+                                        ae::GenericPixelMut::Pixel16(out_pixel),
+                                    ) => {
+                                        let temp16 =
+                                            (fastrand::u16(..32768) as f32 * value).round() as u16;
 
-                                    out_pixel.alpha = pixel.alpha as _;
-                                    out_pixel.red   = pixel.red  .saturating_add(temp16).min(ae::MAX_CHANNEL16 as u16);
-                                    out_pixel.green = pixel.green.saturating_add(temp16).min(ae::MAX_CHANNEL16 as u16);
-                                    out_pixel.blue  = pixel.blue .saturating_add(temp16).min(ae::MAX_CHANNEL16 as u16);
-                                }
-                                (ae::GenericPixel::PixelF32(pixel), ae::GenericPixelMut::PixelF32(out_pixel)) => {
-                                    let temp32 = fastrand::f32() * value;
+                                        out_pixel.alpha = pixel.alpha as _;
+                                        out_pixel.red = pixel
+                                            .red
+                                            .saturating_add(temp16)
+                                            .min(ae::MAX_CHANNEL16 as u16);
+                                        out_pixel.green = pixel
+                                            .green
+                                            .saturating_add(temp16)
+                                            .min(ae::MAX_CHANNEL16 as u16);
+                                        out_pixel.blue = pixel
+                                            .blue
+                                            .saturating_add(temp16)
+                                            .min(ae::MAX_CHANNEL16 as u16);
+                                    }
+                                    (
+                                        ae::GenericPixel::PixelF32(pixel),
+                                        ae::GenericPixelMut::PixelF32(out_pixel),
+                                    ) => {
+                                        let temp32 = fastrand::f32() * value;
 
-                                    out_pixel.alpha = pixel.alpha as _;
-                                    out_pixel.red   = (pixel.red   + temp32).min(1.0);
-                                    out_pixel.green = (pixel.green + temp32).min(1.0);
-                                    out_pixel.blue  = (pixel.blue  + temp32).min(1.0);
+                                        out_pixel.alpha = pixel.alpha as _;
+                                        out_pixel.red = (pixel.red + temp32).min(1.0);
+                                        out_pixel.green = (pixel.green + temp32).min(1.0);
+                                        out_pixel.blue = (pixel.blue + temp32).min(1.0);
+                                    }
+                                    _ => return Err(Error::BadCallbackParameter),
                                 }
-                                _ => return Err(Error::BadCallbackParameter)
-                            }
-                            Ok(())
-                        })?;
+                                Ok(())
+                            },
+                        )?;
                     }
                 }
 

--- a/examples/simplest/src/lib.rs
+++ b/examples/simplest/src/lib.rs
@@ -1,10 +1,12 @@
 use after_effects as ae;
 
 #[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
-enum Params { Opacity }
+enum Params {
+    Opacity,
+}
 
 #[derive(Default)]
-struct Plugin { }
+struct Plugin {}
 
 ae::define_effect!(Plugin, (), Params);
 
@@ -18,38 +20,73 @@ fn mfr_global_state_is_shared() {
 }
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, _: ae::InData, _: ae::OutData) -> Result<(), Error> {
-        params.add(Params::Opacity, "Opacity", ae::FloatSliderDef::setup(|f| {
-            f.set_slider_min(0.0);
-            f.set_slider_max(100.0);
-            f.set_valid_min(0.0);
-            f.set_valid_max(100.0);
-        }))
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _: ae::InData,
+        _: ae::OutData,
+    ) -> Result<(), Error> {
+        params.add(
+            Params::Opacity,
+            "Opacity",
+            ae::FloatSliderDef::setup(|f| {
+                f.set_slider_min(0.0);
+                f.set_slider_max(100.0);
+                f.set_valid_min(0.0);
+                f.set_valid_max(100.0);
+            }),
+        )
     }
 
-    fn handle_command(&self, cmd: ae::Command, in_data: ae::InData, _: ae::OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        in_data: ae::InData,
+        _: ae::OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
-            ae::Command::Render { in_layer, mut out_layer } => {
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
                 let slider_value = params.get(Params::Opacity)?.as_float_slider()?.value();
 
                 let extent_hint = in_data.extent_hint();
 
-                in_layer.iterate_with(&mut out_layer, 0, extent_hint.height(), Some(extent_hint), |_x: i32, _y: i32, pixel: ae::GenericPixel, out_pixel: ae::GenericPixelMut| -> Result<(), Error> {
-                    match (pixel, out_pixel) {
-                        (ae::GenericPixel::Pixel8(pixel), ae::GenericPixelMut::Pixel8(out_pixel)) => {
-                            *out_pixel = *pixel;
-                            out_pixel.alpha = (pixel.alpha as f64 * slider_value / 100.0) as u8;
+                in_layer.iterate_with(
+                    &mut out_layer,
+                    0,
+                    extent_hint.height(),
+                    Some(extent_hint),
+                    |_x: i32,
+                     _y: i32,
+                     pixel: ae::GenericPixel,
+                     out_pixel: ae::GenericPixelMut|
+                     -> Result<(), Error> {
+                        match (pixel, out_pixel) {
+                            (
+                                ae::GenericPixel::Pixel8(pixel),
+                                ae::GenericPixelMut::Pixel8(out_pixel),
+                            ) => {
+                                *out_pixel = *pixel;
+                                out_pixel.alpha = (pixel.alpha as f64 * slider_value / 100.0) as u8;
+                            }
+                            (
+                                ae::GenericPixel::Pixel16(pixel),
+                                ae::GenericPixelMut::Pixel16(out_pixel),
+                            ) => {
+                                *out_pixel = *pixel;
+                                out_pixel.alpha =
+                                    (pixel.alpha as f64 * slider_value / 100.0) as u16;
+                            }
+                            _ => return Err(Error::BadCallbackParameter),
                         }
-                        (ae::GenericPixel::Pixel16(pixel), ae::GenericPixelMut::Pixel16(out_pixel)) => {
-                            *out_pixel = *pixel;
-                            out_pixel.alpha = (pixel.alpha as f64 * slider_value / 100.0) as u16;
-                        }
-                        _ => return Err(Error::BadCallbackParameter)
-                    }
-                    Ok(())
-                })?;
+                        Ok(())
+                    },
+                )?;
             }
-            _ => { }
+            _ => {}
         }
         Ok(())
     }

--- a/examples/supervisor/src/lib.rs
+++ b/examples/supervisor/src/lib.rs
@@ -34,12 +34,17 @@ impl Into<Flavor> for i32 {
 }
 
 struct PreRenderData {
-    color: ae::PixelF32
+    color: ae::PixelF32,
 }
 impl Default for PreRenderData {
     fn default() -> Self {
         Self {
-            color: ae::PixelF32 { red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0 }
+            color: ae::PixelF32 {
+                red: 0.0,
+                green: 0.0,
+                blue: 0.0,
+                alpha: 0.0,
+            },
         }
     }
 }
@@ -55,10 +60,30 @@ enum Params {
 
 fn get_preset_color_value(flavor: Flavor) -> ae::Pixel8 {
     match flavor {
-        Flavor::Chocolate  => ae::Pixel8 { red: 136, green: 83,  blue: 51, alpha: 0 },
-        Flavor::Strawberry => ae::Pixel8 { red: 232, green: 21,  blue: 84, alpha: 0 },
-        Flavor::Sherbet    => ae::Pixel8 { red: 255, green: 128, blue: 0,  alpha: 0 },
-        _                  => ae::Pixel8 { red: 0,   green: 0,   blue: 0,  alpha: 0 },
+        Flavor::Chocolate => ae::Pixel8 {
+            red: 136,
+            green: 83,
+            blue: 51,
+            alpha: 0,
+        },
+        Flavor::Strawberry => ae::Pixel8 {
+            red: 232,
+            green: 21,
+            blue: 84,
+            alpha: 0,
+        },
+        Flavor::Sherbet => ae::Pixel8 {
+            red: 255,
+            green: 128,
+            blue: 0,
+            alpha: 0,
+        },
+        _ => ae::Pixel8 {
+            red: 0,
+            green: 0,
+            blue: 0,
+            alpha: 0,
+        },
     }
 }
 
@@ -71,9 +96,7 @@ struct Plugin {
 #[repr(transparent)]
 struct State(ae::sys::PF_State);
 impl Default for State {
-    fn default() -> Self {
-        Self(unsafe { std::mem::zeroed() })
-    }
+    fn default() -> Self { Self(unsafe { std::mem::zeroed() }) }
 }
 
 #[derive(Default, serde::Serialize, serde::Deserialize)]
@@ -86,40 +109,83 @@ struct Instance {
 ae::define_effect!(Plugin, Instance, Params);
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, _in_data: InData, _: OutData) -> Result<(), Error> {
-        params.add_with_flags(Params::Mode, "Mode", ae::PopupDef::setup(|f| {
-            f.set_options(&["Basic", "Advanced"]);
-            f.set_default(1);
-        }), ae::ParamFlag::SUPERVISE | ae::ParamFlag::CANNOT_TIME_VARY | ae::ParamFlag::CANNOT_INTERP, ae::ParamUIFlags::CONTROL_ONLY)?;
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        params.add_with_flags(
+            Params::Mode,
+            "Mode",
+            ae::PopupDef::setup(|f| {
+                f.set_options(&["Basic", "Advanced"]);
+                f.set_default(1);
+            }),
+            ae::ParamFlag::SUPERVISE
+                | ae::ParamFlag::CANNOT_TIME_VARY
+                | ae::ParamFlag::CANNOT_INTERP,
+            ae::ParamUIFlags::CONTROL_ONLY,
+        )?;
 
-        params.add_with_flags(Params::Flavor, "Flavor", ae::PopupDef::setup(|f| {
-            f.set_options(&["Chocolate", "(-", "Strawberry", "(-", "Sherbet"]);
-            f.set_default(1);
-        }), ae::ParamFlag::SUPERVISE | ae::ParamFlag::CANNOT_INTERP, ae::ParamUIFlags::empty())?;
+        params.add_with_flags(
+            Params::Flavor,
+            "Flavor",
+            ae::PopupDef::setup(|f| {
+                f.set_options(&["Chocolate", "(-", "Strawberry", "(-", "Sherbet"]);
+                f.set_default(1);
+            }),
+            ae::ParamFlag::SUPERVISE | ae::ParamFlag::CANNOT_INTERP,
+            ae::ParamUIFlags::empty(),
+        )?;
 
-        params.add_with_flags(Params::Color, "Color", ae::ColorDef::setup(|f| {
-            f.set_default(get_preset_color_value(Flavor::Chocolate));
-        }), ae::ParamFlag::SUPERVISE, ae::ParamUIFlags::empty())?;
+        params.add_with_flags(
+            Params::Color,
+            "Color",
+            ae::ColorDef::setup(|f| {
+                f.set_default(get_preset_color_value(Flavor::Chocolate));
+            }),
+            ae::ParamFlag::SUPERVISE,
+            ae::ParamUIFlags::empty(),
+        )?;
 
-        params.add_with_flags(Params::Slider, "Slider", ae::FloatSliderDef::setup(|f| {
-            f.set_slider_min(0.0);
-            f.set_slider_max(100.0);
-            f.set_valid_min(0.0);
-            f.set_valid_max(100.0);
-            f.set_default(28.0);
-            f.set_value(f.default());
-            f.set_precision(1);
-        }), ae::ParamFlag::EXCLUDE_FROM_HAVE_INPUTS_CHANGED, ae::ParamUIFlags::empty())?;
+        params.add_with_flags(
+            Params::Slider,
+            "Slider",
+            ae::FloatSliderDef::setup(|f| {
+                f.set_slider_min(0.0);
+                f.set_slider_max(100.0);
+                f.set_valid_min(0.0);
+                f.set_valid_max(100.0);
+                f.set_default(28.0);
+                f.set_value(f.default());
+                f.set_precision(1);
+            }),
+            ae::ParamFlag::EXCLUDE_FROM_HAVE_INPUTS_CHANGED,
+            ae::ParamUIFlags::empty(),
+        )?;
 
-        params.add_with_flags(Params::Checkbox, "Checkbox", ae::CheckBoxDef::setup(|f| {
-            f.set_default(false);
-            f.set_label("Set slider to 50%");
-        }), ae::ParamFlag::SUPERVISE | ae::ParamFlag::CANNOT_TIME_VARY, ae::ParamUIFlags::CONTROL_ONLY)?;
+        params.add_with_flags(
+            Params::Checkbox,
+            "Checkbox",
+            ae::CheckBoxDef::setup(|f| {
+                f.set_default(false);
+                f.set_label("Set slider to 50%");
+            }),
+            ae::ParamFlag::SUPERVISE | ae::ParamFlag::CANNOT_TIME_VARY,
+            ae::ParamUIFlags::CONTROL_ONLY,
+        )?;
 
         Ok(())
     }
 
-    fn handle_command(&mut self, cmd: ae::Command, _in_data: InData, mut out_data: OutData, _params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &mut self,
+        cmd: ae::Command,
+        _in_data: InData,
+        mut out_data: OutData,
+        _params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 let personal_info = ae::suites::App::new()?.personal_info()?;
@@ -131,7 +197,7 @@ impl AdobePluginGlobal for Plugin {
                     self.my_id = suite.register_with_aegp("Supervisor")?;
                 }
             }
-            _ => { }
+            _ => {}
         }
         Ok(())
     }
@@ -139,26 +205,47 @@ impl AdobePluginGlobal for Plugin {
 
 impl AdobePluginInstance for Instance {
     fn flatten(&self) -> Result<(u16, Vec<u8>), Error> {
-        Ok((1, bincode::serde::encode_to_vec(self, bincode::config::standard()).unwrap()))
+        Ok((
+            1,
+            bincode::serde::encode_to_vec(self, bincode::config::standard()).unwrap(),
+        ))
     }
+
     fn unflatten(_version: u16, bytes: &[u8]) -> Result<Self, Error> {
-        Ok(bincode::serde::decode_from_slice(bytes, bincode::config::standard()).unwrap_or_default().0)
+        Ok(
+            bincode::serde::decode_from_slice(bytes, bincode::config::standard())
+                .unwrap_or_default()
+                .0,
+        )
     }
 
-    fn render(&self, _: &mut PluginState, _: &Layer, _: &mut Layer) -> Result<(), ae::Error> { Ok(()) }
+    fn render(&self, _: &mut PluginState, _: &Layer, _: &mut Layer) -> Result<(), ae::Error> {
+        Ok(())
+    }
 
-    fn handle_command(&mut self, plugin: &mut PluginState, cmd: ae::Command) -> Result<(), ae::Error> {
+    fn handle_command(
+        &mut self,
+        plugin: &mut PluginState,
+        cmd: ae::Command,
+    ) -> Result<(), ae::Error> {
         let in_data = &plugin.in_data;
 
         match cmd {
             ae::Command::SequenceSetup => {
                 if !in_data.is_premiere() {
                     let slider_index = plugin.params.index(Params::Slider).unwrap() as _;
-                    self.state = State(in_data.effect().current_param_state(slider_index, None, None)?);
+                    self.state = State(in_data.effect().current_param_state(
+                        slider_index,
+                        None,
+                        None,
+                    )?);
                 }
                 self.advanced_mode = false;
-            },
-            ae::Command::Render { in_layer, mut out_layer } => {
+            }
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
                 let mode = plugin.params.get(Params::Mode)?.as_popup()?.value();
 
                 let extent_hint = in_data.extent_hint();
@@ -171,15 +258,22 @@ impl AdobePluginInstance for Instance {
                 // If we're in Basic mode, use a preset.
                 // Otherwise, use the value of our color param.
                 let scratch8 = if mode == Mode::Basic as i32 {
-                    get_preset_color_value(plugin.params.get(Params::Flavor)?.as_popup()?.value().into())
+                    get_preset_color_value(
+                        plugin
+                            .params
+                            .get(Params::Flavor)?
+                            .as_popup()?
+                            .value()
+                            .into(),
+                    )
                 } else {
                     plugin.params.get(Params::Color)?.as_color()?.value()
                 };
 
                 let pixel_float = ae::PixelF32 {
-                    red:   scratch8.red   as f32 / ae::MAX_CHANNEL8 as f32,
+                    red: scratch8.red as f32 / ae::MAX_CHANNEL8 as f32,
                     green: scratch8.green as f32 / ae::MAX_CHANNEL8 as f32,
-                    blue:  scratch8.blue  as f32 / ae::MAX_CHANNEL8 as f32,
+                    blue: scratch8.blue as f32 / ae::MAX_CHANNEL8 as f32,
                     alpha: scratch8.alpha as f32 / ae::MAX_CHANNEL8 as f32,
                 };
 
@@ -215,7 +309,14 @@ impl AdobePluginInstance for Instance {
                 // Because smart pre-computing of what you'll actually NEED can save time, it's best to check conditionals here in pre-render.
                 extra.set_pre_render_data::<PreRenderData>(Default::default());
 
-                if let Ok(in_result) = extra.callbacks().checkout_layer(0, 0, &req, in_data.current_time(), in_data.time_step(), in_data.time_scale()) {
+                if let Ok(in_result) = extra.callbacks().checkout_layer(
+                    0,
+                    0,
+                    &req,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                ) {
                     let _ = extra.union_result_rect(in_result.result_rect.into());
                     let _ = extra.union_max_result_rect(in_result.max_result_rect.into());
                 }
@@ -228,18 +329,26 @@ impl AdobePluginInstance for Instance {
 
                 let pre_render_data = extra.pre_render_data_mut::<PreRenderData>().unwrap();
                 if self.advanced_mode {
-                    pre_render_data.color = plugin.params.get(Params::Color)?.as_color()?.float_value()?;
+                    pre_render_data.color = plugin
+                        .params
+                        .get(Params::Color)?
+                        .as_color()?
+                        .float_value()?;
                     // color_param gets checked in here
                 } else {
                     // Basic mode
                     let flavor_param = plugin.params.get(Params::Flavor)?;
-                    let lo_rent_color = get_preset_color_value(flavor_param.as_popup()?.value().into());
+                    let lo_rent_color =
+                        get_preset_color_value(flavor_param.as_popup()?.value().into());
 
                     // Rounding slop? Yes! But hey, whaddayawant, they're 0-255 presets...
-                    pre_render_data.color.red   = lo_rent_color.red   as f32 / ae::MAX_CHANNEL8 as f32;
-                    pre_render_data.color.green = lo_rent_color.green as f32 / ae::MAX_CHANNEL8 as f32;
-                    pre_render_data.color.blue  = lo_rent_color.blue  as f32 / ae::MAX_CHANNEL8 as f32;
-                    pre_render_data.color.alpha = lo_rent_color.alpha as f32 / ae::MAX_CHANNEL8 as f32;
+                    pre_render_data.color.red = lo_rent_color.red as f32 / ae::MAX_CHANNEL8 as f32;
+                    pre_render_data.color.green =
+                        lo_rent_color.green as f32 / ae::MAX_CHANNEL8 as f32;
+                    pre_render_data.color.blue =
+                        lo_rent_color.blue as f32 / ae::MAX_CHANNEL8 as f32;
+                    pre_render_data.color.alpha =
+                        lo_rent_color.alpha as f32 / ae::MAX_CHANNEL8 as f32;
                 }
 
                 let pixel_float = pre_render_data.color;
@@ -290,7 +399,12 @@ impl AdobePluginInstance for Instance {
                     flavor.set_ui_flag(ae::ParamUIFlags::DISABLED, false);
                     flavor.set_name("Flavor")?;
                     flavor.update_param_ui()?;
-                } else if mode == Mode::Advanced as i32 && !params_copy.get(Params::Flavor)?.ui_flags().contains(ae::ParamUIFlags::DISABLED) {
+                } else if mode == Mode::Advanced as i32
+                    && !params_copy
+                        .get(Params::Flavor)?
+                        .ui_flags()
+                        .contains(ae::ParamUIFlags::DISABLED)
+                {
                     let mut flavor = params_copy.get_mut(Params::Flavor)?;
                     flavor.set_ui_flag(ae::ParamUIFlags::DISABLED, true);
                     flavor.set_name("Flavor (disabled in Basic mode)")?;
@@ -320,31 +434,67 @@ impl AdobePluginInstance for Instance {
                         let plugin_id = plugin.global.my_id;
                         let me = effect.aegp_effect(plugin_id)?;
                         // let flavor_stream   = me.new_stream_by_index(plugin_id, plugin.params.index(Params::Flavor)  .unwrap() as _)?;
-                        let color_stream    = me.new_stream_by_index(plugin_id, params.index(Params::Color)   .unwrap() as _)?;
-                        let slider_stream   = me.new_stream_by_index(plugin_id, params.index(Params::Slider)  .unwrap() as _)?;
-                        let checkbox_stream = me.new_stream_by_index(plugin_id, params.index(Params::Checkbox).unwrap() as _)?;
+                        let color_stream = me.new_stream_by_index(
+                            plugin_id,
+                            params.index(Params::Color).unwrap() as _,
+                        )?;
+                        let slider_stream = me.new_stream_by_index(
+                            plugin_id,
+                            params.index(Params::Slider).unwrap() as _,
+                        )?;
+                        let checkbox_stream = me.new_stream_by_index(
+                            plugin_id,
+                            params.index(Params::Checkbox).unwrap() as _,
+                        )?;
 
                         // Toggle visibility of parameters
-                        color_stream   .set_dynamic_stream_flag(ae::aegp::DynamicStreamFlags::Hidden, false, hide_them)?;
-                        slider_stream  .set_dynamic_stream_flag(ae::aegp::DynamicStreamFlags::Hidden, false, hide_them)?;
-                        checkbox_stream.set_dynamic_stream_flag(ae::aegp::DynamicStreamFlags::Hidden, false, hide_them)?;
+                        color_stream.set_dynamic_stream_flag(
+                            ae::aegp::DynamicStreamFlags::Hidden,
+                            false,
+                            hide_them,
+                        )?;
+                        slider_stream.set_dynamic_stream_flag(
+                            ae::aegp::DynamicStreamFlags::Hidden,
+                            false,
+                            hide_them,
+                        )?;
+                        checkbox_stream.set_dynamic_stream_flag(
+                            ae::aegp::DynamicStreamFlags::Hidden,
+                            false,
+                            hide_them,
+                        )?;
 
                         // Change popup menu items
-                        let param_union = me.param_union_by_index(plugin_id, params.index(Params::Flavor).unwrap() as _)?;
+                        let param_union = me.param_union_by_index(
+                            plugin_id,
+                            params.index(Params::Flavor).unwrap() as _,
+                        )?;
                         if let ae::Param::Popup(mut popup) = param_union {
-                            popup.set_options(&["Chocolate", "(-", "Strawberry", "(-", "And more!"]);
+                            popup.set_options(&[
+                                "Chocolate",
+                                "(-",
+                                "Strawberry",
+                                "(-",
+                                "And more!",
+                            ]);
                         }
                     }
 
                     // Demonstrate using PF_AreStatesIdentical to check whether a parameter has changed
-                    let new_state = effect.current_param_state(params.index(Params::Slider).unwrap() as _, None, None)?;
-                    let something_changed = effect.are_param_states_identical(&self.state.0, &new_state)?;
+                    let new_state = effect.current_param_state(
+                        params.index(Params::Slider).unwrap() as _,
+                        None,
+                        None,
+                    )?;
+                    let something_changed =
+                        effect.are_param_states_identical(&self.state.0, &new_state)?;
 
                     if something_changed || !plugin.global.initialized {
                         // If something changed (or it's the first time we're being called), get the new state and store it in our sequence data
                         self.state = State(new_state);
                     }
-                } else { // Premiere Pro doesn't support the stream suites, but uses a UI flag instead
+                } else {
+                    // Premiere Pro doesn't support the stream suites, but uses a UI flag instead
                     // Test all parameters except layers for changes
 
                     // If the mode is currently Basic, hide the advanced-only params
@@ -366,7 +516,9 @@ impl AdobePluginInstance for Instance {
 
                 plugin.global.initialized = true;
                 plugin.out_data.set_out_flag(ae::OutFlags::RefreshUi, true);
-                plugin.out_data.set_out_flag(ae::OutFlags::ForceRerender, true);
+                plugin
+                    .out_data
+                    .set_out_flag(ae::OutFlags::ForceRerender, true);
             }
             ae::Command::UserChangedParam { param_index } => {
                 let params = &mut plugin.params;
@@ -374,7 +526,10 @@ impl AdobePluginInstance for Instance {
                 if param == Params::Checkbox {
                     // If checkbox is checked, change slider value to 50 and flip checkbox back off
                     if params.get(Params::Checkbox)?.as_checkbox()?.value() {
-                        params.get_mut(Params::Slider)?.as_float_slider_mut()?.set_value(50.0);
+                        params
+                            .get_mut(Params::Slider)?
+                            .as_float_slider_mut()?
+                            .set_value(50.0);
 
                         let mut cb = params.get_mut(Params::Checkbox)?;
                         cb.as_checkbox_mut()?.set_value(false);
@@ -386,7 +541,7 @@ impl AdobePluginInstance for Instance {
                     plugin.out_data.set_force_rerender();
                 }
             }
-            _ => { }
+            _ => {}
         }
         Ok(())
     }

--- a/examples/transformer/src/lib.rs
+++ b/examples/transformer/src/lib.rs
@@ -2,8 +2,8 @@ use after_effects as ae;
 
 // This sample exercises some of After Effects' image processing callback functions.
 
-const XFORM_AMOUNT_MIN: f32       = 0.0;
-const XFORM_AMOUNT_MAX: f32       = 100.0;
+const XFORM_AMOUNT_MIN: f32 = 0.0;
+const XFORM_AMOUNT_MAX: f32 = 100.0;
 const XFORM_COLOR_BLEND_DFLT: f64 = 50.0;
 
 #[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
@@ -17,68 +17,116 @@ enum Params {
 }
 
 #[derive(Default)]
-struct Plugin { }
+struct Plugin {}
 
 ae::define_effect!(Plugin, (), Params);
 
 impl AdobePluginGlobal for Plugin {
-    fn params_setup(&self, params: &mut ae::Parameters<Params>, _in_data: InData, _: OutData) -> Result<(), Error> {
-        params.add(Params::ColorBlend, "Color Blend Ratio", ae::FloatSliderDef::setup(|f| {
-            f.set_valid_min(XFORM_AMOUNT_MIN);
-            f.set_valid_max(XFORM_AMOUNT_MAX);
-            f.set_slider_min(XFORM_AMOUNT_MIN);
-            f.set_slider_max(XFORM_AMOUNT_MAX);
-            f.set_default(XFORM_COLOR_BLEND_DFLT);
-            f.set_precision(2);
-            f.set_value(f.default());
-            f.set_display_flags(ae::ValueDisplayFlag::PERCENT);
-        }))?;
-
-        params.add(Params::Color, "Color", ae::ColorDef::setup(|f| {
-            f.set_default(ae::Pixel8 {
-                red: 128,
-                green: 255,
-                blue: 255,
-                alpha: 255
-            });
-            f.set_value(f.default());
-        }))?;
-
-        // def.flags = PF_ParamFlag_START_COLLAPSED;
-        params.add_group(Params::GroupStart, Params::GroupEnd, "Layer Controls", false, |params| {
-            params.add(Params::LayerBlend, "Layer Opacity", ae::FloatSliderDef::setup(|f| {
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        params.add(
+            Params::ColorBlend,
+            "Color Blend Ratio",
+            ae::FloatSliderDef::setup(|f| {
                 f.set_valid_min(XFORM_AMOUNT_MIN);
                 f.set_valid_max(XFORM_AMOUNT_MAX);
                 f.set_slider_min(XFORM_AMOUNT_MIN);
                 f.set_slider_max(XFORM_AMOUNT_MAX);
                 f.set_default(XFORM_COLOR_BLEND_DFLT);
+                f.set_precision(2);
                 f.set_value(f.default());
                 f.set_display_flags(ae::ValueDisplayFlag::PERCENT);
-            }))?;
+            }),
+        )?;
 
-            params.add(Params::Layer, "Layer Blend Ratio", ae::LayerDef::setup(|f| {
-                f.set_default_to_this_layer();
-            }))?;
-            Ok(())
-        })?;
+        params.add(
+            Params::Color,
+            "Color",
+            ae::ColorDef::setup(|f| {
+                f.set_default(ae::Pixel8 {
+                    red: 128,
+                    green: 255,
+                    blue: 255,
+                    alpha: 255,
+                });
+                f.set_value(f.default());
+            }),
+        )?;
+
+        // def.flags = PF_ParamFlag_START_COLLAPSED;
+        params.add_group(
+            Params::GroupStart,
+            Params::GroupEnd,
+            "Layer Controls",
+            false,
+            |params| {
+                params.add(
+                    Params::LayerBlend,
+                    "Layer Opacity",
+                    ae::FloatSliderDef::setup(|f| {
+                        f.set_valid_min(XFORM_AMOUNT_MIN);
+                        f.set_valid_max(XFORM_AMOUNT_MAX);
+                        f.set_slider_min(XFORM_AMOUNT_MIN);
+                        f.set_slider_max(XFORM_AMOUNT_MAX);
+                        f.set_default(XFORM_COLOR_BLEND_DFLT);
+                        f.set_value(f.default());
+                        f.set_display_flags(ae::ValueDisplayFlag::PERCENT);
+                    }),
+                )?;
+
+                params.add(
+                    Params::Layer,
+                    "Layer Blend Ratio",
+                    ae::LayerDef::setup(|f| {
+                        f.set_default_to_this_layer();
+                    }),
+                )?;
+                Ok(())
+            },
+        )?;
 
         Ok(())
     }
 
-    fn handle_command(&self, cmd: ae::Command, in_data: InData, mut out_data: OutData, params: &mut ae::Parameters<Params>) -> Result<(), ae::Error> {
+    fn handle_command(
+        &self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
         match cmd {
             ae::Command::About => {
                 out_data.set_return_msg("Resizer, v2.2,\rDemonstrate image processing callbacks.\nCopyright 2007-2023 Adobe Inc.");
             }
-            ae::Command::Render { in_layer, mut out_layer } => {
+            ae::Command::Render {
+                in_layer,
+                mut out_layer,
+            } => {
                 let in_extent = in_layer.extent_hint();
                 let out_extent = out_layer.extent_hint();
 
                 // We're going to blend the input with the color. If the user has picked an additional layer, we'll blend it in too, giving it a 'special' look along the way.
                 if in_data.quality() == ae::Quality::Hi && !in_data.is_premiere() {
-                    ae::pf::suites::WorldTransform::new()?.copy_hq(in_data.effect_ref(), &in_layer, &mut out_layer, Some(in_extent), Some(out_extent))?;
+                    ae::pf::suites::WorldTransform::new()?.copy_hq(
+                        in_data.effect_ref(),
+                        &in_layer,
+                        &mut out_layer,
+                        Some(in_extent),
+                        Some(out_extent),
+                    )?;
                 } else if !in_data.is_premiere() {
-                    ae::pf::suites::WorldTransform::new()?.copy(in_data.effect_ref(), &in_layer, &mut out_layer, Some(in_extent), Some(out_extent))?;
+                    ae::pf::suites::WorldTransform::new()?.copy(
+                        in_data.effect_ref(),
+                        &in_layer,
+                        &mut out_layer,
+                        Some(in_extent),
+                        Some(out_extent),
+                    )?;
                 } else {
                     out_layer.copy_from(&in_layer, Some(in_extent), Some(out_extent))?;
                 }
@@ -102,8 +150,13 @@ impl AdobePluginGlobal for Plugin {
 
                 in_data.interact().abort()?;
 
-                let mut color_world = ae::pf::suites::World::new()?
-                    .new_world(in_data.clone(), width as _, height as _, true, pixel_format)?;
+                let mut color_world = ae::pf::suites::World::new()?.new_world(
+                    in_data.clone(),
+                    width as _,
+                    height as _,
+                    true,
+                    pixel_format,
+                )?;
 
                 in_data.interact().abort()?;
 
@@ -116,15 +169,27 @@ impl AdobePluginGlobal for Plugin {
 
                 in_data.interact().abort()?;
 
-                let layer_blend = params.get(Params::LayerBlend)?.as_float_slider()?.value() as f32 / 100.0;
-                let color_blend = params.get(Params::ColorBlend)?.as_float_slider()?.value() as f32 / 100.0;
+                let layer_blend =
+                    params.get(Params::LayerBlend)?.as_float_slider()?.value() as f32 / 100.0;
+                let color_blend =
+                    params.get(Params::ColorBlend)?.as_float_slider()?.value() as f32 / 100.0;
 
                 if let Some(ref temp_param) = temp_param {
-                    ae::pf::suites::WorldTransform::new()?
-                        .blend(in_data.effect_ref(), temp_param, color_world.as_ptr(), layer_blend, &mut color_world)?;
+                    ae::pf::suites::WorldTransform::new()?.blend(
+                        in_data.effect_ref(),
+                        temp_param,
+                        color_world.as_ptr(),
+                        layer_blend,
+                        &mut color_world,
+                    )?;
                 } else {
-                    ae::pf::suites::WorldTransform::new()?
-                        .blend(in_data.effect_ref(), &in_layer, &color_world, color_blend, &mut out_layer)?;
+                    ae::pf::suites::WorldTransform::new()?.blend(
+                        in_data.effect_ref(),
+                        &in_layer,
+                        &color_world,
+                        color_blend,
+                        &mut out_layer,
+                    )?;
                 }
 
                 in_data.interact().abort()?;
@@ -132,13 +197,13 @@ impl AdobePluginGlobal for Plugin {
                 // Blend the color layer () with the output
 
                 let mode = ae::CompositeMode {
-                    xfer:       ae::TransferMode::Difference,
-                    opacity:    (layer_blend * ae::MAX_CHANNEL8  as f32).round() as _,
+                    xfer: ae::TransferMode::Difference,
+                    opacity: (layer_blend * ae::MAX_CHANNEL8 as f32).round() as _,
                     opacity_su: (layer_blend * ae::MAX_CHANNEL16 as f32).round() as _,
-                    rgb_only:   true,
-                    rand_seed:  0
+                    rgb_only: true,
+                    rand_seed: 0,
                 };
-                let destx = (out_extent.right  - color_world.extent_hint().right).abs() / 2;
+                let destx = (out_extent.right - color_world.extent_hint().right).abs() / 2;
                 let desty = (out_extent.bottom - color_world.extent_hint().bottom).abs() / 2;
                 ae::pf::suites::WorldTransform::new()?.transfer_rect(
                     in_data.effect_ref(),
@@ -151,7 +216,7 @@ impl AdobePluginGlobal for Plugin {
                     None,
                     destx,
                     desty,
-                    &mut out_layer
+                    &mut out_layer,
                 )?;
 
                 in_data.interact().abort()?;

--- a/pipl/src/lib.rs
+++ b/pipl/src/lib.rs
@@ -376,27 +376,27 @@ bitflags::bitflags! {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
 pub enum FilterCaseInfoIn {
-    CantFilter = 0,
-    StraightData = 1,
-    BlackMat = 2,
-    GrayMat = 3,
-    WhiteMat = 4,
-    Defringe = 5,
-    BlackZap = 6,
-    GrayZap = 7,
-    WhiteZap = 8,
+    CantFilter    = 0,
+    StraightData  = 1,
+    BlackMat      = 2,
+    GrayMat       = 3,
+    WhiteMat      = 4,
+    Defringe      = 5,
+    BlackZap      = 6,
+    GrayZap       = 7,
+    WhiteZap      = 8,
     BackgroundZap = 10,
     ForegroundZap = 11,
 }
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
 pub enum FilterCaseInfoOut {
-    CantFilter = 0,
+    CantFilter   = 0,
     StraightData = 1,
-    BlackMat = 2,
-    GrayMat = 3,
-    WhiteMat = 4,
-    FillMask = 9,
+    BlackMat     = 2,
+    GrayMat      = 3,
+    WhiteMat     = 4,
+    FillMask     = 9,
 }
 #[derive(Debug)]
 pub struct FilterCaseInfoStruct {
@@ -411,20 +411,20 @@ pub struct FilterCaseInfoStruct {
 #[repr(u8)]
 #[derive(Debug, Clone, Copy)]
 pub enum BitTypes {
-    None = 0x00,
-    Top = 0x01,
-    Right = 0x02,
-    Bottom = 0x04,
-    Left = 0x08,
+    None       = 0x00,
+    Top        = 0x01,
+    Right      = 0x02,
+    Bottom     = 0x04,
+    Left       = 0x08,
     UpperRight = 0x10,
     LowerRight = 0x20,
-    LowerLeft = 0x40,
-    UpperLeft = 0x80,
+    LowerLeft  = 0x40,
+    UpperLeft  = 0x80,
 }
 #[repr(u32)]
 #[derive(Debug, Clone, Copy)]
 pub enum PixelAspectRatio {
-    AnyPAR = 0x10000,
+    AnyPAR   = 0x10000,
     UnityPAR = 0x20000,
 }
 
@@ -1593,7 +1593,10 @@ pub fn plugin_build(properties: Vec<Property>) {
                 if x.contains(OutFlags::IDoDialog) {
                     println!("cargo:rustc-cfg=does_dialog");
                 }
-                if x.contains(OutFlags::IUseAudio) || x.contains(OutFlags::AudioEffectToo) || x.contains(OutFlags::AudioEffectOnly) {
+                if x.contains(OutFlags::IUseAudio)
+                    || x.contains(OutFlags::AudioEffectToo)
+                    || x.contains(OutFlags::AudioEffectOnly)
+                {
                     println!("cargo:rustc-cfg=uses_audio");
                 }
                 if x.contains(OutFlags::SendUpdateParamsUI) {
@@ -1615,7 +1618,9 @@ pub fn plugin_build(properties: Vec<Property>) {
                     println!("cargo:rustc-cfg=threaded_rendering");
 
                     if !x.contains(OutFlags2::SupportsGetFlattenedSequenceData) {
-                        println!("cargo:warning=Setting the SupportsThreadedRendering flag without the SupportsGetFlattenedSequenceData flag can cause plugins to fail to load in some older versions of After Effects.");
+                        println!(
+                            "cargo:warning=Setting the SupportsThreadedRendering flag without the SupportsGetFlattenedSequenceData flag can cause plugins to fail to load in some older versions of After Effects."
+                        );
                     }
                 }
                 println!("cargo:rustc-check-cfg=cfg(gpu_render)");
@@ -1641,14 +1646,22 @@ pub fn plugin_build(properties: Vec<Property>) {
     // output 8byte PkgInfo and the Info.plist
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     {
-        let pkginfo_path = format!("{}/../../../{}_PkgInfo", std::env::var("OUT_DIR").unwrap(), std::env::var("CARGO_PKG_NAME").unwrap());
+        let pkginfo_path = format!(
+            "{}/../../../{}_PkgInfo",
+            std::env::var("OUT_DIR").unwrap(),
+            std::env::var("CARGO_PKG_NAME").unwrap()
+        );
 
         let fxtc_tag = b"FXTC";
         let kind_tag = _kind.as_bytes();
         let pkginfo_bytes = [kind_tag, *fxtc_tag].concat();
         std::fs::write(pkginfo_path, &pkginfo_bytes).unwrap();
 
-        let plist_path = format!("{}/../../../{}_Info.plist", std::env::var("OUT_DIR").unwrap(), std::env::var("CARGO_PKG_NAME").unwrap());
+        let plist_path = format!(
+            "{}/../../../{}_Info.plist",
+            std::env::var("OUT_DIR").unwrap(),
+            std::env::var("CARGO_PKG_NAME").unwrap()
+        );
         plist::produce_plist(plist_path, _kind, _name);
     }
 

--- a/premiere-sys/build.rs
+++ b/premiere-sys/build.rs
@@ -13,12 +13,15 @@ fn main() {
         return;
     }
 
-    let pr_sdk_path = &env::var("PRSDK_ROOT").ok().filter(|x| !x.is_empty()).expect(
-        "PRSDK_ROOT environment variable not set – cannot find Adobe Premiere SDK.\n\
+    let pr_sdk_path = &env::var("PRSDK_ROOT")
+        .ok()
+        .filter(|x| !x.is_empty())
+        .expect(
+            "PRSDK_ROOT environment variable not set – cannot find Adobe Premiere SDK.\n\
         Please set PRSDK_ROOT to the root folder of your Adobe Premiere SDK\n\
         installation (this folder contains the Examples folder & the SDK\n\
         Guide PDF).",
-    );
+        );
 
     if !Path::new(pr_sdk_path).exists() {
         panic!("PRSDK_ROOT environment variable points to non-existent path: {pr_sdk_path}");
@@ -57,14 +60,15 @@ fn main() {
     }
 
     if let Ok(ae_sdk) = env::var("AESDK_ROOT") {
-        pr_bindings = pr_bindings.clang_arg(format!(
-            "-I{}",
-            Path::new(&ae_sdk)
-                .join("Examples")
-                .join("Headers")
-                .display()
-        ))
-        .clang_arg("--define-macro=HAS_AE_SDK");
+        pr_bindings = pr_bindings
+            .clang_arg(format!(
+                "-I{}",
+                Path::new(&ae_sdk)
+                    .join("Examples")
+                    .join("Headers")
+                    .display()
+            ))
+            .clang_arg("--define-macro=HAS_AE_SDK");
     }
 
     if cfg!(target_os = "macos") {

--- a/premiere/build.rs
+++ b/premiere/build.rs
@@ -3,7 +3,10 @@ use std::path::Path;
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(has_ae_sdk)");
     if let Ok(sdk) = std::env::var("AESDK_ROOT") {
-        if Path::new(&sdk).join("Examples/Headers/AE_Effect.h").exists() {
+        if Path::new(&sdk)
+            .join("Examples/Headers/AE_Effect.h")
+            .exists()
+        {
             println!("cargo:rustc-cfg=has_ae_sdk");
         }
     } else if std::env::var("PRSDK_ROOT").is_err() {

--- a/premiere/src/gpu_filter.rs
+++ b/premiere/src/gpu_filter.rs
@@ -6,45 +6,55 @@ pub struct RenderParams {
     ptr: *const crate::sys::PrGPUFilterRenderParams,
 }
 impl RenderParams {
-    pub fn from_raw(ptr: *const crate::sys::PrGPUFilterRenderParams) -> Self {
-        Self {
-            ptr
-        }
-    }
+    pub fn from_raw(ptr: *const crate::sys::PrGPUFilterRenderParams) -> Self { Self { ptr } }
+
     /// Clip time of the current render
     pub fn clip_time(&self) -> i64 {
         assert!(!self.ptr.is_null());
         unsafe { (*self.ptr).inClipTime }
     }
+
     /// Sequence time of the current render
     pub fn sequence_time(&self) -> i64 {
         assert!(!self.ptr.is_null());
         unsafe { (*self.ptr).inSequenceTime }
     }
+
     pub fn quality(&self) -> RenderQuality {
         assert!(!self.ptr.is_null());
         unsafe { (*self.ptr).inQuality.into() }
     }
+
     pub fn downsample_factor(&self) -> (f32, f32) {
         assert!(!self.ptr.is_null());
-        unsafe { ((*self.ptr).inDownsampleFactorX, (*self.ptr).inDownsampleFactorY) }
+        unsafe {
+            (
+                (*self.ptr).inDownsampleFactorX,
+                (*self.ptr).inDownsampleFactorY,
+            )
+        }
     }
+
     pub fn render_width(&self) -> u32 {
         assert!(!self.ptr.is_null());
         unsafe { (*self.ptr).inRenderWidth }
     }
+
     pub fn render_height(&self) -> u32 {
         assert!(!self.ptr.is_null());
         unsafe { (*self.ptr).inRenderHeight }
     }
-    pub fn render_pixel_aspect_ratio(&self) -> (u32, u32)  {
+
+    pub fn render_pixel_aspect_ratio(&self) -> (u32, u32) {
         assert!(!self.ptr.is_null());
         unsafe { ((*self.ptr).inRenderPARNum, (*self.ptr).inRenderPARDen) }
     }
+
     pub fn render_field_type(&self) -> crate::sys::prFieldType {
         assert!(!self.ptr.is_null());
         unsafe { (*self.ptr).inRenderFieldType }
     }
+
     pub fn render_ticks_per_frame(&self) -> i64 {
         assert!(!self.ptr.is_null());
         unsafe { (*self.ptr).inRenderTicksPerFrame }
@@ -73,10 +83,12 @@ impl GpuFilterData {
         assert!(!self.instance_ptr.is_null());
         unsafe { (*self.instance_ptr).inTimelineID }
     }
+
     pub fn node_id(&self) -> i32 {
         assert!(!self.instance_ptr.is_null());
         unsafe { (*self.instance_ptr).inNodeID as i32 }
     }
+
     pub fn device_index(&self) -> u32 {
         assert!(!self.instance_ptr.is_null());
         unsafe { (*self.instance_ptr).inDeviceIndex as u32 }
@@ -107,30 +119,48 @@ impl GpuFilterData {
     /// Returns a tuple containing:
     /// * `keyframe_time` - The time of the next keyframe > inTime
     /// * `keyframe_interpolation_mode` - The temporal interpolation mode of the keyframe
-    pub fn next_keyframe_time(&self, index: usize, time: i64) -> Result<(i64, KeyframeInterpolationMode), Error> {
+    pub fn next_keyframe_time(
+        &self,
+        index: usize,
+        time: i64,
+    ) -> Result<(i64, KeyframeInterpolationMode), Error> {
         let index = index as i32 - 1; // GPU filters don't include the input frame as first paramter
 
-        self.video_segment_suite.next_keyframe_time(self.node_id(), index, time)
+        self.video_segment_suite
+            .next_keyframe_time(self.node_id(), index, time)
     }
 
-    pub fn param_arbitrary_data<T: for<'a> serde::Deserialize<'a>>(&self, index: usize, time: i64) -> Result<T, Error> {
+    pub fn param_arbitrary_data<T: for<'a> serde::Deserialize<'a>>(
+        &self,
+        index: usize,
+        time: i64,
+    ) -> Result<T, Error> {
         let ptr = self.param(index, time)?;
         if let crate::Param::MemoryPtr(ptr) = ptr {
             if !ptr.is_null() {
-                let serialized = unsafe { std::slice::from_raw_parts(ptr as *mut u8, self.memory_manager_suite.ptr_size(ptr) as _) };
-                if let Ok(t) = bincode::serde::decode_from_slice::<T, _>(serialized, bincode::config::legacy()) {
+                let serialized = unsafe {
+                    std::slice::from_raw_parts(
+                        ptr as *mut u8,
+                        self.memory_manager_suite.ptr_size(ptr) as _,
+                    )
+                };
+                if let Ok(t) =
+                    bincode::serde::decode_from_slice::<T, _>(serialized, bincode::config::legacy())
+                {
                     return Ok(t.0);
                 }
             }
         }
         Err(Error::InvalidParms)
     }
+
     pub fn property(&self, property: Property) -> Result<PropertyData, Error> {
-        self.video_segment_suite.node_property(self.node_id(), property)
+        self.video_segment_suite
+            .node_property(self.node_id(), property)
     }
 }
 
-pub trait GpuFilter : Default {
+pub trait GpuFilter: Default {
     /// Called once at startup to initialize any global state.
     /// * Note that the instances are created and destroyed many times during the same render,
     ///   so don't rely on `Default` or `Drop` for any global state
@@ -142,21 +172,39 @@ pub trait GpuFilter : Default {
     fn global_destroy();
 
     /// Return dependency information about a render, or nothing if only the current frame is required.
-    fn get_frame_dependencies(&self, filter: &GpuFilterData, render_params: RenderParams, query_index: &mut i32) -> Result<crate::sys::PrGPUFilterFrameDependency, Error>;
+    fn get_frame_dependencies(
+        &self,
+        filter: &GpuFilterData,
+        render_params: RenderParams,
+        query_index: &mut i32,
+    ) -> Result<crate::sys::PrGPUFilterFrameDependency, Error>;
 
     /// Precompute a result into preallocated uninitialized host (pinned) memory.
     /// Will only be called if PrGPUDependency_Precompute was returned from GetFrameDependencies.
     /// Precomputation may be called ahead of render time. Results will be
     /// uploaded to the GPU by the host. If outPrecomputePixelFormat is not custom,
     /// frames will be converted to the GPU pixel format.
-    fn precompute(&self, filter: &GpuFilterData, render_params: RenderParams, index: i32, frame: crate::sys::PPixHand) -> Result<(), Error>;
+    fn precompute(
+        &self,
+        filter: &GpuFilterData,
+        render_params: RenderParams,
+        index: i32,
+        frame: crate::sys::PPixHand,
+    ) -> Result<(), Error>;
 
     /// Render into an allocated outFrame allocated with PrSDKGPUDeviceSuite or operate
     /// in place. Result must be in the same pixel format as the input. For effects, frame 0
     /// will always be the frame at the current time, other input frames will be in the same order as
     /// returned from GetFrameDependencies. For transitions frame 0 will be the incoming frame and
     /// frame 1 the outgoing frame. Transitions may not have other frame dependencies.
-    fn render(&self, filter: &GpuFilterData, render_params: RenderParams, frames: *const crate::sys::PPixHand, frame_count: usize, out_frame: *mut crate::sys::PPixHand) -> Result<(), Error>;
+    fn render(
+        &self,
+        filter: &GpuFilterData,
+        render_params: RenderParams,
+        frames: *const crate::sys::PPixHand,
+        frame_count: usize,
+        out_frame: *mut crate::sys::PPixHand,
+    ) -> Result<(), Error>;
 }
 
 pub struct GpuFilterInstance<T: GpuFilter> {
@@ -177,7 +225,9 @@ macro_rules! define_gpu_filter {
     ($struct_name:ty) => {
         use $crate::GpuFilter;
 
-        unsafe extern "C" fn gpu_filter_create_instance(instance_data: *mut $crate::sys::PrGPUFilterInstance) -> $crate::sys::prSuiteError {
+        unsafe extern "C" fn gpu_filter_create_instance(
+            instance_data: *mut $crate::sys::PrGPUFilterInstance,
+        ) -> $crate::sys::prSuiteError {
             assert!(!instance_data.is_null());
 
             let util_funcs = (*(*(*instance_data).piSuites).utilFuncs);
@@ -185,40 +235,45 @@ macro_rules! define_gpu_filter {
 
             let _pica = $crate::PicaBasicSuite::from_sp_basic_suite_raw(sp_basic_suite);
 
-            let result = (|| -> Result<Box<$crate::GpuFilterInstance<$struct_name>>, $crate::Error> {
-                let gpu_suite = $crate::suites::GPUDevice::new()?;
-                let gpu_info = gpu_suite.device_info((*instance_data).inDeviceIndex)?;
-                Ok(Box::new($crate::GpuFilterInstance {
-                    data: $crate::GpuFilterData {
-                        instance_ptr: instance_data,
-                        gpu_device_suite:           gpu_suite,
-                        gpu_image_processing_suite: $crate::suites::GPUImageProcessing::new()?,
-                        memory_manager_suite:       $crate::suites::MemoryManager::new()?,
-                        ppix_suite:                 $crate::suites::PPix::new()?,
-                        ppix2_suite:                $crate::suites::PPix2::new()?,
-                        video_segment_suite:        $crate::suites::VideoSegment::new()?,
-                        gpu_info
-                    },
-                    instance: <$struct_name>::default(),
-                }))
-            })();
+            let result =
+                (|| -> Result<Box<$crate::GpuFilterInstance<$struct_name>>, $crate::Error> {
+                    let gpu_suite = $crate::suites::GPUDevice::new()?;
+                    let gpu_info = gpu_suite.device_info((*instance_data).inDeviceIndex)?;
+                    Ok(Box::new($crate::GpuFilterInstance {
+                        data: $crate::GpuFilterData {
+                            instance_ptr: instance_data,
+                            gpu_device_suite: gpu_suite,
+                            gpu_image_processing_suite: $crate::suites::GPUImageProcessing::new()?,
+                            memory_manager_suite: $crate::suites::MemoryManager::new()?,
+                            ppix_suite: $crate::suites::PPix::new()?,
+                            ppix2_suite: $crate::suites::PPix2::new()?,
+                            video_segment_suite: $crate::suites::VideoSegment::new()?,
+                            gpu_info,
+                        },
+                        instance: <$struct_name>::default(),
+                    }))
+                })();
 
             match result {
                 Ok(instance) => {
                     (*instance_data).ioPrivatePluginData = Box::into_raw(instance) as *mut _;
                     $crate::sys::suiteError_NoError
                 }
-                Err(e) => {
-                    e as $crate::sys::prSuiteError
-                }
+                Err(e) => e as $crate::sys::prSuiteError,
             }
         }
 
-        unsafe extern "C" fn gpu_filter_dispose_instance(instance_data: *mut $crate::sys::PrGPUFilterInstance) -> $crate::sys::prSuiteError {
+        unsafe extern "C" fn gpu_filter_dispose_instance(
+            instance_data: *mut $crate::sys::PrGPUFilterInstance,
+        ) -> $crate::sys::prSuiteError {
             let util_funcs = (*(*(*instance_data).piSuites).utilFuncs);
-            let _pica = $crate::PicaBasicSuite::from_sp_basic_suite_raw((util_funcs.getSPBasicSuite.unwrap())());
+            let _pica = $crate::PicaBasicSuite::from_sp_basic_suite_raw((util_funcs
+                .getSPBasicSuite
+                .unwrap())());
 
-            let _ = Box::<$crate::GpuFilterInstance<$struct_name>>::from_raw((*instance_data).ioPrivatePluginData as *mut _);
+            let _ = Box::<$crate::GpuFilterInstance<$struct_name>>::from_raw(
+                (*instance_data).ioPrivatePluginData as *mut _,
+            );
 
             (*instance_data).ioPrivatePluginData = std::ptr::null_mut();
 
@@ -232,14 +287,22 @@ macro_rules! define_gpu_filter {
             out_frame_dependencies: *mut $crate::sys::PrGPUFilterFrameDependency,
         ) -> $crate::sys::prSuiteError {
             let util_funcs = (*(*(*instance_data).piSuites).utilFuncs);
-            let _pica = $crate::PicaBasicSuite::from_sp_basic_suite_raw((util_funcs.getSPBasicSuite.unwrap())());
+            let _pica = $crate::PicaBasicSuite::from_sp_basic_suite_raw((util_funcs
+                .getSPBasicSuite
+                .unwrap())());
 
-            let mut instance = Box::<$crate::GpuFilterInstance<$struct_name>>::from_raw((*instance_data).ioPrivatePluginData as *mut _);
+            let mut instance = Box::<$crate::GpuFilterInstance<$struct_name>>::from_raw(
+                (*instance_data).ioPrivatePluginData as *mut _,
+            );
 
             instance.data.instance_ptr = instance_data;
 
             let render_params = $crate::RenderParams::from_raw(render_params);
-            let result = instance.instance.get_frame_dependencies(&instance.data, render_params, &mut *io_query_index);
+            let result = instance.instance.get_frame_dependencies(
+                &instance.data,
+                render_params,
+                &mut *io_query_index,
+            );
 
             let _ = Box::into_raw(instance); // leak the box so it doesn't run the destructor
 
@@ -247,7 +310,7 @@ macro_rules! define_gpu_filter {
                 Ok(dep) => {
                     *out_frame_dependencies = dep;
                     $crate::sys::suiteError_NoError
-                },
+                }
                 Err(e) => e as $crate::sys::prSuiteError,
             }
         }
@@ -259,14 +322,20 @@ macro_rules! define_gpu_filter {
             frame: $crate::sys::PPixHand,
         ) -> $crate::sys::prSuiteError {
             let util_funcs = (*(*(*instance_data).piSuites).utilFuncs);
-            let _pica = $crate::PicaBasicSuite::from_sp_basic_suite_raw((util_funcs.getSPBasicSuite.unwrap())());
+            let _pica = $crate::PicaBasicSuite::from_sp_basic_suite_raw((util_funcs
+                .getSPBasicSuite
+                .unwrap())());
 
-            let mut instance = Box::<$crate::GpuFilterInstance<$struct_name>>::from_raw((*instance_data).ioPrivatePluginData as *mut _);
+            let mut instance = Box::<$crate::GpuFilterInstance<$struct_name>>::from_raw(
+                (*instance_data).ioPrivatePluginData as *mut _,
+            );
 
             instance.data.instance_ptr = instance_data;
 
             let render_params = $crate::RenderParams::from_raw(render_params);
-            let result = instance.instance.precompute(&instance.data, render_params, index, frame);
+            let result = instance
+                .instance
+                .precompute(&instance.data, render_params, index, frame);
 
             let _ = Box::into_raw(instance); // leak the box so it doesn't run the destructor
 
@@ -284,14 +353,24 @@ macro_rules! define_gpu_filter {
             out_frame: *mut $crate::sys::PPixHand,
         ) -> $crate::sys::prSuiteError {
             let util_funcs = (*(*(*instance_data).piSuites).utilFuncs);
-            let _pica = $crate::PicaBasicSuite::from_sp_basic_suite_raw((util_funcs.getSPBasicSuite.unwrap())());
+            let _pica = $crate::PicaBasicSuite::from_sp_basic_suite_raw((util_funcs
+                .getSPBasicSuite
+                .unwrap())());
 
-            let mut instance = Box::<$crate::GpuFilterInstance<$struct_name>>::from_raw((*instance_data).ioPrivatePluginData as *mut _);
+            let mut instance = Box::<$crate::GpuFilterInstance<$struct_name>>::from_raw(
+                (*instance_data).ioPrivatePluginData as *mut _,
+            );
 
             instance.data.instance_ptr = instance_data;
 
             let render_params = $crate::RenderParams::from_raw(render_params);
-            let result = instance.instance.render(&instance.data, render_params, frames, frame_count as usize, out_frame);
+            let result = instance.instance.render(
+                &instance.data,
+                render_params,
+                frames,
+                frame_count as usize,
+                out_frame,
+            );
 
             let _ = Box::into_raw(instance); // leak the box so it doesn't run the destructor
 
@@ -311,16 +390,17 @@ macro_rules! define_gpu_filter {
             out_filter: *mut $crate::sys::PrGPUFilter,
             out_filter_info: *mut $crate::sys::PrGPUFilterInfo,
         ) -> $crate::sys::prSuiteError {
-
             let util_funcs = (*(*pi_suites).utilFuncs);
-            let _pica = $crate::PicaBasicSuite::from_sp_basic_suite_raw((util_funcs.getSPBasicSuite.unwrap())());
+            let _pica = $crate::PicaBasicSuite::from_sp_basic_suite_raw((util_funcs
+                .getSPBasicSuite
+                .unwrap())());
 
             if is_startup == 1 {
-                (*out_filter).CreateInstance       = Some(gpu_filter_create_instance);
-                (*out_filter).DisposeInstance      = Some(gpu_filter_dispose_instance);
+                (*out_filter).CreateInstance = Some(gpu_filter_create_instance);
+                (*out_filter).DisposeInstance = Some(gpu_filter_dispose_instance);
                 (*out_filter).GetFrameDependencies = Some(gpu_filter_get_frame_dependencies);
-                (*out_filter).Precompute           = Some(gpu_filter_precompute);
-                (*out_filter).Render               = Some(gpu_filter_render);
+                (*out_filter).Precompute = Some(gpu_filter_precompute);
+                (*out_filter).Render = Some(gpu_filter_render);
 
                 let plugin_count = 1;
 
@@ -334,7 +414,8 @@ macro_rules! define_gpu_filter {
 
                 // let match_name = $crate::sys::PrSDKString::default();
                 (*out_filter_info).outMatchName = unsafe { std::mem::zeroed() };
-                (*out_filter_info).outInterfaceVersion = $crate::sys::PrSDKGPUFilterInterfaceVersion;
+                (*out_filter_info).outInterfaceVersion =
+                    $crate::sys::PrSDKGPUFilterInterfaceVersion;
 
                 <$struct_name>::global_init();
             } else {

--- a/premiere/src/lib.rs
+++ b/premiere/src/lib.rs
@@ -2,8 +2,8 @@
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
 
 use premiere_sys as pr_sys;
-use std::ptr;
 use std::cell::RefCell;
+use std::ptr;
 
 #[macro_use]
 mod macros;
@@ -20,39 +20,50 @@ pub(crate) mod pf_suites {
     pub(crate) mod utility;
 }
 pub mod suites {
-    pub(crate) mod gpu_device;               pub use gpu_device          ::GPUDeviceSuite          as GPUDevice;
-    pub(crate) mod gpu_image_processing;     pub use gpu_image_processing::GPUImageProcessingSuite as GPUImageProcessing;
-    pub(crate) mod memory_manager;           pub use memory_manager      ::MemoryManagerSuite      as MemoryManager;
-    pub(crate) mod ppix;                     pub use ppix                ::{PPixSuite              as PPix,
-                                                                            PPix2Suite             as PPix2 };
-    pub(crate) mod time;                     pub use time                ::TimeSuite               as Time;
-    pub(crate) mod sequence_info;            pub use sequence_info       ::SequenceInfoSuite       as SequenceInfo;
-    pub(crate) mod video_segment;            pub use video_segment       ::VideoSegmentSuite       as VideoSegment;
-    pub(crate) mod string;                   pub use string              ::PrStringSuite           as PrString;
-    pub(crate) mod window;                   pub use window              ::WindowSuite             as Window;
+    pub(crate) mod gpu_device;
+    pub use gpu_device::GPUDeviceSuite as GPUDevice;
+    pub(crate) mod gpu_image_processing;
+    pub use gpu_image_processing::GPUImageProcessingSuite as GPUImageProcessing;
+    pub(crate) mod memory_manager;
+    pub use memory_manager::MemoryManagerSuite as MemoryManager;
+    pub(crate) mod ppix;
+    pub use ppix::{PPix2Suite as PPix2, PPixSuite as PPix};
+    pub(crate) mod time;
+    pub use time::TimeSuite as Time;
+    pub(crate) mod sequence_info;
+    pub use sequence_info::SequenceInfoSuite as SequenceInfo;
+    pub(crate) mod video_segment;
+    pub use video_segment::VideoSegmentSuite as VideoSegment;
+    pub(crate) mod string;
+    pub use string::PrStringSuite as PrString;
+    pub(crate) mod window;
+    pub use window::WindowSuite as Window;
+    #[cfg(has_ae_sdk)]
+    mod opaque_effect_data;
     pub(crate) mod video_segment_properties;
-    #[cfg(has_ae_sdk)] mod opaque_effect_data;
-    #[cfg(has_ae_sdk)] pub use opaque_effect_data::OpaqueEffectDataSuite as OpaqueEffectData;
+    #[cfg(has_ae_sdk)]
+    pub use opaque_effect_data::OpaqueEffectDataSuite as OpaqueEffectData;
 
     pub use crate::pf_suites::background_frame::BackgroundFrameSuite as BackgroundFrame;
-    pub use crate::pf_suites::cache_on_load   ::CacheOnLoadSuite     as CacheOnLoad;
-    pub use crate::pf_suites::pixel_format    ::PixelFormatSuite     as PixelFormat;
-    pub use crate::pf_suites::source_settings ::SourceSettingsSuite  as SourceSettings;
-    pub use crate::pf_suites::transition      ::TransitionSuite      as Transition;
-    pub use crate::pf_suites::utility         ::UtilitySuite         as Utility;
+    pub use crate::pf_suites::cache_on_load::CacheOnLoadSuite as CacheOnLoad;
+    pub use crate::pf_suites::pixel_format::PixelFormatSuite as PixelFormat;
+    pub use crate::pf_suites::source_settings::SourceSettingsSuite as SourceSettings;
+    pub use crate::pf_suites::transition::TransitionSuite as Transition;
+    pub use crate::pf_suites::utility::UtilitySuite as Utility;
 }
 
 pub mod utils {
-    pub mod video_sequence_parser; pub use video_sequence_parser::VideoSequenceParser;
+    pub mod video_sequence_parser;
+    pub use video_sequence_parser::VideoSequenceParser;
 }
 
-pub use suites::string::PrString;
-pub use suites::video_segment_properties::*;
-pub use suites::video_segment::VideoSegmentProperties;
-pub use suites::ppix::YUV420PlanarBuffers;
-pub use suites::sequence_info::ImmersiveVideoVRConfiguration;
 pub use pf_suites::background_frame::TransferMode;
 pub use pf_suites::pixel_format::NewWorldFlags;
+pub use suites::ppix::YUV420PlanarBuffers;
+pub use suites::sequence_info::ImmersiveVideoVRConfiguration;
+pub use suites::string::PrString;
+pub use suites::video_segment::VideoSegmentProperties;
+pub use suites::video_segment_properties::*;
 
 pub use premiere_sys as sys;
 
@@ -129,67 +140,93 @@ define_enum! {
 impl From<Error> for &'static str {
     fn from(error: Error) -> &'static str {
         match error {
-            Error::None                                 => "No error",
-            Error::Fail                                 => "Method failed",
-            Error::InvalidParms                         => "A parameter to this method is invalid",
-            Error::OutOfMemory                          => "There is not enough memory to complete this method",
-            Error::InvalidCall                          => "Usually this means this method call is not appropriate at this time",
-            Error::NotImplemented                       => "The requested action is not implemented",
-            Error::IDNotValid                           => "The passed in ID (pluginID, clipID...) is not valid",
-            Error::RenderPending                        => "Render is pending",
-            Error::RenderedFrameNotFound                => "A cached frame was not found.",
-            Error::RenderedFrameCanceled                => "A render was canceled",
-            Error::RenderInvalidPixelFormat             => "Render output pixel format list is invalid",
-            Error::RenderCompletionProcNotSet           => "The render completion proc was not set for an async request",
-            Error::TimeRoundedAudioRate                 => "Audio rate returned was rounded",
-            Error::CompilerCompileAbort                 => "User aborted the compile",
-            Error::CompilerCompileDone                  => "Compile finished normally",
-            Error::CompilerOutputFormatAccept           => "The output format is valid",
-            Error::CompilerOutputFormatDecline          => "The compile module cannot compile to the output format",
-            Error::CompilerRebuildCutList               => "Return value from compGetFilePrefs used to force Premiere to bebuild its cutlist",
-            Error::CompilerIterateCompiler              => "6.0 Return value from compInit to request compiler iteration",
-            Error::CompilerIterateCompilerDone          => "6.0 Return value from compInit to indicate there are no more compilers",
-            Error::CompilerInternalErrorSilent          => "6.0 Silent error code; Premiere will not display an error message on screen. \nCompilers can return this error code from compDoCompile if they wish to put their own customized error message on screen just before returning control to Premiere",
-            Error::CompilerIterateCompilerCacheable     => "7.0 Return value from compInit to request compiler iteration and indicating that this compiler is cacheable.",
-            Error::CompilerBadFormatIndex               => "Invalid format index - used to stop compGetIndFormat queries",
-            Error::CompilerInternalError                => "Compiler interna error",
-            Error::CompilerOutOfDiskSpace               => "Out of disk space error",
-            Error::CompilerBufferFull                   => "The offset into the audio buffer would overflow it",
-            Error::CompilerErrOther                     => "Someone set gCompileErr",
-            Error::CompilerErrMemory                    => "Ran out of memory",
-            Error::CompilerErrFileNotFound              => "File not found",
-            Error::CompilerErrTooManyOpenFiles          => "Too many open files",
-            Error::CompilerErrPermErr                   => "Permission violation",
-            Error::CompilerErrOpenErr                   => "Unable to open the file",
-            Error::CompilerErrInvalidDrive              => "Drive isn't valid.",
-            Error::CompilerErrDupFile                   => "Duplicate Filename",
-            Error::CompilerErrIo                        => "File io error",
-            Error::CompilerErrInUse                     => "File is in use",
-            Error::CompilerErrCodecBadInput             => "A video codec refused the input format",
-            Error::ExporterSuspended                    => "The host has suspended the export",
-            Error::ExporterNoMoreFrames                 => "Halt export early skipping all remaining frames including this one. AE uses",
-            Error::FileBufferTooSmall                   => "File buffer is too small",
-            Error::FileNotImportableFileType            => "Not an importable file type",
-            Error::LegacyInvalidVideoRate               => "Invalid video rate (scale and sample rate don't match a valid rate)",
-            Error::PlayModuleAudioInitFailure           => "PlayModuleAudio - init failure",
-            Error::PlayModuleAudioIllegalPlaySetting    => "PlayModuleAudio - illegal play setting",
-            Error::PlayModuleAudioNotInitialized        => "PlayModuleAudio - not initialized",
-            Error::PlayModuleAudioNotStarted            => "PlayModuleAudio - not started",
-            Error::PlayModuleAudioIllegalAction         => "PlayModuleAudio - illegal action",
-            Error::PlayModuleDeviceControlSuiteIllegalCallSequence => "PlayModuleDeviceControlSuite - illegal call sequence",
-            Error::MediaAcceleratorSuitePathNotFound    => "MediaAcceleratorSuite - path notFound",
-            Error::MediaAcceleratorSuiteRegisterFailure => "MediaAcceleratorSuite - register failure",
-            Error::RepositoryReadFailed                 => "Repository read failed",
-            Error::RepositoryWriteFailed                => "Repository write failed",
-            Error::NotActivated                         => "Not activated",
-            Error::DataNotPresent                       => "Data not present",
-            Error::ServerCommunicationFailed            => "Server communication failed",
-            Error::Internal                             => "Internal error",
-            Error::StringNotFound                       => "String not found",
-            Error::StringBufferTooSmall                 => "String buffer is too small",
-            Error::NoKeyframeAfterInTime                => "No keyframe after InTime",
-            Error::NoMoreData                           => "No more data",
-            Error::InstanceDestroyed                    => "Instance destroyed",
+            Error::None => "No error",
+            Error::Fail => "Method failed",
+            Error::InvalidParms => "A parameter to this method is invalid",
+            Error::OutOfMemory => "There is not enough memory to complete this method",
+            Error::InvalidCall => {
+                "Usually this means this method call is not appropriate at this time"
+            }
+            Error::NotImplemented => "The requested action is not implemented",
+            Error::IDNotValid => "The passed in ID (pluginID, clipID...) is not valid",
+            Error::RenderPending => "Render is pending",
+            Error::RenderedFrameNotFound => "A cached frame was not found.",
+            Error::RenderedFrameCanceled => "A render was canceled",
+            Error::RenderInvalidPixelFormat => "Render output pixel format list is invalid",
+            Error::RenderCompletionProcNotSet => {
+                "The render completion proc was not set for an async request"
+            }
+            Error::TimeRoundedAudioRate => "Audio rate returned was rounded",
+            Error::CompilerCompileAbort => "User aborted the compile",
+            Error::CompilerCompileDone => "Compile finished normally",
+            Error::CompilerOutputFormatAccept => "The output format is valid",
+            Error::CompilerOutputFormatDecline => {
+                "The compile module cannot compile to the output format"
+            }
+            Error::CompilerRebuildCutList => {
+                "Return value from compGetFilePrefs used to force Premiere to bebuild its cutlist"
+            }
+            Error::CompilerIterateCompiler => {
+                "6.0 Return value from compInit to request compiler iteration"
+            }
+            Error::CompilerIterateCompilerDone => {
+                "6.0 Return value from compInit to indicate there are no more compilers"
+            }
+            Error::CompilerInternalErrorSilent => {
+                "6.0 Silent error code; Premiere will not display an error message on screen. \nCompilers can return this error code from compDoCompile if they wish to put their own customized error message on screen just before returning control to Premiere"
+            }
+            Error::CompilerIterateCompilerCacheable => {
+                "7.0 Return value from compInit to request compiler iteration and indicating that this compiler is cacheable."
+            }
+            Error::CompilerBadFormatIndex => {
+                "Invalid format index - used to stop compGetIndFormat queries"
+            }
+            Error::CompilerInternalError => "Compiler interna error",
+            Error::CompilerOutOfDiskSpace => "Out of disk space error",
+            Error::CompilerBufferFull => "The offset into the audio buffer would overflow it",
+            Error::CompilerErrOther => "Someone set gCompileErr",
+            Error::CompilerErrMemory => "Ran out of memory",
+            Error::CompilerErrFileNotFound => "File not found",
+            Error::CompilerErrTooManyOpenFiles => "Too many open files",
+            Error::CompilerErrPermErr => "Permission violation",
+            Error::CompilerErrOpenErr => "Unable to open the file",
+            Error::CompilerErrInvalidDrive => "Drive isn't valid.",
+            Error::CompilerErrDupFile => "Duplicate Filename",
+            Error::CompilerErrIo => "File io error",
+            Error::CompilerErrInUse => "File is in use",
+            Error::CompilerErrCodecBadInput => "A video codec refused the input format",
+            Error::ExporterSuspended => "The host has suspended the export",
+            Error::ExporterNoMoreFrames => {
+                "Halt export early skipping all remaining frames including this one. AE uses"
+            }
+            Error::FileBufferTooSmall => "File buffer is too small",
+            Error::FileNotImportableFileType => "Not an importable file type",
+            Error::LegacyInvalidVideoRate => {
+                "Invalid video rate (scale and sample rate don't match a valid rate)"
+            }
+            Error::PlayModuleAudioInitFailure => "PlayModuleAudio - init failure",
+            Error::PlayModuleAudioIllegalPlaySetting => "PlayModuleAudio - illegal play setting",
+            Error::PlayModuleAudioNotInitialized => "PlayModuleAudio - not initialized",
+            Error::PlayModuleAudioNotStarted => "PlayModuleAudio - not started",
+            Error::PlayModuleAudioIllegalAction => "PlayModuleAudio - illegal action",
+            Error::PlayModuleDeviceControlSuiteIllegalCallSequence => {
+                "PlayModuleDeviceControlSuite - illegal call sequence"
+            }
+            Error::MediaAcceleratorSuitePathNotFound => "MediaAcceleratorSuite - path notFound",
+            Error::MediaAcceleratorSuiteRegisterFailure => {
+                "MediaAcceleratorSuite - register failure"
+            }
+            Error::RepositoryReadFailed => "Repository read failed",
+            Error::RepositoryWriteFailed => "Repository write failed",
+            Error::NotActivated => "Not activated",
+            Error::DataNotPresent => "Data not present",
+            Error::ServerCommunicationFailed => "Server communication failed",
+            Error::Internal => "Internal error",
+            Error::StringNotFound => "String not found",
+            Error::StringBufferTooSmall => "String buffer is too small",
+            Error::NoKeyframeAfterInTime => "No keyframe after InTime",
+            Error::NoMoreData => "No more data",
+            Error::InstanceDestroyed => "Instance destroyed",
         }
     }
 }
@@ -256,7 +293,6 @@ pub(crate) trait Suite {
     fn new() -> Result<Self, Error>
     where
         Self: Sized;
-
 }
 
 pub trait AsPtr<T> {
@@ -267,5 +303,6 @@ pub trait AsPtr<T> {
 
 pub trait AsMutPtr<T> {
     fn as_mut_ptr(&mut self) -> T
-    where T: Sized;
+    where
+        T: Sized;
 }

--- a/premiere/src/pf_suites/background_frame.rs
+++ b/premiere/src/pf_suites/background_frame.rs
@@ -1,4 +1,3 @@
-
 use crate::*;
 use pr_sys::*;
 
@@ -13,22 +12,37 @@ define_suite!(
 impl BackgroundFrameSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
+    pub fn add_supported_background_transfer_mode(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        supported_transfer_mode: TransferMode,
+        supported_pixel_format: PixelFormat,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AddSupportedBackgroundTransferMode,
+            effect_ref.as_ptr(),
+            supported_transfer_mode.into(),
+            supported_pixel_format.into()
+        )
     }
 
-    pub fn add_supported_background_transfer_mode(&self, effect_ref: impl AsPtr<PF_ProgPtr>, supported_transfer_mode: TransferMode, supported_pixel_format: PixelFormat) -> Result<(), Error> {
-        call_suite_fn!(self, AddSupportedBackgroundTransferMode, effect_ref.as_ptr(), supported_transfer_mode.into(), supported_pixel_format.into())
-    }
-
-    pub fn background_frame(&self, in_data: impl AsPtr<*const PF_InData>) -> Result<(*mut PF_EffectWorld, TransferMode), Error> {
+    pub fn background_frame(
+        &self,
+        in_data: impl AsPtr<*const PF_InData>,
+    ) -> Result<(*mut PF_EffectWorld, TransferMode), Error> {
         let mut background_frame = std::ptr::null_mut();
         let mut background_transfer_mode: pr_sys::PF_TransferMode = 0;
-        call_suite_fn!(self, GetBackgroundFrame, (*in_data.as_ptr()).effect_ref, &mut background_frame, &mut background_transfer_mode)?;
-        Ok((
-            background_frame,
-            background_transfer_mode.into()
-        ))
+        call_suite_fn!(
+            self,
+            GetBackgroundFrame,
+            (*in_data.as_ptr()).effect_ref,
+            &mut background_frame,
+            &mut background_transfer_mode
+        )?;
+        Ok((background_frame, background_transfer_mode.into()))
     }
 }
 

--- a/premiere/src/pf_suites/cache_on_load.rs
+++ b/premiere/src/pf_suites/cache_on_load.rs
@@ -1,4 +1,3 @@
-
 use crate::*;
 use pr_sys::*;
 
@@ -19,13 +18,20 @@ define_suite!(
 impl CacheOnLoadSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Pass a non-zero value if you want your effect to show up in the UI.
     /// Pass zero if loading failed, but you still want Premiere Pro to attempt to load it again on the next relaunch.
-    pub fn set_no_cache_on_load(&self, effect_ref: impl AsPtr<PF_ProgPtr>, effect_available: bool) -> Result<(), Error> {
-        call_suite_fn!(self, PF_SetNoCacheOnLoad, effect_ref.as_ptr(), effect_available as _)
+    pub fn set_no_cache_on_load(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        effect_available: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PF_SetNoCacheOnLoad,
+            effect_ref.as_ptr(),
+            effect_available as _
+        )
     }
 }

--- a/premiere/src/pf_suites/pixel_format.rs
+++ b/premiere/src/pf_suites/pixel_format.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use pr_sys::{ PF_ProgPtr, PF_InData };
+use pr_sys::{PF_InData, PF_ProgPtr};
 
 define_suite!(
     /// Premiere pixel format suite. Not available in After Effects.
@@ -12,28 +12,55 @@ define_suite!(
 impl PixelFormatSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
+    pub fn add_supported_pixel_format(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        pixel_format: PixelFormat,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            AddSupportedPixelFormat,
+            effect_ref.as_ptr(),
+            pixel_format.into()
+        )
     }
 
-    pub fn add_supported_pixel_format(&self, effect_ref: impl AsPtr<PF_ProgPtr>, pixel_format: PixelFormat) -> Result<(), Error> {
-        call_suite_fn!(self, AddSupportedPixelFormat, effect_ref.as_ptr(), pixel_format.into())
-    }
-
-    pub fn clear_supported_pixel_formats(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<(), Error> {
+    pub fn clear_supported_pixel_formats(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, ClearSupportedPixelFormats, effect_ref.as_ptr())
     }
 
-    pub fn new_world_of_pixel_format(&self, in_data: impl AsPtr<*mut PF_InData>, width: u32, height: u32, flags: NewWorldFlags, pixel_format: PixelFormat) -> Result<pr_sys::PF_EffectWorld, Error> {
+    pub fn new_world_of_pixel_format(
+        &self,
+        in_data: impl AsPtr<*mut PF_InData>,
+        width: u32,
+        height: u32,
+        flags: NewWorldFlags,
+        pixel_format: PixelFormat,
+    ) -> Result<pr_sys::PF_EffectWorld, Error> {
         call_suite_fn_single!(self, NewWorldOfPixelFormat -> pr_sys::PF_EffectWorld, (*in_data.as_ptr()).effect_ref, width, height, flags.bits(), pixel_format.into())
     }
 
-    pub fn dispose_world(&self, effect_ref: impl AsPtr<PF_ProgPtr>, world: *mut pr_sys::PF_EffectWorld) -> Result<(), Error> {
+    pub fn dispose_world(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        world: *mut pr_sys::PF_EffectWorld,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, DisposeWorld, effect_ref.as_ptr(), world)
     }
 
-    pub fn pixel_format(&self, world: impl AsPtr<*mut pr_sys::PF_EffectWorld>) -> Result<PixelFormat, Error> {
-        Ok(call_suite_fn_single!(self, GetPixelFormat -> pr_sys::PrPixelFormat, world.as_ptr())?.into())
+    pub fn pixel_format(
+        &self,
+        world: impl AsPtr<*mut pr_sys::PF_EffectWorld>,
+    ) -> Result<PixelFormat, Error> {
+        Ok(
+            call_suite_fn_single!(self, GetPixelFormat -> pr_sys::PrPixelFormat, world.as_ptr())?
+                .into(),
+        )
     }
 
     /// Retrieves the minimum i.e. "black" value for a give pixel type.
@@ -44,7 +71,12 @@ impl PixelFormatSuite {
     /// * `pixel_data` - a void pointer to data large enough to hold the pixel value (see note above)
     pub fn black_for_pixel_format(&self, pixel_format: PixelFormat) -> Result<Vec<u8>, Error> {
         let mut pixel_data = vec![0u8; pixel_size(pixel_format)];
-        call_suite_fn!(self, GetBlackForPixelFormat, pixel_format.into(), pixel_data.as_mut_ptr() as *mut _)?;
+        call_suite_fn!(
+            self,
+            GetBlackForPixelFormat,
+            pixel_format.into(),
+            pixel_data.as_mut_ptr() as *mut _
+        )?;
         Ok(pixel_data)
     }
 
@@ -56,7 +88,12 @@ impl PixelFormatSuite {
     /// * `pixel_data` - a void pointer to data large enough to hold the pixel value (see note above)
     pub fn white_for_pixel_format(&self, pixel_format: PixelFormat) -> Result<Vec<u8>, Error> {
         let mut pixel_data = vec![0u8; pixel_size(pixel_format)];
-        call_suite_fn!(self, GetWhiteForPixelFormat, pixel_format.into(), pixel_data.as_mut_ptr() as *mut _)?;
+        call_suite_fn!(
+            self,
+            GetWhiteForPixelFormat,
+            pixel_format.into(),
+            pixel_data.as_mut_ptr() as *mut _
+        )?;
         Ok(pixel_data)
     }
 
@@ -70,9 +107,25 @@ impl PixelFormatSuite {
     /// * `green`        - green value (0.0 - 1.0)
     /// * `blue`         - blue value (0.0 - 1.0)
     /// * `pixel_data`   - a void pointer to data large enough to hold the pixel value (see note above)
-    pub fn convert_color_to_pixel_formatted_data(&self, pixel_format: PixelFormat, alpha: f32, red: f32, green: f32, blue: f32) -> Result<Vec<u8>, Error> {
+    pub fn convert_color_to_pixel_formatted_data(
+        &self,
+        pixel_format: PixelFormat,
+        alpha: f32,
+        red: f32,
+        green: f32,
+        blue: f32,
+    ) -> Result<Vec<u8>, Error> {
         let mut pixel_data = vec![0u8; pixel_size(pixel_format)];
-        call_suite_fn!(self, ConvertColorToPixelFormattedData, pixel_format.into(), alpha, red, green, blue, pixel_data.as_mut_ptr() as *mut _)?;
+        call_suite_fn!(
+            self,
+            ConvertColorToPixelFormattedData,
+            pixel_format.into(),
+            alpha,
+            red,
+            green,
+            blue,
+            pixel_data.as_mut_ptr() as *mut _
+        )?;
         Ok(pixel_data)
     }
 }
@@ -80,20 +133,39 @@ impl PixelFormatSuite {
 fn pixel_size(pixel_format: PixelFormat) -> usize {
     use PixelFormat::*;
     match pixel_format {
-        Bgra4444_8u | Vuya4444_8u | Vuya4444_8u709 | Argb4444_8u | Bgrx4444_8u | Vuyx4444_8u | Vuyx4444_8u709 | Xrgb4444_8u | Bgrp4444_8u | Vuyp4444_8u |
-        Vuyp4444_8u709 | Prgb4444_8u | Vuya4444_16u | Rgb444_10u | Yuyv422_8u601 | Yuyv422_8u709 | Uyvy422_8u601 | Uyvy422_8u709 | Xrgb4444_32fLinear => 4,
+        Bgra4444_8u | Vuya4444_8u | Vuya4444_8u709 | Argb4444_8u | Bgrx4444_8u | Vuyx4444_8u
+        | Vuyx4444_8u709 | Xrgb4444_8u | Bgrp4444_8u | Vuyp4444_8u | Vuyp4444_8u709
+        | Prgb4444_8u | Vuya4444_16u | Rgb444_10u | Yuyv422_8u601 | Yuyv422_8u709
+        | Uyvy422_8u601 | Uyvy422_8u709 | Xrgb4444_32fLinear => 4,
 
-        Bgra4444_16u | Argb4444_16u | Bgrx4444_16u | Xrgb4444_16u | Bgrp4444_16u | Prgb4444_16u => 8,
+        Bgra4444_16u | Argb4444_16u | Bgrx4444_16u | Xrgb4444_16u | Bgrp4444_16u | Prgb4444_16u => {
+            8
+        }
 
-        Bgra4444_32f | Vuya4444_32f | Vuya4444_32f709 | Argb4444_32f | Bgrx4444_32f | Vuyx4444_32f | Vuyx4444_32f709 | Xrgb4444_32f | Bgrp4444_32f | Vuyp4444_32f | Vuyp4444_32f709 | Prgb4444_32f |
-        V210422_10u601 | V210422_10u709 | Uyvy422_32f601 | Uyvy422_32f709 | Bgra4444_32fLinear | Bgrp4444_32fLinear | Bgrx4444_32fLinear | Argb4444_32fLinear | Prgb4444_32fLinear => 16,
+        Bgra4444_32f | Vuya4444_32f | Vuya4444_32f709 | Argb4444_32f | Bgrx4444_32f
+        | Vuyx4444_32f | Vuyx4444_32f709 | Xrgb4444_32f | Bgrp4444_32f | Vuyp4444_32f
+        | Vuyp4444_32f709 | Prgb4444_32f | V210422_10u601 | V210422_10u709 | Uyvy422_32f601
+        | Uyvy422_32f709 | Bgra4444_32fLinear | Bgrp4444_32fLinear | Bgrx4444_32fLinear
+        | Argb4444_32fLinear | Prgb4444_32fLinear => 16,
 
-        Yuv420Mpeg2FramePicturePlanar8u601 | Yuv420Mpeg2FieldPicturePlanar8u601 | Yuv420Mpeg2FramePicturePlanar8u601FullRange | Yuv420Mpeg2FieldPicturePlanar8u601FullRange |
-        Yuv420Mpeg2FramePicturePlanar8u709 | Yuv420Mpeg2FieldPicturePlanar8u709 | Yuv420Mpeg2FramePicturePlanar8u709FullRange | Yuv420Mpeg2FieldPicturePlanar8u709FullRange |
-        Yuv420Mpeg4FramePicturePlanar8u601 | Yuv420Mpeg4FieldPicturePlanar8u601 | Yuv420Mpeg4FramePicturePlanar8u601FullRange | Yuv420Mpeg4FieldPicturePlanar8u601FullRange |
-        Yuv420Mpeg4FramePicturePlanar8u709 | Yuv420Mpeg4FieldPicturePlanar8u709 | Yuv420Mpeg4FramePicturePlanar8u709FullRange | Yuv420Mpeg4FieldPicturePlanar8u709FullRange => 1,
+        Yuv420Mpeg2FramePicturePlanar8u601
+        | Yuv420Mpeg2FieldPicturePlanar8u601
+        | Yuv420Mpeg2FramePicturePlanar8u601FullRange
+        | Yuv420Mpeg2FieldPicturePlanar8u601FullRange
+        | Yuv420Mpeg2FramePicturePlanar8u709
+        | Yuv420Mpeg2FieldPicturePlanar8u709
+        | Yuv420Mpeg2FramePicturePlanar8u709FullRange
+        | Yuv420Mpeg2FieldPicturePlanar8u709FullRange
+        | Yuv420Mpeg4FramePicturePlanar8u601
+        | Yuv420Mpeg4FieldPicturePlanar8u601
+        | Yuv420Mpeg4FramePicturePlanar8u601FullRange
+        | Yuv420Mpeg4FieldPicturePlanar8u601FullRange
+        | Yuv420Mpeg4FramePicturePlanar8u709
+        | Yuv420Mpeg4FieldPicturePlanar8u709
+        | Yuv420Mpeg4FramePicturePlanar8u709FullRange
+        | Yuv420Mpeg4FieldPicturePlanar8u709FullRange => 1,
 
-        _ => 32 // just to be safe
+        _ => 32, // just to be safe
     }
 }
 

--- a/premiere/src/pf_suites/source_settings.rs
+++ b/premiere/src/pf_suites/source_settings.rs
@@ -1,4 +1,3 @@
-
 use crate::*;
 use pr_sys::*;
 
@@ -51,12 +50,21 @@ define_suite!(
 impl SourceSettingsSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
-    pub fn perform_source_settings_command(&self, effect_ref: impl AsPtr<PF_ProgPtr>, command_struct: *mut std::ffi::c_void, data_size: usize) -> Result<(), Error> {
-        call_suite_fn!(self, PerformSourceSettingsCommand, effect_ref.as_ptr(), command_struct, data_size as _)
+    pub fn perform_source_settings_command(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        command_struct: *mut std::ffi::c_void,
+        data_size: usize,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            PerformSourceSettingsCommand,
+            effect_ref.as_ptr(),
+            command_struct,
+            data_size as _
+        )
     }
 
     // pub fn set_is_source_settings_effect(&self, effect_ref: impl AsPtr<PF_ProgPtr>, value: bool) -> Result<(), Error> {

--- a/premiere/src/pf_suites/transition.rs
+++ b/premiere/src/pf_suites/transition.rs
@@ -1,4 +1,3 @@
-
 use crate::*;
 use pr_sys::*;
 
@@ -31,23 +30,48 @@ define_suite!(
 impl TransitionSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Register an effect as a transition using the passed in input layer as the outgoing clip.
     /// When registered the effect will be available to be dragged directly onto clip ends rather than only applied to layers.
-    pub fn register_transition_input_param(&self, effect_ref: impl AsPtr<PF_ProgPtr>, index: i32) -> Result<(), Error> {
-        call_suite_fn!(self, RegisterTransitionInputParam, effect_ref.as_ptr(), index as _)
+    pub fn register_transition_input_param(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        index: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            RegisterTransitionInputParam,
+            effect_ref.as_ptr(),
+            index as _
+        )
     }
 
     /// Register a PF_ADD_FLOAT_SLIDER parameter to receive changes to the start of the transition region through the `Command::UserChangedParam` command.
-    pub fn register_transition_start_param(&self, effect_ref: impl AsPtr<PF_ProgPtr>, index: i32) -> Result<(), Error> {
-        call_suite_fn!(self, RegisterTransitionStartParam, effect_ref.as_ptr(), index as _)
+    pub fn register_transition_start_param(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        index: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            RegisterTransitionStartParam,
+            effect_ref.as_ptr(),
+            index as _
+        )
     }
 
     /// Register a PF_ADD_FLOAT_SLIDER parameter to receive changes to the end of the transition region through the `Command::UserChangedParam` command.
-    pub fn register_transition_end_param(&self, effect_ref: impl AsPtr<PF_ProgPtr>, index: i32) -> Result<(), Error> {
-        call_suite_fn!(self, RegisterTransitionEndParam, effect_ref.as_ptr(), index as _)
+    pub fn register_transition_end_param(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        index: i32,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            RegisterTransitionEndParam,
+            effect_ref.as_ptr(),
+            index as _
+        )
     }
 }

--- a/premiere/src/pf_suites/utility.rs
+++ b/premiere/src/pf_suites/utility.rs
@@ -10,9 +10,7 @@ define_suite!(
 );
 
 impl UtilitySuite {
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Gets the filter ID for the current effect reference.
     pub fn filter_instance_id(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<i32, Error> {
@@ -22,7 +20,10 @@ impl UtilitySuite {
     /// Retrieves formatted timecode, as well as the currently active video frame.
     ///
     /// Returns a tuple containing `(current_frame, time_display)`
-    pub fn media_timecode(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<(i32, PF_TimeDisplay), Error> {
+    pub fn media_timecode(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<(i32, PF_TimeDisplay), Error> {
         call_suite_fn_double!(self, GetMediaTimecode -> i32, PF_TimeDisplay, effect_ref.as_ptr())
     }
 
@@ -43,12 +44,18 @@ impl UtilitySuite {
 
     /// Retrieves the duration of the clip, unaffected by any speed or retiming changes.
     pub fn unscaled_clip_duration(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, GetUnscaledClipDuration -> A_long, effect_ref.as_ptr())? as i32)
+        Ok(
+            call_suite_fn_single!(self, GetUnscaledClipDuration -> A_long, effect_ref.as_ptr())?
+                as i32,
+        )
     }
 
     /// Retrives the start time of the clip, unaffected by any speed or retiming changes.
     pub fn unscaled_clip_start(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, GetUnscaledClipStart -> A_long, effect_ref.as_ptr())? as i32)
+        Ok(
+            call_suite_fn_single!(self, GetUnscaledClipStart -> A_long, effect_ref.as_ptr())?
+                as i32,
+        )
     }
 
     /// Gets the start time of the track item.
@@ -57,7 +64,10 @@ impl UtilitySuite {
     }
 
     /// Retrieves the filed type in use with the media.
-    pub fn media_field_type(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<prFieldType, Error> {
+    pub fn media_field_type(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<prFieldType, Error> {
         call_suite_fn_single!(self, GetMediaFieldType -> prFieldType, effect_ref.as_ptr())
     }
 
@@ -67,151 +77,312 @@ impl UtilitySuite {
     }
 
     /// Gets the ID of the timeline containing the clip to which the effect is applied.
-    pub fn containing_timeline_id(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<PrTimelineID, Error> {
+    pub fn containing_timeline_id(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<PrTimelineID, Error> {
         call_suite_fn_single!(self, GetContainingTimelineID -> PrTimelineID, effect_ref.as_ptr())
     }
 
     /// Gets the name of the clip to which the effect is applied (or the master clip).
-    pub fn clip_name(&self, effect_ref: impl AsPtr<PF_ProgPtr>, get_master_clip_name: bool) -> Result<String, Error> {
+    pub fn clip_name(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        get_master_clip_name: bool,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetClipName -> PrSDKString, effect_ref.as_ptr(), get_master_clip_name as _)?).into())
     }
 
     /// Indicates that the effect wants to received checked out frames, in the same format used for destination rendering.
-    pub fn effect_wants_checked_out_frames_to_match_render_pixel_format(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<(), Error> {
-        call_suite_fn!(self, EffectWantsCheckedOutFramesToMatchRenderPixelFormat, effect_ref.as_ptr())
+    pub fn effect_wants_checked_out_frames_to_match_render_pixel_format(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            EffectWantsCheckedOutFramesToMatchRenderPixelFormat,
+            effect_ref.as_ptr()
+        )
     }
 
     /// Indicates whether the effect depends on the name of the clip to which it is applied.
-    pub fn set_effect_depends_on_clip_name(&self, effect_ref: impl AsPtr<PF_ProgPtr>, depends_on_clip_name: bool) -> Result<(), Error> {
-        call_suite_fn!(self, EffectDependsOnClipName, effect_ref.as_ptr(), depends_on_clip_name as _)
+    pub fn set_effect_depends_on_clip_name(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        depends_on_clip_name: bool,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            EffectDependsOnClipName,
+            effect_ref.as_ptr(),
+            depends_on_clip_name as _
+        )
     }
 
     /// Sets the instance name of the effect.
-    pub fn set_effect_instance_name(&self, effect_ref: impl AsPtr<PF_ProgPtr>, name: &str) -> Result<(), Error> {
+    pub fn set_effect_instance_name(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        name: &str,
+    ) -> Result<(), Error> {
         let pr_string = suites::PrString::new()?.allocate_from_utf8(name)?;
         call_suite_fn!(self, SetEffectInstanceName, effect_ref.as_ptr(), &pr_string)
     }
 
     /// Retrieves the name of the media file to which the effect instance is applied.
     pub fn file_name(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<String, Error> {
-        Ok(PrString(call_suite_fn_single!(self, GetFileName -> PrSDKString, effect_ref.as_ptr())?).into())
+        Ok(
+            PrString(call_suite_fn_single!(self, GetFileName -> PrSDKString, effect_ref.as_ptr())?)
+                .into(),
+        )
     }
 
     /// Retrieves the original (non-interpreted, un-re-timed) frame rate, of the media to which the effect instance is applied.
-    pub fn original_clip_frame_rate(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<PrTime, Error> {
+    pub fn original_clip_frame_rate(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<PrTime, Error> {
         call_suite_fn_single!(self, GetOriginalClipFrameRate -> PrTime, effect_ref.as_ptr())
     }
 
     /// Retrieves the source media timecode for the specified frame within the specified layer, with or without transforms and start time offsets applied.
-    pub fn source_track_media_timecode(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, apply_transform: bool, add_start_time_offset: bool) -> Result<A_long, Error> {
+    pub fn source_track_media_timecode(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        apply_transform: bool,
+        add_start_time_offset: bool,
+    ) -> Result<A_long, Error> {
         call_suite_fn_single!(self, GetSourceTrackMediaTimecode -> A_long, effect_ref.as_ptr(), layer_param_index, apply_transform, add_start_time_offset)
     }
 
     /// Retrieves the name of the layer in use by the effect instance.
-    pub fn source_track_clip_name(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, get_master_clip_name: bool) -> Result<String, Error> {
+    pub fn source_track_clip_name(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        get_master_clip_name: bool,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetSourceTrackClipName -> PrSDKString, effect_ref.as_ptr(), layer_param_index, get_master_clip_name as _)?).into())
     }
 
     /// Retrieves the file name of the source track item for the specified layer parameter.
-    pub fn source_track_file_name(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32) -> Result<String, Error> {
+    pub fn source_track_file_name(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetSourceTrackFileName -> PrSDKString, effect_ref.as_ptr(), layer_param_index)?).into())
     }
 
     /// Specifies whether the effect instance depends on the specified layer parameter.
-    pub fn set_effect_depends_on_clip_name2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, depends_on_clip_name: bool, layer_param_index: u8) -> Result<(), Error> {
-        call_suite_fn!(self, EffectDependsOnClipName2, effect_ref.as_ptr(), layer_param_index, depends_on_clip_name as _)
+    pub fn set_effect_depends_on_clip_name2(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        depends_on_clip_name: bool,
+        layer_param_index: u8,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            EffectDependsOnClipName2,
+            effect_ref.as_ptr(),
+            layer_param_index,
+            depends_on_clip_name as _
+        )
     }
 
     /// Retrieves formatted timecode and current frame number, with or without trims applied.
     ///
     /// Returns a tuple containing `(current_frame, time_display)`
-    pub fn media_timecode2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, apply_trim: bool) -> Result<(i32, PF_TimeDisplay), Error> {
+    pub fn media_timecode2(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        apply_trim: bool,
+    ) -> Result<(i32, PF_TimeDisplay), Error> {
         call_suite_fn_double!(self, GetMediaTimecode2 -> i32, PF_TimeDisplay, effect_ref.as_ptr(), apply_trim)
     }
 
     /// Given a specific sequence time, retrieves the source track media timecode for the specified layer parameter.
-    pub fn source_track_media_timecode2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, apply_transform: bool, add_start_time_offset: bool, sequence_time: PrTime) -> Result<A_long, Error> {
+    pub fn source_track_media_timecode2(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        apply_transform: bool,
+        add_start_time_offset: bool,
+        sequence_time: PrTime,
+    ) -> Result<A_long, Error> {
         call_suite_fn_single!(self, GetSourceTrackMediaTimecode2 -> A_long, effect_ref.as_ptr(), layer_param_index, apply_transform, add_start_time_offset, sequence_time)
     }
 
     /// Retrieves the clip name used by the specific layer parameter.
-    pub fn source_track_clip_name2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, get_master_clip_name: bool, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn source_track_clip_name2(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        get_master_clip_name: bool,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         let mut val: PrSDKString = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, GetSourceTrackClipName2, effect_ref.as_ptr(), layer_param_index, get_master_clip_name as _, &mut val, sequence_time)?;
+        call_suite_fn!(
+            self,
+            GetSourceTrackClipName2,
+            effect_ref.as_ptr(),
+            layer_param_index,
+            get_master_clip_name as _,
+            &mut val,
+            sequence_time
+        )?;
 
         Ok(PrString(val).into())
     }
 
     /// Retrieves the clip name in use by the specified layer parameter.
-    pub fn source_track_file_name2(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn source_track_file_name2(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         let mut val: PrSDKString = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, GetSourceTrackFileName2, effect_ref.as_ptr(), layer_param_index, &mut val, sequence_time)?;
+        call_suite_fn!(
+            self,
+            GetSourceTrackFileName2,
+            effect_ref.as_ptr(),
+            layer_param_index,
+            &mut val,
+            sequence_time
+        )?;
 
         Ok(PrString(val).into())
     }
 
     /// Retrieves the comment string associated with the specified source track item, at the specified time.
-    pub fn comment_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn comment_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetCommentString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the log note associated with the source track, at the specified time.
-    pub fn log_note_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn log_note_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetLogNoteString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the camera rolll info associated with the source track, at the specified time.
-    pub fn camera_roll_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn camera_roll_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetCameraRollString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the metadata string associated with the source track, at the specified time.
-    pub fn client_metadata_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn client_metadata_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetClientMetadataString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the daily roll string associated with the source track, at the specified time.
-    pub fn daily_roll_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn daily_roll_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetDailyRollString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the description metadata string associated with the source track, at the specified time.
-    pub fn description_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn description_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetDescriptionString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the lab roll string associated with the source track, at the specified time.
-    pub fn lab_roll_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn lab_roll_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetLabRollString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the scene string associated with the source track, at the specified time.
-    pub fn scene_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn scene_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetSceneString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the shot string associated with the source track item, at the specified time.
-    pub fn shot_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn shot_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetShotString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves the tape name string associated with the source track item, at the specified time.
-    pub fn tape_name_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn tape_name_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetTapeNameString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves a string representing the video codec associated with the source track item, at the specified time.
-    pub fn video_codec_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn video_codec_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetVideoCodecString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves a string representing the "good" state of the source track item, at the specified time.
-    pub fn good_metadata_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn good_metadata_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetGoodMetadataString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
     /// Retrieves a string representing the "sound roll" state of the source track item, at the specified time.
-    pub fn sound_roll_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn sound_roll_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetSoundRollString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 
@@ -221,53 +392,99 @@ impl UtilitySuite {
     }
 
     /// Retrieves the frame of the specified source time.
-    pub fn sound_timecode(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<i32, Error> {
-        Ok(call_suite_fn_single!(self, GetSoundTimecode -> A_long, effect_ref.as_ptr(), source_track, sequence_time)? as i32)
+    pub fn sound_timecode(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<i32, Error> {
+        Ok(
+            call_suite_fn_single!(self, GetSoundTimecode -> A_long, effect_ref.as_ptr(), source_track, sequence_time)?
+                as i32,
+        )
     }
 
     /// Retrieves the original "ticks per frame" for the specified source track.
-    pub fn original_clip_frame_rate_for_source_track(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32) -> Result<PrTime, Error> {
+    pub fn original_clip_frame_rate_for_source_track(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+    ) -> Result<PrTime, Error> {
         call_suite_fn_single!(self, GetOriginalClipFrameRateForSourceTrack -> PrTime, effect_ref.as_ptr(), source_track)
     }
 
     /// Retrieves the media frame rate for the specified source track.
-    pub fn media_frame_rate_for_source_track(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<PrTime, Error> {
+    pub fn media_frame_rate_for_source_track(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<PrTime, Error> {
         call_suite_fn_single!(self, GetMediaFrameRateForSourceTrack -> PrTime, effect_ref.as_ptr(), source_track, sequence_time)
     }
 
     /// Retrieves the start time of the specified layer parameter.
-    pub fn source_track_media_actual_start_time(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, sequence_time: PrTime) -> Result<PrTime, Error> {
+    pub fn source_track_media_actual_start_time(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        sequence_time: PrTime,
+    ) -> Result<PrTime, Error> {
         call_suite_fn_single!(self, GetSourceTrackMediaActualStartTime -> PrTime, effect_ref.as_ptr(), layer_param_index, sequence_time)
     }
 
     /// Retrieves whether the source track item has been trimmed.
-    pub fn is_source_track_media_trimmed(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, sequence_time: PrTime) -> Result<bool, Error> {
+    pub fn is_source_track_media_trimmed(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        sequence_time: PrTime,
+    ) -> Result<bool, Error> {
         call_suite_fn_single!(self, IsSourceTrackMediaTrimmed -> bool, effect_ref.as_ptr(), layer_param_index, sequence_time)
     }
 
     /// Retrieves whether the track item has been trimmed.
-    pub fn is_media_trimmed(&self, effect_ref: impl AsPtr<PF_ProgPtr>, sequence_time: PrTime) -> Result<bool, Error> {
+    pub fn is_media_trimmed(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        sequence_time: PrTime,
+    ) -> Result<bool, Error> {
         call_suite_fn_single!(self, IsMediaTrimmed -> bool, effect_ref.as_ptr(), sequence_time)
     }
 
     /// Retrieves whether, for the specified layer parameter, the track is empty.
-    pub fn is_track_empty(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, sequence_time: PrTime) -> Result<bool, Error> {
+    pub fn is_track_empty(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        sequence_time: PrTime,
+    ) -> Result<bool, Error> {
         call_suite_fn_single!(self, IsTrackEmpty -> bool, effect_ref.as_ptr(), layer_param_index, sequence_time)
     }
 
     /// Retrieves whether the effect is applied to a track item backed by a synthetic importer.
-    pub fn is_track_item_effect_applied_to_synthetic(&self, effect_ref: impl AsPtr<PF_ProgPtr>) -> Result<bool, Error> {
+    pub fn is_track_item_effect_applied_to_synthetic(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+    ) -> Result<bool, Error> {
         call_suite_fn_single!(self, IsTrackItemEffectAppliedToSynthetic -> bool, effect_ref.as_ptr())
     }
 
     /// Retrieves the current media time, including ticks per frame and a formatted string representing that time.
     ///
     /// Returns a tuple containing `(current_media_time, media_ticks_per_frame, media_time_display)`
-    pub fn source_track_current_media_time_info(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, use_sound_timecode_as_start_time: bool, sequence_time: PrTime) -> Result<(PrTime, PrTime, PF_TimeDisplay), Error> {
+    pub fn source_track_current_media_time_info(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        use_sound_timecode_as_start_time: bool,
+        sequence_time: PrTime,
+    ) -> Result<(PrTime, PrTime, PF_TimeDisplay), Error> {
         let mut current_media_time = 0;
         let mut media_ticks_per_frame = 0;
         let mut media_time_display = 0;
-        call_suite_fn!(self,
+        call_suite_fn!(
+            self,
             GetSourceTrackCurrentMediaTimeInfo,
             effect_ref.as_ptr(),
             layer_param_index,
@@ -277,7 +494,11 @@ impl UtilitySuite {
             &mut media_ticks_per_frame,
             &mut media_time_display
         )?;
-        Ok((current_media_time, media_ticks_per_frame, media_time_display))
+        Ok((
+            current_media_time,
+            media_ticks_per_frame,
+            media_time_display,
+        ))
     }
 
     /// Retrieves the zero point (start time) of the sequence in which the effect is applied.
@@ -286,7 +507,12 @@ impl UtilitySuite {
     }
 
     /// Retrieves the duration of the clip, at the specified layer index, at inSequenceTime.
-    pub fn source_track_current_clip_duration(&self, effect_ref: impl AsPtr<PF_ProgPtr>, layer_param_index: u32, sequence_time: PrTime) -> Result<PrTime, Error> {
+    pub fn source_track_current_clip_duration(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        layer_param_index: u32,
+        sequence_time: PrTime,
+    ) -> Result<PrTime, Error> {
         call_suite_fn_single!(self, GetSourceTrackCurrentClipDuration -> PrTime, effect_ref.as_ptr(), layer_param_index, sequence_time)
     }
 
@@ -298,7 +524,12 @@ impl UtilitySuite {
     /// Retrieve a string representing the dimensions of the track item to which the effect is applied.
     /// It's formatted as a "width x height".
     /// Set `source_track` to -1 to query the top-most clip at `sequence_time` (only if effect is on an adjustment layer)
-    pub fn video_resolution_string(&self, effect_ref: impl AsPtr<PF_ProgPtr>, source_track: i32, sequence_time: PrTime) -> Result<String, Error> {
+    pub fn video_resolution_string(
+        &self,
+        effect_ref: impl AsPtr<PF_ProgPtr>,
+        source_track: i32,
+        sequence_time: PrTime,
+    ) -> Result<String, Error> {
         Ok(PrString(call_suite_fn_single!(self, GetVideoResolutionString -> PrSDKString, effect_ref.as_ptr(), source_track, sequence_time)?).into())
     }
 }

--- a/premiere/src/suites/gpu_device.rs
+++ b/premiere/src/suites/gpu_device.rs
@@ -19,15 +19,16 @@ define_suite!(
 impl GPUDeviceSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
     pub fn device_count(&self) -> Result<usize, Error> {
         Ok(call_suite_fn_single!(self, GetDeviceCount -> u32)? as usize)
     }
+
     pub fn device_info(&self, device_index: u32) -> Result<pr_sys::PrGPUDeviceInfo, Error> {
         call_suite_fn_single!(self, GetDeviceInfo -> pr_sys::PrGPUDeviceInfo, pr_sys::kPrSDKGPUDeviceSuiteVersion, device_index)
     }
+
     /// Acquire/release exclusive access to inDeviceIndex. All calls below this point generally require access be held.
     /// For full GPU plugins (those that use a separate entry point for GPU rendering) exclusive access is always held.
     /// These calls do not need to be made in that case.
@@ -35,35 +36,67 @@ impl GPUDeviceSuite {
     pub fn acquire_exclusive_device_access(&self, device_index: u32) -> Result<(), Error> {
         call_suite_fn!(self, AcquireExclusiveDeviceAccess, device_index)
     }
+
     pub fn release_exclusive_device_access(&self, device_index: u32) -> Result<(), Error> {
         call_suite_fn!(self, ReleaseExclusiveDeviceAccess, device_index)
     }
+
     /// All device memory must be allocated through this suite.
     /// Purge should be called only in emergency situations when working with GPU memory
     /// that cannot be allocated through this suite (eg OpenGL memory).
     /// Returned pointer value represents memory allocated through cuMemAlloc or clCreateBuffer.
-    pub fn allocate_device_memory(&self, device_index: u32, size_in_bytes: usize) -> Result<*mut std::ffi::c_void, Error> {
+    pub fn allocate_device_memory(
+        &self,
+        device_index: u32,
+        size_in_bytes: usize,
+    ) -> Result<*mut std::ffi::c_void, Error> {
         call_suite_fn_single!(self, AllocateDeviceMemory -> *mut std::ffi::c_void, device_index, size_in_bytes)
     }
-    pub fn free_device_memory(&self, device_index: u32, ptr: *mut std::ffi::c_void) -> Result<(), Error> {
+
+    pub fn free_device_memory(
+        &self,
+        device_index: u32,
+        ptr: *mut std::ffi::c_void,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, FreeDeviceMemory, device_index, ptr)
     }
-    pub fn purge_device_memory(&self, device_index: u32, requested_bytes_to_purge: usize) -> Result<usize, Error> {
+
+    pub fn purge_device_memory(
+        &self,
+        device_index: u32,
+        requested_bytes_to_purge: usize,
+    ) -> Result<usize, Error> {
         call_suite_fn_single!(self, PurgeDeviceMemory -> usize, device_index, requested_bytes_to_purge)
     }
+
     /// All host (pinned) memory must be allocated through this suite.
     /// Purge should be called only in emergency situations when working with GPU memory
     /// that cannot be allocated through this suite (eg OpenGL memory).
     /// Returned pointer value represents memory allocated through cuMemHostAlloc or malloc.
-    pub fn allocate_host_memory(&self, device_index: u32, size_in_bytes: usize) -> Result<*mut std::ffi::c_void, Error> {
+    pub fn allocate_host_memory(
+        &self,
+        device_index: u32,
+        size_in_bytes: usize,
+    ) -> Result<*mut std::ffi::c_void, Error> {
         call_suite_fn_single!(self, AllocateHostMemory -> *mut std::ffi::c_void, device_index, size_in_bytes)
     }
-    pub fn free_host_memory(&self, device_index: u32, ptr: *mut std::ffi::c_void) -> Result<(), Error> {
+
+    pub fn free_host_memory(
+        &self,
+        device_index: u32,
+        ptr: *mut std::ffi::c_void,
+    ) -> Result<(), Error> {
         call_suite_fn!(self, FreeHostMemory, device_index, ptr)
     }
-    pub fn purge_host_memory(&self, device_index: u32, requested_bytes_to_purge: usize) -> Result<usize, Error> {
+
+    pub fn purge_host_memory(
+        &self,
+        device_index: u32,
+        requested_bytes_to_purge: usize,
+    ) -> Result<usize, Error> {
         call_suite_fn_single!(self, PurgeHostMemory -> usize, device_index, requested_bytes_to_purge)
     }
+
     /// Information on a GPU ppix. The following ppix functions may also be used:
     /// - PPixSuite::Dispose
     /// - PPixSuite::GetBounds
@@ -71,15 +104,30 @@ impl GPUDeviceSuite {
     /// - PPixSuite::GetPixelAspectRatio
     /// - PPixSuite::GetPixelFormat
     /// - PPix2Suite::GetFieldOrder
-    pub fn create_gpu_ppix(&self, device_index: u32, pixel_format: PixelFormat, width: i32, height: i32, par_numerator: i32, par_denominator: i32, field_type: pr_sys::prFieldType) -> Result<pr_sys::PPixHand, Error> {
+    pub fn create_gpu_ppix(
+        &self,
+        device_index: u32,
+        pixel_format: PixelFormat,
+        width: i32,
+        height: i32,
+        par_numerator: i32,
+        par_denominator: i32,
+        field_type: pr_sys::prFieldType,
+    ) -> Result<pr_sys::PPixHand, Error> {
         call_suite_fn_single!(self, CreateGPUPPix -> pr_sys::PPixHand, device_index, pixel_format.into(), width, height, par_numerator, par_denominator, field_type.into())
     }
-    pub fn gpu_ppix_data(&self, ppix_handle: pr_sys::PPixHand) -> Result<*mut std::ffi::c_void, Error> {
+
+    pub fn gpu_ppix_data(
+        &self,
+        ppix_handle: pr_sys::PPixHand,
+    ) -> Result<*mut std::ffi::c_void, Error> {
         call_suite_fn_single!(self, GetGPUPPixData -> *mut std::ffi::c_void, ppix_handle)
     }
+
     pub fn gpu_ppix_device_index(&self, ppix_handle: pr_sys::PPixHand) -> Result<u32, Error> {
         call_suite_fn_single!(self, GetGPUPPixDeviceIndex -> u32, ppix_handle)
     }
+
     pub fn gpu_ppix_size(&self, ppix_handle: pr_sys::PPixHand) -> Result<usize, Error> {
         call_suite_fn_single!(self, GetGPUPPixSize -> usize, ppix_handle)
     }

--- a/premiere/src/suites/gpu_image_processing.rs
+++ b/premiere/src/suites/gpu_image_processing.rs
@@ -11,52 +11,117 @@ define_suite!(
 impl GPUImageProcessingSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Convert between formats on the GPU
     /// One of src_format or dst_format must be a host format,
     /// the other must be either [`PixelFormat::GpuBgra4444_16f`] or [`PixelFormat::GpuBgra4444_32f`]
-    pub fn pixel_format_convert(&self,
+    pub fn pixel_format_convert(
+        &self,
         device_index: u32,
-        src: *const std::ffi::c_void, src_stride: i32, src_format: PixelFormat,
-        dst: *mut   std::ffi::c_void, dst_stride: i32, dst_format: PixelFormat,
+        src: *const std::ffi::c_void,
+        src_stride: i32,
+        src_format: PixelFormat,
+        dst: *mut std::ffi::c_void,
+        dst_stride: i32,
+        dst_format: PixelFormat,
         width: u32,
         height: u32,
-        quality: RenderQuality
+        quality: RenderQuality,
     ) -> Result<(), Error> {
-        call_suite_fn!(self, PixelFormatConvert, device_index, src, src_stride, src_format.into(), dst, dst_stride, dst_format.into(), width, height, quality.into())
+        call_suite_fn!(
+            self,
+            PixelFormatConvert,
+            device_index,
+            src,
+            src_stride,
+            src_format.into(),
+            dst,
+            dst_stride,
+            dst_format.into(),
+            width,
+            height,
+            quality.into()
+        )
     }
 
     /// Scale a frame on the GPU
     /// `format` must be [`PixelFormat::GpuBgra4444_16f`] or [`PixelFormat::GpuBgra4444_32f`]
-    pub fn scale(&self,
+    pub fn scale(
+        &self,
         device_index: u32,
-        src: *const std::ffi::c_void, src_stride: i32, src_width: u32, src_height: u32,
-        dst: *mut   std::ffi::c_void, dst_stride: i32, dst_width: u32, dst_height: u32,
+        src: *const std::ffi::c_void,
+        src_stride: i32,
+        src_width: u32,
+        src_height: u32,
+        dst: *mut std::ffi::c_void,
+        dst_stride: i32,
+        dst_width: u32,
+        dst_height: u32,
         format: PixelFormat,
         scale_x: f32,
         scale_y: f32,
-        quality: RenderQuality
+        quality: RenderQuality,
     ) -> Result<(), Error> {
-        call_suite_fn!(self, Scale, device_index, src, src_stride, src_width, src_height, dst, dst_stride, dst_width, dst_height, format.into(), scale_x, scale_y, quality.into())
+        call_suite_fn!(
+            self,
+            Scale,
+            device_index,
+            src,
+            src_stride,
+            src_width,
+            src_height,
+            dst,
+            dst_stride,
+            dst_width,
+            dst_height,
+            format.into(),
+            scale_x,
+            scale_y,
+            quality.into()
+        )
     }
 
     /// Gaussian blur on the GPU
     /// `format` must be [`PixelFormat::GpuBgra4444_16f`] or [`PixelFormat::GpuBgra4444_32f`]
-    pub fn gaussian_blur(&self,
+    pub fn gaussian_blur(
+        &self,
         device_index: u32,
-        src: *const std::ffi::c_void, src_stride: i32, src_width: u32, src_height: u32,
-        dst: *mut   std::ffi::c_void, dst_stride: i32, dst_width: u32, dst_height: u32,
+        src: *const std::ffi::c_void,
+        src_stride: i32,
+        src_width: u32,
+        src_height: u32,
+        dst: *mut std::ffi::c_void,
+        dst_stride: i32,
+        dst_width: u32,
+        dst_height: u32,
         format: PixelFormat,
         sigma_x: f32,
         sigma_y: f32,
         repeat_edge_pixels: bool,
         blur_horizontally: bool,
         blur_vertically: bool,
-        quality: RenderQuality
+        quality: RenderQuality,
     ) -> Result<(), Error> {
-        call_suite_fn!(self, GaussianBlur, device_index, src, src_stride, src_width, src_height, dst, dst_stride, dst_width, dst_height, format.into(), sigma_x, sigma_y, if repeat_edge_pixels { 1 } else { 0 }, if blur_horizontally { 1 } else { 0 }, if blur_vertically { 1 } else { 0 }, quality.into())
+        call_suite_fn!(
+            self,
+            GaussianBlur,
+            device_index,
+            src,
+            src_stride,
+            src_width,
+            src_height,
+            dst,
+            dst_stride,
+            dst_width,
+            dst_height,
+            format.into(),
+            sigma_x,
+            sigma_y,
+            if repeat_edge_pixels { 1 } else { 0 },
+            if blur_horizontally { 1 } else { 0 },
+            if blur_vertically { 1 } else { 0 },
+            quality.into()
+        )
     }
 }

--- a/premiere/src/suites/memory_manager.rs
+++ b/premiere/src/suites/memory_manager.rs
@@ -10,9 +10,7 @@ define_suite!(
 impl MemoryManagerSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Set the memory reserve size in bytes for the plugin with the specified ID.
     /// * `plugin_id` - The ID of the plugin.
@@ -33,9 +31,15 @@ impl MemoryManagerSuite {
     /// * `purge_function` - The function that will be called to purge the item.
     ///
     /// Returns the id the host will use for this item.
-    pub fn add_block<F: FnOnce(u32) + Send + Sync + 'static>(&self, size: u64, purge_function: F) -> Result<u32, Error> {
+    pub fn add_block<F: FnOnce(u32) + Send + Sync + 'static>(
+        &self,
+        size: u64,
+        purge_function: F,
+    ) -> Result<u32, Error> {
         unsafe extern "C" fn purge_fn(data: *mut std::ffi::c_void, memory_id: u32) {
-            let cb = unsafe { Box::<Box<dyn FnOnce(u32) + Send + Sync + 'static>>::from_raw(data as *mut _) };
+            let cb = unsafe {
+                Box::<Box<dyn FnOnce(u32) + Send + Sync + 'static>>::from_raw(data as *mut _)
+            };
             cb(memory_id);
         }
         let cb = Box::new(Box::new(purge_function));
@@ -46,9 +50,7 @@ impl MemoryManagerSuite {
     /// Each time you use a block of memory, you should call this function. This pushes its
     /// priority up in the cache, making a purge less likely.
     /// * `id` - The id of the block to touch.
-    pub fn touch_block(&self, id: u32) -> Result<(), Error> {
-        call_suite_fn!(self, TouchBlock, id)
-    }
+    pub fn touch_block(&self, id: u32) -> Result<(), Error> { call_suite_fn!(self, TouchBlock, id) }
 
     /// You can manually expire an item from the cache with this function. Note that the purge function
     /// on the item will not be called.

--- a/premiere/src/suites/opaque_effect_data.rs
+++ b/premiere/src/suites/opaque_effect_data.rs
@@ -36,15 +36,16 @@ define_suite!(
 impl OpaqueEffectDataSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Acquire pointer to opaque effect data. This is reference counted meaning that
     /// [`acquire_opaque_effect_data()`](Self::acquire_opaque_effect_data) and [`release_opaque_effect_data()`](Self::release_opaque_effect_data) should always be called in pairs.
     /// If no opaque effect was registered for the given effect_ref [`acquire_opaque_effect_data()`](Self::acquire_opaque_effect_data)
     /// will return 0 and the reference count remains 0.
-    pub fn acquire_opaque_effect_data(&self, instance_id: i32) -> Result<*mut pr_sys::OpaqueEffectDataType, Error> {
+    pub fn acquire_opaque_effect_data(
+        &self,
+        instance_id: i32,
+    ) -> Result<*mut pr_sys::OpaqueEffectDataType, Error> {
         call_suite_fn_single!(self, AcquireOpaqueEffectData -> *mut pr_sys::OpaqueEffectDataType, instance_id)
     }
 
@@ -74,8 +75,17 @@ impl OpaqueEffectDataSuite {
     /// }
     /// // data now points to the right OpaqueEffectDataType object and we can start using it
     /// ```
-    pub fn register_opaque_effect_data(&self, instance_id: i32, opaque_effect_data: *mut *mut pr_sys::OpaqueEffectDataType) -> Result<(), Error> {
-        call_suite_fn!(self, RegisterOpaqueEffectData, instance_id, opaque_effect_data)
+    pub fn register_opaque_effect_data(
+        &self,
+        instance_id: i32,
+        opaque_effect_data: *mut *mut pr_sys::OpaqueEffectDataType,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            RegisterOpaqueEffectData,
+            instance_id,
+            opaque_effect_data
+        )
     }
 
     /// Release opaque effect data. This decrements the internal reference count.
@@ -85,7 +95,16 @@ impl OpaqueEffectDataSuite {
     ///
     /// If the internal reference count goes to 0 any calls made to [`acquire_opaque_effect_data()`](Self::acquire_opaque_effect_data)
     /// will return 0 until new opaque effect data is registered via [`register_opaque_effect_data()`](Self::register_opaque_effect_data).
-    pub fn release_opaque_effect_data(&self, instance_id: i32, out_dispose_opaque_effect_data: *mut *mut pr_sys::OpaqueEffectDataType) -> Result<(), Error> {
-        call_suite_fn!(self, ReleaseOpaqueEffectData, instance_id, out_dispose_opaque_effect_data)
+    pub fn release_opaque_effect_data(
+        &self,
+        instance_id: i32,
+        out_dispose_opaque_effect_data: *mut *mut pr_sys::OpaqueEffectDataType,
+    ) -> Result<(), Error> {
+        call_suite_fn!(
+            self,
+            ReleaseOpaqueEffectData,
+            instance_id,
+            out_dispose_opaque_effect_data
+        )
     }
 }

--- a/premiere/src/suites/ppix.rs
+++ b/premiere/src/suites/ppix.rs
@@ -28,23 +28,27 @@ pub struct YUV420PlanarBuffers {
 impl PPixSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// This will free this ppix. The ppix is no longer valid after this function is called.
     /// * `ppix_handle` - The ppix handle you want to dispose.
     pub fn dispose(&self, ppix_handle: pr_sys::PPixHand) -> Result<(), Error> {
         call_suite_fn!(self, Dispose, ppix_handle)
     }
+
     /// This will return a pointer to the pixel buffer.
     /// * `ppix_handle` - The ppix handle you want to operate on.
     /// * `requested_access` - Requested pixel access. Most PPixs do not support write access modes.
     ///
     /// Returns the output pixel buffer address. May be NULL if the requested pixel access is not supported.
-    pub fn pixels(&self, ppix_handle: pr_sys::PPixHand, requested_access: PPixBufferAccess) -> Result<*mut std::ffi::c_char, Error> {
+    pub fn pixels(
+        &self,
+        ppix_handle: pr_sys::PPixHand,
+        requested_access: PPixBufferAccess,
+    ) -> Result<*mut std::ffi::c_char, Error> {
         call_suite_fn_single!(self, GetPixels -> *mut std::ffi::c_char, ppix_handle, requested_access.into())
     }
+
     /// This will return the bounding rect.
     /// * `ppix_handle` - The ppix handle you want to operate on.
     ///
@@ -52,6 +56,7 @@ impl PPixSuite {
     pub fn bounds(&self, ppix_handle: pr_sys::PPixHand) -> Result<pr_sys::prRect, Error> {
         call_suite_fn_single!(self, GetBounds -> pr_sys::prRect, ppix_handle)
     }
+
     /// This will return the row bytes of the ppix.
     /// * `ppix_handle` - The ppix handle you want to operate on.
     ///
@@ -61,6 +66,7 @@ impl PPixSuite {
     pub fn row_bytes(&self, ppix_handle: pr_sys::PPixHand) -> Result<i32, Error> {
         call_suite_fn_single!(self, GetRowBytes -> i32, ppix_handle)
     }
+
     /// This will return the pixel aspect ratio of this ppix.
     /// * `ppix_handle` - The ppix handle you want to operate on.
     ///
@@ -71,13 +77,18 @@ impl PPixSuite {
         call_suite_fn!(self, GetPixelAspectRatio, ppix_handle, &mut num, &mut den)?;
         Ok((num, den))
     }
+
     /// This will return the pixel format of this ppix.
     /// * `ppix_handle` - The ppix handle you want to operate on.
     ///
     /// Returns the pixel format of this ppix.
     pub fn pixel_format(&self, ppix_handle: pr_sys::PPixHand) -> Result<PixelFormat, Error> {
-        Ok(call_suite_fn_single!(self, GetPixelFormat -> pr_sys::PrPixelFormat, ppix_handle)?.into())
+        Ok(
+            call_suite_fn_single!(self, GetPixelFormat -> pr_sys::PrPixelFormat, ppix_handle)?
+                .into(),
+        )
     }
+
     /// This will return the unique key for this ppix.
     /// * `ppix_handle` - The ppix handle you want to operate on.
     ///
@@ -90,6 +101,7 @@ impl PPixSuite {
         call_suite_fn!(self, GetUniqueKey, ppix_handle, buffer.as_mut_ptr(), size)?;
         Ok(buffer)
     }
+
     /// This will return the render time for this ppix.
     /// * `ppix_handle` - The ppix handle you want to operate on.
     ///
@@ -102,9 +114,8 @@ impl PPixSuite {
 impl PPix2Suite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
     /// This will return the total size of the ppix in bytes.
     /// * `ppix_handle` - The ppix handle you want to operate on.
     ///
@@ -112,6 +123,7 @@ impl PPix2Suite {
     pub fn size(&self, ppix_handle: pr_sys::PPixHand) -> Result<usize, Error> {
         call_suite_fn_single!(self, GetSize -> usize, ppix_handle)
     }
+
     /// [Added in CS4]
     /// This will return the planar buffers and rowbytes for a PPixHand if the contained pixels are in a planar format, such as
     /// - [`PixelFormat::Yuv420Mpeg2FramePicturePlanar8u601`]
@@ -124,18 +136,31 @@ impl PPix2Suite {
     /// Returns [`YUV420PlanarBuffers`] which contains:
     /// * `xxx_data` - The output (Y, U, or V) pixel buffer address. May be NULL if the requested access is not supported.
     /// * `xxx_row_bytes` - How many bytes must be added to the pixel buffer address to get to the next line. May be negative.
-    pub fn yuv420_planar_buffers(&self, ppix_handle: pr_sys::PPixHand, requested_access: PPixBufferAccess) -> Result<YUV420PlanarBuffers, Error> {
+    pub fn yuv420_planar_buffers(
+        &self,
+        ppix_handle: pr_sys::PPixHand,
+        requested_access: PPixBufferAccess,
+    ) -> Result<YUV420PlanarBuffers, Error> {
         let mut ret: YUV420PlanarBuffers = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, GetYUV420PlanarBuffers, ppix_handle, requested_access.into(),
-            &mut ret.y_data, &mut ret.y_row_bytes,
-            &mut ret.u_data, &mut ret.u_row_bytes,
-            &mut ret.v_data, &mut ret.v_row_bytes,
+        call_suite_fn!(
+            self,
+            GetYUV420PlanarBuffers,
+            ppix_handle,
+            requested_access.into(),
+            &mut ret.y_data,
+            &mut ret.y_row_bytes,
+            &mut ret.u_data,
+            &mut ret.u_row_bytes,
+            &mut ret.v_data,
+            &mut ret.v_row_bytes,
         )?;
         Ok(ret)
     }
+
     pub fn origin(&self, ppix_handle: pr_sys::PPixHand) -> Result<(i32, i32), Error> {
         call_suite_fn_double!(self, GetOrigin -> i32, i32, ppix_handle)
     }
+
     pub fn field_order(&self, ppix_handle: pr_sys::PPixHand) -> Result<pr_sys::prFieldType, Error> {
         call_suite_fn_single!(self, GetFieldOrder -> pr_sys::prFieldType, ppix_handle)
     }

--- a/premiere/src/suites/sequence_info.rs
+++ b/premiere/src/suites/sequence_info.rs
@@ -24,9 +24,8 @@ pub struct ImmersiveVideoVRConfiguration {
 impl SequenceInfoSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
+
     /// Get the video frame size of the sequence.
     /// * `timeline_id` - the timeline instance data
     ///
@@ -34,16 +33,21 @@ impl SequenceInfoSuite {
     pub fn frame_rect(&self, timeline_id: pr_sys::PrTimelineID) -> Result<pr_sys::prRect, Error> {
         call_suite_fn_single!(self, GetFrameRect -> pr_sys::prRect, timeline_id)
     }
+
     /// Get the aspect ratio of the sequence.
     /// * `timeline_id` - the timeline instance data
     ///
     /// Returns the aspect ratio numerator and denominator.
-    pub fn pixel_aspect_ratio(&self, timeline_id: pr_sys::PrTimelineID) -> Result<(u32, u32), Error> {
+    pub fn pixel_aspect_ratio(
+        &self,
+        timeline_id: pr_sys::PrTimelineID,
+    ) -> Result<(u32, u32), Error> {
         let mut num = 0;
         let mut den = 0;
         call_suite_fn!(self, GetPixelAspectRatio, timeline_id, &mut num, &mut den)?;
         Ok((num, den))
     }
+
     /// Get the framerate of the sequence.
     /// * `timeline_id` - the timeline instance data
     ///
@@ -51,13 +55,18 @@ impl SequenceInfoSuite {
     pub fn frame_rate(&self, timeline_id: pr_sys::PrTimelineID) -> Result<pr_sys::PrTime, Error> {
         call_suite_fn_single!(self, GetFrameRate -> pr_sys::PrTime, timeline_id)
     }
+
     /// Get the field type of the sequence.
     /// * `timeline_id` - the timeline instance data
     ///
     /// Returns the field type.
-    pub fn field_type(&self, timeline_id: pr_sys::PrTimelineID) -> Result<pr_sys::prFieldType, Error> {
+    pub fn field_type(
+        &self,
+        timeline_id: pr_sys::PrTimelineID,
+    ) -> Result<pr_sys::prFieldType, Error> {
         call_suite_fn_single!(self, GetFieldType -> pr_sys::prFieldType, timeline_id)
     }
+
     /// Get the zero point of the sequence.
     /// * `timeline_id` - the timeline instance data
     ///
@@ -65,6 +74,7 @@ impl SequenceInfoSuite {
     pub fn zero_point(&self, timeline_id: pr_sys::PrTimelineID) -> Result<pr_sys::PrTime, Error> {
         call_suite_fn_single!(self, GetZeroPoint -> pr_sys::PrTime, timeline_id)
     }
+
     /// Returns if the sequence timecode is drop or non drop.
     /// * `timeline_id` - the timeline instance data
     ///
@@ -72,6 +82,7 @@ impl SequenceInfoSuite {
     pub fn timecode_drop_frame(&self, timeline_id: pr_sys::PrTimelineID) -> Result<bool, Error> {
         Ok(call_suite_fn_single!(self, GetTimecodeDropFrame -> i32, timeline_id)? != 0)
     }
+
     /// Returns if the sequence has the proxy flag set.
     /// * `timeline_id` - the timeline instance data
     ///
@@ -79,6 +90,7 @@ impl SequenceInfoSuite {
     pub fn proxy_flag(&self, timeline_id: pr_sys::PrTimelineID) -> Result<bool, Error> {
         Ok(call_suite_fn_single!(self, GetProxyFlag -> i32, timeline_id)? != 0)
     }
+
     /// Returns the VR Video settings of the specified sequence.
     /// * `timeline_id` - The timeline instance data.
     ///
@@ -87,24 +99,42 @@ impl SequenceInfoSuite {
     /// * `frame_layout` - The type of frame layout the specified sequence is using.
     /// * `horizontal_captured_view` - How many degrees of horizontal view is captured in the video stream (up to 360).
     /// * `vertical_captured_view` - How many degrees of vertical view is captured in the video stream (up to 180).
-    pub fn immersive_video_vr_configuration(&self, timeline_id: pr_sys::PrTimelineID) -> Result<ImmersiveVideoVRConfiguration, Error> {
+    pub fn immersive_video_vr_configuration(
+        &self,
+        timeline_id: pr_sys::PrTimelineID,
+    ) -> Result<ImmersiveVideoVRConfiguration, Error> {
         let mut conf = ImmersiveVideoVRConfiguration::default();
-        call_suite_fn!(self, GetImmersiveVideoVRConfiguration, timeline_id, &mut conf.projection_type, &mut conf.frame_layout, &mut conf.horizontal_captured_view, &mut conf.vertical_captured_view)?;
+        call_suite_fn!(
+            self,
+            GetImmersiveVideoVRConfiguration,
+            timeline_id,
+            &mut conf.projection_type,
+            &mut conf.frame_layout,
+            &mut conf.horizontal_captured_view,
+            &mut conf.vertical_captured_view
+        )?;
         Ok(conf)
     }
+
     /// Returns the identifier of the sequence working color space
     /// * `timeline_id` - The timeline instance data.
     ///
     /// Returns PrSDKColorSpaceID with working color space identifier
-    pub fn working_color_space(&self, timeline_id: pr_sys::PrTimelineID) -> Result<pr_sys::PrSDKColorSpaceID, Error> {
+    pub fn working_color_space(
+        &self,
+        timeline_id: pr_sys::PrTimelineID,
+    ) -> Result<pr_sys::PrSDKColorSpaceID, Error> {
         call_suite_fn_single!(self, GetWorkingColorSpace -> pr_sys::PrSDKColorSpaceID, timeline_id)
     }
+
     /// Get the HDR graphics white luminance value of the sequence in nits.
     /// * `timeline_id` - the timeline instance data
     ///
     /// Returns HDR graphics white luminance value of the sequence in nits.
-    pub fn graphics_white_luminance(&self, timeline_id: pr_sys::PrTimelineID) -> Result<u32, Error> {
+    pub fn graphics_white_luminance(
+        &self,
+        timeline_id: pr_sys::PrTimelineID,
+    ) -> Result<u32, Error> {
         call_suite_fn_single!(self, GetGraphicsWhiteLuminance -> u32, timeline_id)
     }
 }
-

--- a/premiere/src/suites/string.rs
+++ b/premiere/src/suites/string.rs
@@ -12,9 +12,7 @@ define_suite!(
 impl PrStringSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// This will dispose of an SDKString. It is OK to pass in an empty string.
     /// * `sdk_string` - the string to dispose of
@@ -39,7 +37,12 @@ impl PrStringSuite {
     pub fn allocate_from_utf8(&self, string: &str) -> Result<PrSDKString, Error> {
         let mut out_sdk_string = unsafe { std::mem::zeroed() };
         let in_string = CString::new(string).map_err(|_| Error::InvalidParms)?;
-        call_suite_fn!(self, AllocateFromUTF8, in_string.as_bytes_with_nul().as_ptr(), &mut out_sdk_string)?;
+        call_suite_fn!(
+            self,
+            AllocateFromUTF8,
+            in_string.as_bytes_with_nul().as_ptr(),
+            &mut out_sdk_string
+        )?;
         Ok(out_sdk_string)
     }
 
@@ -52,17 +55,29 @@ impl PrStringSuite {
         let mut buffer = vec![0u8; 128];
         let mut buffer_size = buffer.len() as u32;
 
-        let mut result = call_suite_fn!(self, CopyToUTF8String, sdk_string, buffer.as_mut_ptr() as *mut _, &mut buffer_size);
+        let mut result = call_suite_fn!(
+            self,
+            CopyToUTF8String,
+            sdk_string,
+            buffer.as_mut_ptr() as *mut _,
+            &mut buffer_size
+        );
         if result == Err(Error::StringBufferTooSmall) {
             buffer = vec![0u8; buffer_size as usize + 1];
-            result = call_suite_fn!(self, CopyToUTF8String, sdk_string, buffer.as_mut_ptr() as *mut _, &mut buffer_size);
+            result = call_suite_fn!(
+                self,
+                CopyToUTF8String,
+                sdk_string,
+                buffer.as_mut_ptr() as *mut _,
+                &mut buffer_size
+            );
         }
         match result {
             Ok(()) => {
                 buffer.resize(buffer_size as usize - 1, 0u8);
                 String::from_utf8(buffer).map_err(|_| Error::InvalidParms)
             }
-            Err(e) => Err(Error::from(e))
+            Err(e) => Err(Error::from(e)),
         }
     }
 }
@@ -70,17 +85,21 @@ impl PrStringSuite {
 #[repr(transparent)]
 pub struct PrString(pub PrSDKString);
 impl From<&str> for PrString {
-    fn from(s: &str) -> Self {
-        Self(PrStringSuite::new().unwrap().allocate_from_utf8(s).unwrap())
-    }
+    fn from(s: &str) -> Self { Self(PrStringSuite::new().unwrap().allocate_from_utf8(s).unwrap()) }
 }
 impl From<PrString> for String {
     fn from(s: PrString) -> Self {
-        PrStringSuite::new().unwrap().copy_to_utf8_string(&s.0).unwrap()
+        PrStringSuite::new()
+            .unwrap()
+            .copy_to_utf8_string(&s.0)
+            .unwrap()
     }
 }
 impl Drop for PrString {
     fn drop(&mut self) {
-        PrStringSuite::new().unwrap().dispose_string(&self.0).unwrap();
+        PrStringSuite::new()
+            .unwrap()
+            .dispose_string(&self.0)
+            .unwrap();
     }
 }

--- a/premiere/src/suites/time.rs
+++ b/premiere/src/suites/time.rs
@@ -15,9 +15,7 @@ define_suite!(
 impl TimeSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Get the current ticks per second. This is guaranteed to be constant for the duration of runtime.
     ///
@@ -32,7 +30,10 @@ impl TimeSuite {
     /// * `frame_rate` - an enum value for a video frame rate.
     ///
     /// Returns the number of time ticks per frame.
-    pub fn ticks_per_video_frame(&self, frame_rate: crate::VideoFrameRates) -> Result<pr_sys::PrTime, Error> {
+    pub fn ticks_per_video_frame(
+        &self,
+        frame_rate: crate::VideoFrameRates,
+    ) -> Result<pr_sys::PrTime, Error> {
         call_suite_fn_single!(self, GetTicksPerVideoFrame -> pr_sys::PrTime, frame_rate.into())
     }
 

--- a/premiere/src/suites/video_segment.rs
+++ b/premiere/src/suites/video_segment.rs
@@ -45,16 +45,17 @@ pub struct VideoSegmentProperties {
 impl VideoSegmentSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// From a sequence, get an ID to its video segments ID. This is a ref-counted
     /// object, and must be released when no longer needed.
     /// * `timeline_id` - The plugin timeline ID for the sequence
     ///
     /// Returns the ID for the Video Segments
-    pub fn acquire_video_segments_id(&self, timeline_data: pr_sys::PrTimelineID) -> Result<i32, Error> {
+    pub fn acquire_video_segments_id(
+        &self,
+        timeline_data: pr_sys::PrTimelineID,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, AcquireVideoSegmentsID -> i32, timeline_data)
     }
 
@@ -63,7 +64,10 @@ impl VideoSegmentSuite {
     /// * `timeline_id` - The plugin timeline ID for the sequence
     ///
     /// Returns the ID for the Video Segments with Previews.
-    pub fn acquire_video_segments_with_previews_id(&self, timeline_data: pr_sys::PrTimelineID) -> Result<i32, Error> {
+    pub fn acquire_video_segments_with_previews_id(
+        &self,
+        timeline_data: pr_sys::PrTimelineID,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, AcquireVideoSegmentsWithPreviewsID -> i32, timeline_data)
     }
 
@@ -73,7 +77,10 @@ impl VideoSegmentSuite {
     /// * `timeline_id` - The plugin timeline ID for the sequence
     ///
     /// Returns the ID for the Video Segments with Previews.
-    pub fn acquire_video_segments_with_opaque_previews_id(&self, timeline_data: pr_sys::PrTimelineID) -> Result<i32, Error> {
+    pub fn acquire_video_segments_with_opaque_previews_id(
+        &self,
+        timeline_data: pr_sys::PrTimelineID,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, AcquireVideoSegmentsWithOpaquePreviewsID -> i32, timeline_data)
     }
 
@@ -82,6 +89,7 @@ impl VideoSegmentSuite {
     pub fn release_video_segments_id(&self, video_segments_id: i32) -> Result<(), Error> {
         call_suite_fn!(self, ReleaseVideoSegmentsID, video_segments_id)
     }
+
     /// Get the hash of a Video Segments object
     /// * `video_segments_id` - The Video Segments ID
     ///
@@ -107,12 +115,25 @@ impl VideoSegmentSuite {
     /// * `end_time` - The end time of the segment
     /// * `segment_offset` - The offset value for the segment
     /// * `hash` - The hash for the segment
-    pub fn segment_info(&self, video_segments_id: i32, index: i32) -> Result<(i64, i64, i64, pr_sys::prPluginID), Error> {
+    pub fn segment_info(
+        &self,
+        video_segments_id: i32,
+        index: i32,
+    ) -> Result<(i64, i64, i64, pr_sys::prPluginID), Error> {
         let mut start_time = 0;
         let mut end_time = 0;
         let mut segment_offset = 0;
         let mut hash: pr_sys::prPluginID = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, GetSegmentInfo, video_segments_id, index, &mut start_time, &mut end_time, &mut segment_offset, &mut hash)?;
+        call_suite_fn!(
+            self,
+            GetSegmentInfo,
+            video_segments_id,
+            index,
+            &mut start_time,
+            &mut end_time,
+            &mut segment_offset,
+            &mut hash
+        )?;
         Ok((start_time, end_time, segment_offset, hash))
     }
 
@@ -121,7 +142,11 @@ impl VideoSegmentSuite {
     /// * `hash` - The hash for the segment
     ///
     /// Returns the video node ID.
-    pub fn acquire_node_id(&self, video_segments_id: i32, hash: *mut pr_sys::prPluginID) -> Result<i32, Error> {
+    pub fn acquire_node_id(
+        &self,
+        video_segments_id: i32,
+        hash: *mut pr_sys::prPluginID,
+    ) -> Result<i32, Error> {
         call_suite_fn_single!(self, AcquireNodeID -> i32, video_segments_id, hash)
     }
 
@@ -130,6 +155,7 @@ impl VideoSegmentSuite {
     pub fn release_video_node_id(&self, video_node_id: i32) -> Result<(), Error> {
         call_suite_fn!(self, ReleaseVideoNodeID, video_node_id)
     }
+
     /// Get details about a node.
     /// * `video_node_id` - The Video Node ID
     ///
@@ -137,11 +163,21 @@ impl VideoSegmentSuite {
     /// * `node_type` - A string of size kMaxNodeTypeStringSize holding the node type
     /// * `hash` - The hash for the node (may be different than the hash used to get the node)
     /// * `info_flags` - The flags for this node (see enum above)
-    pub fn node_info(&self, video_node_id: i32) -> Result<(String, pr_sys::prPluginID, i32), Error> {
+    pub fn node_info(
+        &self,
+        video_node_id: i32,
+    ) -> Result<(String, pr_sys::prPluginID, i32), Error> {
         let mut node_type = [0; pr_sys::kMaxNodeTypeStringSize as usize];
         let mut hash: pr_sys::prPluginID = unsafe { std::mem::zeroed() };
         let mut flags = 0;
-        call_suite_fn!(self, GetNodeInfo, video_node_id, node_type.as_mut_ptr() as *mut i8, &mut hash, &mut flags)?;
+        call_suite_fn!(
+            self,
+            GetNodeInfo,
+            video_node_id,
+            node_type.as_mut_ptr() as *mut i8,
+            &mut hash,
+            &mut flags
+        )?;
         Ok((String::from_utf8_lossy(&node_type).to_string(), hash, flags))
     }
 
@@ -160,7 +196,11 @@ impl VideoSegmentSuite {
     /// Returns a tuple containing:
     /// * `offset` - The time offset relative to it's parent node
     /// * `input_video_node_id` - The video node ID of the input node.
-    pub fn acquire_input_node_id(&self, video_node_id: i32, index: i32) -> Result<(i64, i32), Error> {
+    pub fn acquire_input_node_id(
+        &self,
+        video_node_id: i32,
+        index: i32,
+    ) -> Result<(i64, i32), Error> {
         call_suite_fn_double!(self, AcquireInputNodeID -> i64, i32, video_node_id, index)
     }
 
@@ -184,18 +224,36 @@ impl VideoSegmentSuite {
     /// Iterate all of the properties on a node.
     /// * `video_node_id` - The Video Node ID
     /// * `callback` - The callback function to return the properties
-    pub fn iterate_node_properties<F: Fn(Property, PropertyData) + Send + Sync + 'static>(&self, video_node_id: i32, callback: F) -> Result<(), Error> {
-        use std::sync::OnceLock;
-        use std::collections::HashMap;
+    pub fn iterate_node_properties<F: Fn(Property, PropertyData) + Send + Sync + 'static>(
+        &self,
+        video_node_id: i32,
+        callback: F,
+    ) -> Result<(), Error> {
         use parking_lot::RwLock;
-        static MAP: OnceLock<RwLock<HashMap<i32, Box<dyn Fn(Property, PropertyData) + Send + Sync + 'static>>>> = OnceLock::new();
+        use std::collections::HashMap;
+        use std::sync::OnceLock;
+        static MAP: OnceLock<
+            RwLock<HashMap<i32, Box<dyn Fn(Property, PropertyData) + Send + Sync + 'static>>>,
+        > = OnceLock::new();
 
         let map = MAP.get_or_init(|| RwLock::new(HashMap::new()));
 
-        unsafe extern "C" fn cb(plugin_object: pr_sys::csSDK_int32, in_key: *const std::ffi::c_char, in_value: *const pr_sys::prUTF8Char) -> pr_sys::prSuiteError {
+        unsafe extern "C" fn cb(
+            plugin_object: pr_sys::csSDK_int32,
+            in_key: *const std::ffi::c_char,
+            in_value: *const pr_sys::prUTF8Char,
+        ) -> pr_sys::prSuiteError {
             if let Some(callback) = MAP.get().unwrap().read().get(&plugin_object) {
-                let key   = unsafe { std::ffi::CStr::from_ptr(in_key   as *const _).to_str().unwrap() };
-                let value = unsafe { std::ffi::CStr::from_ptr(in_value as *const _).to_str().unwrap() };
+                let key = unsafe {
+                    std::ffi::CStr::from_ptr(in_key as *const _)
+                        .to_str()
+                        .unwrap()
+                };
+                let value = unsafe {
+                    std::ffi::CStr::from_ptr(in_value as *const _)
+                        .to_str()
+                        .unwrap()
+                };
 
                 let key = Property::from_id(key.as_bytes());
                 let value = key.parse_result(value);
@@ -225,14 +283,22 @@ impl VideoSegmentSuite {
 
         let key_bytes: &[u8] = key.as_id();
 
-        call_suite_fn!(self, GetNodeProperty, video_node_id, key_bytes.as_ptr() as *const _, &mut ptr)?;
+        call_suite_fn!(
+            self,
+            GetNodeProperty,
+            video_node_id,
+            key_bytes.as_ptr() as *const _,
+            &mut ptr
+        )?;
         let value = unsafe { std::ffi::CStr::from_ptr(ptr).to_str().unwrap() };
 
         let result = key.parse_result(value);
 
         match crate::suites::MemoryManager::new() {
             Ok(mem) => mem.dispose_ptr(ptr),
-            Err(e) => log::error!("Failed to dispose pointer in get_node_property. Failed to acquire memory suite: {e:?}")
+            Err(e) => log::error!(
+                "Failed to dispose pointer in get_node_property. Failed to acquire memory suite: {e:?}"
+            ),
         }
 
         Ok(result)
@@ -253,7 +319,10 @@ impl VideoSegmentSuite {
     ///
     /// Returns the param
     pub fn param(&self, video_node_id: i32, index: i32, time: i64) -> Result<crate::Param, Error> {
-        Ok(call_suite_fn_single!(self, GetParam -> pr_sys::PrParam, video_node_id, index, time)?.into())
+        Ok(
+            call_suite_fn_single!(self, GetParam -> pr_sys::PrParam, video_node_id, index, time)?
+                .into(),
+        )
     }
 
     /// Get the next keyframe time after the specified time.
@@ -271,10 +340,23 @@ impl VideoSegmentSuite {
     /// Returns a tuple containing:
     /// * `keyframe_time` - The time of the next keyframe > inTime
     /// * `keyframe_interpolation_mode` - The temporal interpolation mode of the keyframe
-    pub fn next_keyframe_time(&self, video_node_id: i32, index: i32, time: i64) -> Result<(i64, KeyframeInterpolationMode), Error> {
+    pub fn next_keyframe_time(
+        &self,
+        video_node_id: i32,
+        index: i32,
+        time: i64,
+    ) -> Result<(i64, KeyframeInterpolationMode), Error> {
         let mut keyframe_time = 0;
         let mut keyframe_interpolation_mode: pr_sys::PrKeyframeInterpolationModeFlag = 0;
-        call_suite_fn!(self, GetNextKeyframeTime, video_node_id, index, time, &mut keyframe_time, &mut keyframe_interpolation_mode as *mut pr_sys::PrKeyframeInterpolationModeFlag as _)?;
+        call_suite_fn!(
+            self,
+            GetNextKeyframeTime,
+            video_node_id,
+            index,
+            time,
+            &mut keyframe_time,
+            &mut keyframe_interpolation_mode as *mut pr_sys::PrKeyframeInterpolationModeFlag as _
+        )?;
         Ok((keyframe_time, keyframe_interpolation_mode.into()))
     }
 
@@ -298,11 +380,24 @@ impl VideoSegmentSuite {
     /// * `par_den` - Pixel aspect ratio denominator of the sequence
     /// * `frame_rate` - Frame rate of the sequence
     /// * `field_type` - Field type of the sequence
-    pub fn video_segments_properties(&self, timeline_data: pr_sys::PrTimelineID) -> Result<VideoSegmentProperties, Error> {
+    pub fn video_segments_properties(
+        &self,
+        timeline_data: pr_sys::PrTimelineID,
+    ) -> Result<VideoSegmentProperties, Error> {
         let mut p: VideoSegmentProperties = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, GetVideoSegmentsProperties, timeline_data, &mut p.bounds, &mut p.par_num, &mut p.par_den, &mut p.frame_rate, &mut p.field_type)?;
+        call_suite_fn!(
+            self,
+            GetVideoSegmentsProperties,
+            timeline_data,
+            &mut p.bounds,
+            &mut p.par_num,
+            &mut p.par_den,
+            &mut p.frame_rate,
+            &mut p.field_type
+        )?;
         Ok(p)
     }
+
     /// From a sequence, get a segment node for a requested time. This is a ref-counted
     /// object, and must be released when no longer needed.
     /// * `video_segments_id` - The Video Segments ID
@@ -311,10 +406,21 @@ impl VideoSegmentSuite {
     /// Returns a tuple containing:
     /// * `video_node_id` - The video node ID
     /// * `segment_offset` - Offset of retrieved segment
-    pub fn acquire_node_for_time(&self, video_segments_id: i32, time: i64) -> Result<(i32, i64), Error> {
+    pub fn acquire_node_for_time(
+        &self,
+        video_segments_id: i32,
+        time: i64,
+    ) -> Result<(i32, i64), Error> {
         let mut video_node_id = 0;
         let mut segment_offset = 0;
-        call_suite_fn!(self, AcquireNodeForTime, video_segments_id, time, &mut video_node_id, &mut segment_offset)?;
+        call_suite_fn!(
+            self,
+            AcquireNodeForTime,
+            video_segments_id,
+            time,
+            &mut video_node_id,
+            &mut segment_offset
+        )?;
         Ok((video_node_id, segment_offset))
     }
 
@@ -323,11 +429,21 @@ impl VideoSegmentSuite {
     /// * `timeline_id` - The plugin timeline ID for the sequence
     ///
     /// Returns the ID for the Video Segments
-    pub fn acquire_video_segments_id_with_stream_label(&self, timeline_data: pr_sys::PrTimelineID, stream_label: &str) -> Result<i32, Error> {
+    pub fn acquire_video_segments_id_with_stream_label(
+        &self,
+        timeline_data: pr_sys::PrTimelineID,
+        stream_label: &str,
+    ) -> Result<i32, Error> {
         let mut val = 0;
         let stream_label_c = std::ffi::CString::new(stream_label).unwrap();
         let stream_label_c = stream_label_c.as_bytes_with_nul();
-        call_suite_fn!(self, AcquireVideoSegmentsIDWithStreamLabel, timeline_data, stream_label_c.as_ptr() as *const _, &mut val)?;
+        call_suite_fn!(
+            self,
+            AcquireVideoSegmentsIDWithStreamLabel,
+            timeline_data,
+            stream_label_c.as_ptr() as *const _,
+            &mut val
+        )?;
         Ok(val)
     }
 
@@ -336,11 +452,21 @@ impl VideoSegmentSuite {
     /// * `timeline_id` - The plugin timeline ID for the sequence
     ///
     /// Returns the ID for the Video Segments with Previews.
-    pub fn acquire_video_segments_with_previews_id_with_stream_label(&self, timeline_data: pr_sys::PrTimelineID, stream_label: &str) -> Result<i32, Error> {
+    pub fn acquire_video_segments_with_previews_id_with_stream_label(
+        &self,
+        timeline_data: pr_sys::PrTimelineID,
+        stream_label: &str,
+    ) -> Result<i32, Error> {
         let mut val = 0;
         let stream_label_c = std::ffi::CString::new(stream_label).unwrap();
         let stream_label_c = stream_label_c.as_bytes_with_nul();
-        call_suite_fn!(self, AcquireVideoSegmentsWithPreviewsIDWithStreamLabel, timeline_data, stream_label_c.as_ptr() as *const _, &mut val)?;
+        call_suite_fn!(
+            self,
+            AcquireVideoSegmentsWithPreviewsIDWithStreamLabel,
+            timeline_data,
+            stream_label_c.as_ptr() as *const _,
+            &mut val
+        )?;
         Ok(val)
     }
 
@@ -350,11 +476,21 @@ impl VideoSegmentSuite {
     /// * `timeline_id` - The plugin timeline ID for the sequence
     ///
     /// Returns the ID for the Video Segments with Previews.
-    pub fn acquire_video_segments_with_opaque_previews_id_with_stream_label(&self, timeline_data: pr_sys::PrTimelineID, stream_label: &str) -> Result<i32, Error> {
+    pub fn acquire_video_segments_with_opaque_previews_id_with_stream_label(
+        &self,
+        timeline_data: pr_sys::PrTimelineID,
+        stream_label: &str,
+    ) -> Result<i32, Error> {
         let mut val = 0;
         let stream_label_c = std::ffi::CString::new(stream_label).unwrap();
         let stream_label_c = stream_label_c.as_bytes_with_nul();
-        call_suite_fn!(self, AcquireVideoSegmentsWithOpaquePreviewsIDWithStreamLabel, timeline_data, stream_label_c.as_ptr() as *const _, &mut val)?;
+        call_suite_fn!(
+            self,
+            AcquireVideoSegmentsWithOpaquePreviewsIDWithStreamLabel,
+            timeline_data,
+            stream_label_c.as_ptr() as *const _,
+            &mut val
+        )?;
         Ok(val)
     }
 
@@ -367,10 +503,23 @@ impl VideoSegmentSuite {
     /// Returns a tuple containing:
     /// * `video_node_id` - The video node ID
     /// * `segment_offset` - Offset of retrieved segment
-    pub fn acquire_first_node_in_time_range(&self, video_segments_id: i32, start_time: i64, end_time: i64) -> Result<(i32, i64), Error> {
+    pub fn acquire_first_node_in_time_range(
+        &self,
+        video_segments_id: i32,
+        start_time: i64,
+        end_time: i64,
+    ) -> Result<(i32, i64), Error> {
         let mut video_node_id = 0;
         let mut segment_offset = 0;
-        call_suite_fn!(self, AcquireFirstNodeInTimeRange, video_segments_id, start_time, end_time, &mut video_node_id, &mut segment_offset)?;
+        call_suite_fn!(
+            self,
+            AcquireFirstNodeInTimeRange,
+            video_segments_id,
+            start_time,
+            end_time,
+            &mut video_node_id,
+            &mut segment_offset
+        )?;
         Ok((video_node_id, segment_offset))
     }
 
@@ -389,12 +538,33 @@ impl VideoSegmentSuite {
     /// * `time` - The time requested (in Media time)
     ///
     /// Returns a tuple containing: (position, anchor, scale, rotation)
-    pub fn graphics_transformed_params(&self, video_node_id: i32, time: i64) -> Result<(pr_sys::prFPoint64, pr_sys::prFPoint64, pr_sys::prFPoint64, f32), Error> {
+    pub fn graphics_transformed_params(
+        &self,
+        video_node_id: i32,
+        time: i64,
+    ) -> Result<
+        (
+            pr_sys::prFPoint64,
+            pr_sys::prFPoint64,
+            pr_sys::prFPoint64,
+            f32,
+        ),
+        Error,
+    > {
         let mut position = pr_sys::prFPoint64 { x: 0.0, y: 0.0 };
         let mut anchor = pr_sys::prFPoint64 { x: 0.0, y: 0.0 };
         let mut scale = pr_sys::prFPoint64 { x: 0.0, y: 0.0 };
         let mut rotation = 0.0;
-        call_suite_fn!(self, GetGraphicsTransformedParams, video_node_id, time, &mut position, &mut anchor, &mut scale, &mut rotation)?;
+        call_suite_fn!(
+            self,
+            GetGraphicsTransformedParams,
+            video_node_id,
+            time,
+            &mut position,
+            &mut anchor,
+            &mut scale,
+            &mut rotation
+        )?;
         Ok((position, anchor, scale, rotation))
     }
 
@@ -422,10 +592,23 @@ impl VideoSegmentSuite {
     /// * `frame_rate` - Frame rate of the sequence
     /// * `field_type` - Field type of the sequence
     /// * `color_space` - Opaque ID of the sequence's working color space
-    pub fn video_segments_properties_ext(&self, timeline_data: pr_sys::PrTimelineID) -> Result<VideoSegmentProperties, Error> {
+    pub fn video_segments_properties_ext(
+        &self,
+        timeline_data: pr_sys::PrTimelineID,
+    ) -> Result<VideoSegmentProperties, Error> {
         let mut p: VideoSegmentProperties = unsafe { std::mem::zeroed() };
         let mut color_space: pr_sys::PrSDKColorSpaceID = unsafe { std::mem::zeroed() };
-        call_suite_fn!(self, GetVideoSegmentsPropertiesExt, timeline_data, &mut p.bounds, &mut p.par_num, &mut p.par_den, &mut p.frame_rate, &mut p.field_type, &mut color_space)?;
+        call_suite_fn!(
+            self,
+            GetVideoSegmentsPropertiesExt,
+            timeline_data,
+            &mut p.bounds,
+            &mut p.par_num,
+            &mut p.par_den,
+            &mut p.frame_rate,
+            &mut p.field_type,
+            &mut color_space
+        )?;
         p.color_space = Some(color_space);
         Ok(p)
     }
@@ -441,13 +624,33 @@ impl VideoSegmentSuite {
     /// * `segment_start_time` - Start time of retrieved segment
     /// * `segment_end_time` - End time of retrieved segment
     /// * `segment_offset` - Offset of retrieved segment
-    pub fn acquire_first_node_in_time_range_ext(&self, video_segments_id: i32, start_time: i64, end_time: i64) -> Result<(i32, i64, i64, i64), Error> {
+    pub fn acquire_first_node_in_time_range_ext(
+        &self,
+        video_segments_id: i32,
+        start_time: i64,
+        end_time: i64,
+    ) -> Result<(i32, i64, i64, i64), Error> {
         let mut video_node_id = 0;
         let mut segment_start_time = 0;
         let mut segment_end_time = 0;
         let mut segment_offset = 0;
-        call_suite_fn!(self, AcquireFirstNodeInTimeRangeExt, video_segments_id, start_time, end_time, &mut video_node_id, &mut segment_start_time, &mut segment_end_time, &mut segment_offset)?;
-        Ok((video_node_id, segment_start_time, segment_end_time, segment_offset))
+        call_suite_fn!(
+            self,
+            AcquireFirstNodeInTimeRangeExt,
+            video_segments_id,
+            start_time,
+            end_time,
+            &mut video_node_id,
+            &mut segment_start_time,
+            &mut segment_end_time,
+            &mut segment_offset
+        )?;
+        Ok((
+            video_node_id,
+            segment_start_time,
+            segment_end_time,
+            segment_offset,
+        ))
     }
 
     /// Returns the relative time rate of a node at a given point in time.

--- a/premiere/src/suites/video_segment_properties.rs
+++ b/premiere/src/suites/video_segment_properties.rs
@@ -2,7 +2,10 @@
 
 use crate::*;
 use pr_sys::*;
-use std::{ops::{Deref, DerefMut}, str::FromStr};
+use std::{
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
 
 #[derive(Debug, Clone)]
 pub enum PropertyData {
@@ -23,14 +26,26 @@ pub enum PropertyData {
 
 // ------------------- Float point -------------------
 #[derive(Debug, Clone, Copy)]
-pub struct Point32 { pub x: f32, pub y: f32 }
+pub struct Point32 {
+    pub x: f32,
+    pub y: f32,
+}
 
 impl FromStr for Point32 {
     type Err = Error;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut parts = s.split_whitespace();
-        let x = parts.next().ok_or(Error::InvalidParms)?.parse::<f32>().map_err(|_| Error::InvalidParms)?;
-        let y = parts.next().ok_or(Error::InvalidParms)?.parse::<f32>().map_err(|_| Error::InvalidParms)?;
+        let x = parts
+            .next()
+            .ok_or(Error::InvalidParms)?
+            .parse::<f32>()
+            .map_err(|_| Error::InvalidParms)?;
+        let y = parts
+            .next()
+            .ok_or(Error::InvalidParms)?
+            .parse::<f32>()
+            .map_err(|_| Error::InvalidParms)?;
         Ok(Point32 { x, y })
     }
 }
@@ -40,13 +55,17 @@ impl FromStr for Point32 {
 pub struct Binary(Vec<u8>);
 impl FromStr for Binary {
     type Err = Error;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use base64::prelude::*;
-        Ok(Binary(BASE64_STANDARD.decode(s).map_err(|_| Error::InvalidParms)?))
+        Ok(Binary(
+            BASE64_STANDARD.decode(s).map_err(|_| Error::InvalidParms)?,
+        ))
     }
 }
 impl Deref for Binary {
     type Target = Vec<u8>;
+
     fn deref(&self) -> &Self::Target { &self.0 }
 }
 impl DerefMut for Binary {
@@ -60,6 +79,7 @@ pub struct Keyframes(pub String); // TODO: not implemented
 
 impl FromStr for Keyframes {
     type Err = Error;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(s.to_owned())) // TODO implement parsing this
     }

--- a/premiere/src/suites/window.rs
+++ b/premiere/src/suites/window.rs
@@ -11,25 +11,17 @@ define_suite!(
 impl WindowSuite {
     /// Acquire this suite from the host. Returns error if the suite is not available.
     /// Suite is released on drop.
-    pub fn new() -> Result<Self, Error> {
-        crate::Suite::new()
-    }
+    pub fn new() -> Result<Self, Error> { crate::Suite::new() }
 
     /// Returns a handle to the main application window-- a `HWND` on Windows and a `*mut NSView` on macOS.
     /// These correspond to the `Win32WindowHandle` and `AppKitWindowHandle` types in the `raw-window-handle` crate.
-    pub fn main_window(&self) -> prWnd {
-        call_suite_fn_no_err!(self, GetMainWindow, )
-    }
+    pub fn main_window(&self) -> prWnd { call_suite_fn_no_err!(self, GetMainWindow,) }
 
     /// Returns a handle to the main application window-- a `HWND` on Windows and a `*mut NSView` on macOS.
     /// These correspond to the `Win32WindowHandle` and `AppKitWindowHandle` types in the `raw-window-handle` crate.
     #[deprecated(since = "0.5.0", note = "renamed to `main_window`")]
-    pub fn get_main_window(&self) -> prWnd {
-        self.main_window()
-    }
+    pub fn get_main_window(&self) -> prWnd { self.main_window() }
 
     /// Updates all windows. Windows only, doesn’t work on Mac OS.
-    pub fn update_all_windows(&self) {
-        call_suite_fn_no_err!(self, UpdateAllWindows, )
-    }
+    pub fn update_all_windows(&self) { call_suite_fn_no_err!(self, UpdateAllWindows,) }
 }

--- a/premiere/src/types.rs
+++ b/premiere/src/types.rs
@@ -1,4 +1,3 @@
-
 use crate::*;
 
 define_enum! {
@@ -240,16 +239,32 @@ impl From<pr_sys::PrParam> for Param {
         use pr_sys::*;
         #[allow(non_upper_case_globals)]
         match value.mType {
-            PrParamType_kPrParamType_Int8        => Param::Int8     (unsafe { value.__bindgen_anon_1.mInt8 }),
-            PrParamType_kPrParamType_Int16       => Param::Int16    (unsafe { value.__bindgen_anon_1.mInt16 }),
-            PrParamType_kPrParamType_Int32       => Param::Int32    (unsafe { value.__bindgen_anon_1.mInt32 }),
-            PrParamType_kPrParamType_Int64       => Param::Int64    (unsafe { value.__bindgen_anon_1.mInt64 }),
-            PrParamType_kPrParamType_Float32     => Param::Float32  (unsafe { value.__bindgen_anon_1.mFloat32 }),
-            PrParamType_kPrParamType_Float64     => Param::Float64  (unsafe { value.__bindgen_anon_1.mFloat64 }),
-            PrParamType_kPrParamType_Bool        => Param::Bool     (unsafe { value.__bindgen_anon_1.mBool == 1 }),
-            PrParamType_kPrParamType_Point       => Param::Point    (unsafe { value.__bindgen_anon_1.mPoint }),
-            PrParamType_kPrParamType_Guid        => Param::Guid     (unsafe { value.__bindgen_anon_1.mGuid }),
-            PrParamType_kPrParamType_PrMemoryPtr => Param::MemoryPtr(unsafe { value.__bindgen_anon_1.mMemoryPtr }),
+            PrParamType_kPrParamType_Int8 => Param::Int8(unsafe { value.__bindgen_anon_1.mInt8 }),
+            PrParamType_kPrParamType_Int16 => {
+                Param::Int16(unsafe { value.__bindgen_anon_1.mInt16 })
+            }
+            PrParamType_kPrParamType_Int32 => {
+                Param::Int32(unsafe { value.__bindgen_anon_1.mInt32 })
+            }
+            PrParamType_kPrParamType_Int64 => {
+                Param::Int64(unsafe { value.__bindgen_anon_1.mInt64 })
+            }
+            PrParamType_kPrParamType_Float32 => {
+                Param::Float32(unsafe { value.__bindgen_anon_1.mFloat32 })
+            }
+            PrParamType_kPrParamType_Float64 => {
+                Param::Float64(unsafe { value.__bindgen_anon_1.mFloat64 })
+            }
+            PrParamType_kPrParamType_Bool => {
+                Param::Bool(unsafe { value.__bindgen_anon_1.mBool == 1 })
+            }
+            PrParamType_kPrParamType_Point => {
+                Param::Point(unsafe { value.__bindgen_anon_1.mPoint })
+            }
+            PrParamType_kPrParamType_Guid => Param::Guid(unsafe { value.__bindgen_anon_1.mGuid }),
+            PrParamType_kPrParamType_PrMemoryPtr => {
+                Param::MemoryPtr(unsafe { value.__bindgen_anon_1.mMemoryPtr })
+            }
             _ => panic!("Invalid PrParamType"),
         }
     }
@@ -262,16 +277,46 @@ impl Into<pr_sys::PrParam> for Param {
             __bindgen_anon_1: PrParam__bindgen_ty_1 { mInt8: 0 },
         };
         match self {
-            Param::Int8     (value) => { param.mType = PrParamType_kPrParamType_Int8;        param.__bindgen_anon_1.mInt8 = value; },
-            Param::Int16    (value) => { param.mType = PrParamType_kPrParamType_Int16;       param.__bindgen_anon_1.mInt16 = value; },
-            Param::Int32    (value) => { param.mType = PrParamType_kPrParamType_Int32;       param.__bindgen_anon_1.mInt32 = value; },
-            Param::Int64    (value) => { param.mType = PrParamType_kPrParamType_Int64;       param.__bindgen_anon_1.mInt64 = value; },
-            Param::Float32  (value) => { param.mType = PrParamType_kPrParamType_Float32;     param.__bindgen_anon_1.mFloat32 = value; },
-            Param::Float64  (value) => { param.mType = PrParamType_kPrParamType_Float64;     param.__bindgen_anon_1.mFloat64 = value; },
-            Param::Bool     (value) => { param.mType = PrParamType_kPrParamType_Bool;        param.__bindgen_anon_1.mBool = if value { 1 } else { 0 }; },
-            Param::Point    (value) => { param.mType = PrParamType_kPrParamType_Point;       param.__bindgen_anon_1.mPoint = value; },
-            Param::Guid     (value) => { param.mType = PrParamType_kPrParamType_Guid;        param.__bindgen_anon_1.mGuid = value; },
-            Param::MemoryPtr(value) => { param.mType = PrParamType_kPrParamType_PrMemoryPtr; param.__bindgen_anon_1.mMemoryPtr = value; },
+            Param::Int8(value) => {
+                param.mType = PrParamType_kPrParamType_Int8;
+                param.__bindgen_anon_1.mInt8 = value;
+            }
+            Param::Int16(value) => {
+                param.mType = PrParamType_kPrParamType_Int16;
+                param.__bindgen_anon_1.mInt16 = value;
+            }
+            Param::Int32(value) => {
+                param.mType = PrParamType_kPrParamType_Int32;
+                param.__bindgen_anon_1.mInt32 = value;
+            }
+            Param::Int64(value) => {
+                param.mType = PrParamType_kPrParamType_Int64;
+                param.__bindgen_anon_1.mInt64 = value;
+            }
+            Param::Float32(value) => {
+                param.mType = PrParamType_kPrParamType_Float32;
+                param.__bindgen_anon_1.mFloat32 = value;
+            }
+            Param::Float64(value) => {
+                param.mType = PrParamType_kPrParamType_Float64;
+                param.__bindgen_anon_1.mFloat64 = value;
+            }
+            Param::Bool(value) => {
+                param.mType = PrParamType_kPrParamType_Bool;
+                param.__bindgen_anon_1.mBool = if value { 1 } else { 0 };
+            }
+            Param::Point(value) => {
+                param.mType = PrParamType_kPrParamType_Point;
+                param.__bindgen_anon_1.mPoint = value;
+            }
+            Param::Guid(value) => {
+                param.mType = PrParamType_kPrParamType_Guid;
+                param.__bindgen_anon_1.mGuid = value;
+            }
+            Param::MemoryPtr(value) => {
+                param.mType = PrParamType_kPrParamType_PrMemoryPtr;
+                param.__bindgen_anon_1.mMemoryPtr = value;
+            }
         }
         param
     }

--- a/premiere/src/utils/video_sequence_parser.rs
+++ b/premiere/src/utils/video_sequence_parser.rs
@@ -9,14 +9,14 @@ pub struct ClipOperator {
     pub hash: prPluginID,
     pub flags: i32,
 
-    pub effect: Option<EffectDetails>
+    pub effect: Option<EffectDetails>,
 }
 
 #[derive(Debug, Clone)]
 pub struct EffectDetails {
     pub name: Option<String>,
     pub instance_id: Option<u32>,
-    pub params: Option<PropertyData>
+    pub params: Option<PropertyData>,
 }
 
 pub type ClipOperatorsMap = HashMap<i32, ClipOperator>;
@@ -44,34 +44,35 @@ impl VideoSequenceParser {
             let (operator_node_type, operator_node_hash, operator_node_flags) =
                 self.segment_suite.node_info(operator_node_id)?;
 
-            let effect = if operator_node_type == String::from_utf8_lossy(kVideoSegment_NodeType_Effect) {
-                let effect_name = self
-                    .segment_suite
-                    .node_property(operator_node_id, Property::Effect_FilterMatchName)
-                    .unwrap_or_else(|_| PropertyData::String("<Unknown Effect>".to_string()));
+            let effect =
+                if operator_node_type == String::from_utf8_lossy(kVideoSegment_NodeType_Effect) {
+                    let effect_name = self
+                        .segment_suite
+                        .node_property(operator_node_id, Property::Effect_FilterMatchName)
+                        .unwrap_or_else(|_| PropertyData::String("<Unknown Effect>".to_string()));
 
-                let effect_instance_id = self
-                    .segment_suite
-                    .node_property(operator_node_id, Property::Effect_RuntimeInstanceID);
+                    let effect_instance_id = self
+                        .segment_suite
+                        .node_property(operator_node_id, Property::Effect_RuntimeInstanceID);
 
-                let filter_params = self
-                    .segment_suite
-                    .node_property(operator_node_id, Property::Effect_FilterParams);
+                    let filter_params = self
+                        .segment_suite
+                        .node_property(operator_node_id, Property::Effect_FilterParams);
 
-                Some(EffectDetails {
-                    name: match effect_name {
-                        PropertyData::String(s) => Some(s),
-                        _ => None
-                    },
-                    instance_id: match effect_instance_id {
-                        Ok(PropertyData::UInt32(x)) => Some(x),
-                        _ => None
-                    },
-                    params: filter_params.ok()
-                })
-            } else {
-                None
-            };
+                    Some(EffectDetails {
+                        name: match effect_name {
+                            PropertyData::String(s) => Some(s),
+                            _ => None,
+                        },
+                        instance_id: match effect_instance_id {
+                            Ok(PropertyData::UInt32(x)) => Some(x),
+                            _ => None,
+                        },
+                        params: filter_params.ok(),
+                    })
+                } else {
+                    None
+                };
 
             operators_map.insert(
                 operator_node_id,
@@ -81,7 +82,7 @@ impl VideoSequenceParser {
                     hash: operator_node_hash,
                     flags: operator_node_flags,
 
-                    effect
+                    effect,
                 },
             );
             self.segment_suite.release_video_node_id(operator_node_id)?;


### PR DESCRIPTION
Mechanical, **whitespace-only** `cargo fmt --all` to satisfy the repo's own `rustfmt.toml`. The tree was previously not fmt-clean (the config enables options the code was never formatted against), so `cargo fmt --all -- --check` failed repo-wide. After this, it exits 0.

- **No semantic changes** -- pure formatting (~124 files, per `rustfmt.toml`).
- **Unblocks a hard CI gate**: once merged, the advisory `fmt --check` step (added in #114) can be flipped to enforcing.

## Merge order
Because this touches ~124 files it will conflict with every other open PR. Merge this **last**, then a fresh `cargo fmt --all` regenerates it in seconds if needed -- do not hand-resolve conflicts. Refs the blueprint vet.